### PR TITLE
Use newer version of gcc install action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install Embedded Arm Toolchain arm-none-eabi-gcc
         if:   steps.cache-toolchain.outputs.cache-hit != 'true'  # Install toolchain if not found in cache
-        uses: fiam/arm-none-eabi-gcc@v1.0.2
+        uses: fiam/arm-none-eabi-gcc@v1.0.4
         with:
           # GNU Embedded Toolchain for Arm release name, in the V-YYYY-qZ format (e.g. "9-2019-q4")
           release: 9-2020-q2


### PR DESCRIPTION
Github changed the way that things can be added to the PATH in the CI workflow. (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

This commit updates the fiam/arm-none-eabi-action to a version that includes the new way of adding the toolchain to the PATH