### PR TITLE
Respect time format system-wide

### DIFF
--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -118,3 +118,29 @@ char const* DateTime::MonthsStringLow[] = {"--", "Jan", "Feb", "Mar", "Apr", "Ma
 
 char const* DateTime::MonthsLow[] = {
   "--", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"};
+
+void DateTime::GetTimeStr(char* string, bool is24h) {
+  char minutesChar[3];
+  sprintf(minutesChar, "%02d", static_cast<int>(minute));
+  char hoursChar[3];
+  char ampmChar[3] = "  ";
+  if (is24h) {
+    sprintf(hoursChar, "%02d", hour);
+  } else {
+    if (hour == 0) {
+      hour = 12;
+      sprintf(ampmChar, "AM");
+    } else if (hour < 12) {
+      sprintf(ampmChar, "AM");
+    } else if (hour >= 12) {
+      hour = hour - 12;
+      sprintf(ampmChar, "PM");
+    }
+    sprintf(hoursChar, "%02d", hour);
+    if (hoursChar[0] == '0') {
+      hoursChar[0] = ' ';
+    }
+  }
+  
+  sprintf(string, "%c%c:%c%c %c%c", hoursChar[0], hoursChar[1], minutesChar[0], minutesChar[1], ampmChar[0], ampmChar[1]);
+}

--- a/src/components/datetime/DateTimeController.h
+++ b/src/components/datetime/DateTimeController.h
@@ -74,6 +74,8 @@ namespace Pinetime {
       std::chrono::seconds Uptime() const {
         return uptime;
       }
+  
+      void GetTimeStr(char* string, bool is24h = true);
 
     private:
       System::SystemTask& systemTask;

--- a/src/displayapp/screens/Tile.cpp
+++ b/src/displayapp/screens/Tile.cpp
@@ -31,7 +31,9 @@ Tile::Tile(uint8_t screenID,
 
   // Time
   label_time = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_fmt(label_time, "%02i:%02i", dateTimeController.Hours(), dateTimeController.Minutes());
+  char timeStr[9];
+  dateTimeController.GetTimeStr(timeStr, settingsController.GetClockType() == Controllers::Settings::ClockType::H24);
+  lv_label_set_text(label_time, timeStr);
   lv_label_set_align(label_time, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(label_time, nullptr, LV_ALIGN_IN_TOP_LEFT, 15, 6);
 

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -32,7 +32,11 @@ QuickSettings::QuickSettings(Pinetime::Applications::DisplayApp* app,
 
   // Time
   label_time = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_fmt(label_time, "%02i:%02i", dateTimeController.Hours(), dateTimeController.Minutes());
+  
+  char timeStr[9];
+  dateTimeController.GetTimeStr(timeStr, settingsController.GetClockType() == Controllers::Settings::ClockType::H24);
+  
+  lv_label_set_text(label_time, timeStr);
   lv_label_set_align(label_time, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 15, 4);
 


### PR DESCRIPTION
added a function in DateTime to give a correctly formatted time. It is used by tiles and quick settings. fixes #368 