### PR TITLE
WIP: LCD display rotation

### DIFF
--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -88,7 +88,7 @@ namespace Pinetime {
 
         bool isLeftHandWorn;
         void SetHandOrientation(bool left_hand);
-        void SetTapCoordinates(uint16_t x, uint16_t y);
+        void SetScreenCoordinates(Drivers::Cst816S::TouchInfos& touch_info);
     };
   }
 }

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -85,6 +85,10 @@ namespace Pinetime {
         Pinetime::Controllers::NotificationManager& notificationManager;
         Pinetime::Controllers::FirmwareValidator validator;
         TouchModes touchMode = TouchModes::Gestures;
+
+        bool isLeftHandWorn;
+        void SetHandOrientation(bool left_hand);
+        void SetTapCoordinates(uint16_t x, uint16_t y);
     };
   }
 }

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -26,12 +26,22 @@ namespace Pinetime {
         void DisplayOn();
         void DisplayOff();
 
+        enum Orientation : uint8_t {
+          Orientation_0   = 0x00, // MADCTL[MY=0,MX=0,MV=0]
+          Orientation_90  = 0x60, // MADCTL[MY=0,MX=1,MV=1]
+          Orientation_180 = 0xc0, // MADCTL[MY=1,MX=1,MV=0]
+          Orientation_270 = 0xa0, // MADCTL[MY=1,MX=0,MV=1]
+          };
+        void SetOrientation(Orientation orientation);
+        Orientation GetOrientation() { return (Orientation) madctlReg; }
+
         void Sleep();
         void Wakeup();
       private:
         Spi& spi;
         uint8_t pinDataCommand;
         uint8_t verticalScrollingStartAddress = 0;
+        uint8_t madctlReg = 0x00;
 
         void HardwareReset();
         void SoftwareReset();
@@ -57,8 +67,8 @@ namespace Pinetime {
           ColumnAddressSet = 0x2a,
           RowAddressSet = 0x2b,
           WriteToRam = 0x2c,
-          MemoryDataAccessControl = 036,
           VerticalScrollDefinition = 0x33,
+          MemoryDataAccessControl = 0x36,
           VerticalScrollStartAddress = 0x37,
           ColMod = 0x3a,
         };


### PR DESCRIPTION
Implementing a new feature to support [left/right-handed option](https://forum.pine64.org/showthread.php?tid=11785).

WIP:
- [X] Use MADCTL register on ST7789 to use 0/180 degrees rotation.
- [x] Invert touchpad x-y coordinates when usage is rotated.
- [ ] Review scrolling to change the extra display buffer offset.
- [ ] RotationController to keep the state of face rotation.
- [ ] Add the "Wear on right/left" option to the user interface.
- [ ] Save the user option in non-volatile memory.