### PR TITLE
Ticker

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -420,6 +420,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/settings/SettingWakeUp.cpp
         displayapp/screens/settings/SettingDisplay.cpp
         displayapp/screens/settings/SettingSteps.cpp
+        displayapp/screens/settings/SettingTicker.cpp
 
         ## Watch faces
         displayapp/icons/bg_clock.c

--- a/src/components/ble/NotificationManager.h
+++ b/src/components/ble/NotificationManager.h
@@ -5,6 +5,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#define MESSAGE_SIZE 100
+
 namespace Pinetime {
   namespace Controllers {
     class NotificationManager {
@@ -22,7 +24,7 @@ namespace Pinetime {
         HighProriotyAlert,
         InstantMessage
       };
-      static constexpr uint8_t MessageSize {100};
+      static constexpr uint8_t MessageSize {MESSAGE_SIZE};
 
       struct Notification {
         using Id = uint8_t;

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -12,6 +12,7 @@ namespace Pinetime {
       enum class ClockType { H24, H12 };
       enum class Vibration { ON, OFF };
       enum class WakeUpMode { None, SingleTap, DoubleTap, RaiseWrist };
+      enum class TickerMode { Off, Update, Keep };
 
       Settings(Pinetime::Drivers::SpiNorFlash& spiNorFlash);
 
@@ -77,6 +78,15 @@ namespace Pinetime {
         return settings.wakeUpMode;
       };
 
+      void setTickerMode(TickerMode ticker) {
+        if (ticker != settings.tickerMode)
+          settingsChanged = true;
+	settings.tickerMode = ticker;
+      }
+      TickerMode getTickerMode() const {
+        return settings.tickerMode;
+      }
+
       void SetBrightness(Controllers::BrightnessController::Levels level) {
         if (level != settings.brightLevel)
           settingsChanged = true;
@@ -107,6 +117,7 @@ namespace Pinetime {
         uint32_t screenTimeOut = 15000;
 
         WakeUpMode wakeUpMode = WakeUpMode::None;
+	TickerMode tickerMode = TickerMode::Update;
 
         Controllers::BrightnessController::Levels brightLevel = Controllers::BrightnessController::Levels::Medium;
       };

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -133,7 +133,7 @@ namespace Pinetime {
       uint8_t settingsFlashBlock = 99; // default to indicate it needs to find the active block
 
       static constexpr uint32_t settingsBaseAddr = 0x3F6000; // Flash Settings Location
-      static constexpr uint16_t settingsVersion = 0x0100;    // Flash Settings Version
+      static constexpr uint16_t settingsVersion = 0x0101;    // Flash Settings Version
 
       bool FindHeader();
       void ReadSettingsData();

--- a/src/displayapp/Apps.h
+++ b/src/displayapp/Apps.h
@@ -30,7 +30,8 @@ namespace Pinetime {
       SettingTimeFormat,
       SettingDisplay,
       SettingWakeUp,
-      SettingSteps
+      SettingSteps,
+      SettingTicker
     };
   }
 }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -42,6 +42,7 @@
 #include "displayapp/screens/settings/SettingWakeUp.h"
 #include "displayapp/screens/settings/SettingDisplay.h"
 #include "displayapp/screens/settings/SettingSteps.h"
+#include "displayapp/screens/settings/SettingTicker.h"
 
 using namespace Pinetime::Applications;
 using namespace Pinetime::Applications::Display;
@@ -321,6 +322,10 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       break;
     case Apps::SettingSteps:
       currentScreen = std::make_unique<Screens::SettingSteps>(this, settingsController);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      break;
+    case Apps::SettingTicker:
+      currentScreen = std::make_unique<Screens::SettingTicker>(this, settingsController);
       ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::BatteryInfo:

--- a/src/displayapp/screens/WatchFaceAnalog.h
+++ b/src/displayapp/screens/WatchFaceAnalog.h
@@ -47,6 +47,7 @@ namespace Pinetime {
         Pinetime::Controllers::DateTime::Months currentMonth = Pinetime::Controllers::DateTime::Months::Unknown;
         Pinetime::Controllers::DateTime::Days currentDayOfWeek = Pinetime::Controllers::DateTime::Days::Unknown;
         uint8_t currentDay = 0;
+	char tickerMessage[MESSAGE_SIZE];
 
         DirtyValue<float> batteryPercentRemaining {0};
         DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime;

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -100,6 +100,25 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   lv_obj_set_style_local_text_color(stepIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FFE7));
   lv_label_set_text(stepIcon, Symbols::shoe);
   lv_obj_align(stepIcon, stepValue, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+
+  label_ticker = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(label_ticker, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x888888));
+  /*
+  if (title == nullptr)
+    title = "Notification";
+  char* pchar;
+  pchar = strchr(title, '\n');
+  while (pchar != nullptr) {
+    *pchar = ' ';
+    pchar = strchr(pchar + 1, '\n');
+  }
+  */
+  lv_label_set_text(label_ticker, "Eph 2:8,9 For by grace you have been saved through faith, and this is not your own doing, it is the gift of God, that no one may boast.");
+  lv_label_set_long_mode(label_ticker, LV_LABEL_LONG_SROLL_CIRC);
+  lv_label_set_anim_speed(label_ticker, 6);
+  lv_obj_set_width(label_ticker, 240);
+  lv_obj_align(label_ticker, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 32);
+
 }
 
 WatchFaceDigital::~WatchFaceDigital() {

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -113,7 +113,11 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
     pchar = strchr(pchar + 1, '\n');
   }
   */
-  lv_label_set_text(label_ticker, "Eph 2:8,9 For by grace you have been saved through faith, and this is not your own doing, it is the gift of God, that no one may boast.");
+  // update notification ticker
+  Controllers::NotificationManager::Notification lastNotification;
+  lastNotification = notificatioManager.GetLastNotification();
+  lv_label_set_text(label_ticker, lastNotification.Message());
+  //lv_label_set_text(label_ticker, "Eph 2:8,9 For by grace you have been saved through faith, and this is not your own doing, it is the gift of God, that no one may boast.");
   lv_label_set_long_mode(label_ticker, LV_LABEL_LONG_SROLL_CIRC);
   lv_label_set_anim_speed(label_ticker, 6);
   lv_obj_set_width(label_ticker, 240);
@@ -148,11 +152,12 @@ bool WatchFaceDigital::Refresh() {
 
   notificationState = notificatioManager.AreNewNotificationsAvailable();
   if (notificationState.IsUpdated()) {
-    if (notificationState.Get() == true)
+    if (notificationState.Get() == true) {
       lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(true));
-    else
+    } else
       lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(false));
   }
+
 
   currentDateTime = dateTimeController.CurrentDateTime();
 

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -3,6 +3,7 @@
 #include <date/date.h>
 #include <lvgl/lvgl.h>
 #include <cstdio>
+#include <string>
 #include "BatteryIcon.h"
 #include "BleIcon.h"
 #include "NotificationIcon.h"
@@ -101,8 +102,6 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   lv_label_set_text(stepIcon, Symbols::shoe);
   lv_obj_align(stepIcon, stepValue, LV_ALIGN_OUT_LEFT_MID, -5, 0);
 
-  label_ticker = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(label_ticker, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x888888));
   /*
   if (title == nullptr)
     title = "Notification";
@@ -114,14 +113,20 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   }
   */
   // update notification ticker
-  Controllers::NotificationManager::Notification lastNotification;
-  lastNotification = notificatioManager.GetLastNotification();
-  lv_label_set_text(label_ticker, lastNotification.Message());
-  //lv_label_set_text(label_ticker, "Eph 2:8,9 For by grace you have been saved through faith, and this is not your own doing, it is the gift of God, that no one may boast.");
-  lv_label_set_long_mode(label_ticker, LV_LABEL_LONG_SROLL_CIRC);
-  lv_label_set_anim_speed(label_ticker, 6);
-  lv_obj_set_width(label_ticker, 240);
-  lv_obj_align(label_ticker, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 32);
+  if (settingsController.getTickerMode() != Pinetime::Controllers::Settings::TickerMode::Off) {
+    label_ticker = lv_label_create(lv_scr_act(), nullptr);
+    lv_obj_set_style_local_text_color(label_ticker, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x888888));
+    if (settingsController.getTickerMode() == Pinetime::Controllers::Settings::TickerMode::Update) {
+      Controllers::NotificationManager::Notification lastNotification;
+      lastNotification = notificatioManager.GetLastNotification();
+      strcpy(tickerMessage, lastNotification.Message());
+    }
+    lv_label_set_text(label_ticker, tickerMessage);
+    lv_label_set_long_mode(label_ticker, LV_LABEL_LONG_SROLL_CIRC);
+    lv_label_set_anim_speed(label_ticker, 6);
+    lv_obj_set_width(label_ticker, 240);
+    lv_obj_align(label_ticker, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 32);
+  }
 
 }
 

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -57,6 +57,7 @@ namespace Pinetime {
         lv_obj_t* label_time;
         lv_obj_t* label_time_ampm;
         lv_obj_t* label_date;
+	lv_obj_t* label_ticker;
         lv_obj_t* backgroundLabel;
         lv_obj_t* batteryIcon;
         lv_obj_t* bleIcon;

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -7,6 +7,7 @@
 #include "Screen.h"
 #include "ScreenList.h"
 #include "components/datetime/DateTimeController.h"
+#include "components/ble/NotificationManager.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -44,6 +45,8 @@ namespace Pinetime {
         Pinetime::Controllers::DateTime::Months currentMonth = Pinetime::Controllers::DateTime::Months::Unknown;
         Pinetime::Controllers::DateTime::Days currentDayOfWeek = Pinetime::Controllers::DateTime::Days::Unknown;
         uint8_t currentDay = 0;
+
+	char tickerMessage[MESSAGE_SIZE];
 
         DirtyValue<int> batteryPercentRemaining {};
         DirtyValue<bool> bleState {};

--- a/src/displayapp/screens/settings/SettingTicker.cpp
+++ b/src/displayapp/screens/settings/SettingTicker.cpp
@@ -1,0 +1,102 @@
+#include "SettingTicker.h"
+#include <lvgl/lvgl.h>
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  static void event_handler(lv_obj_t* obj, lv_event_t event) {
+    SettingTicker* screen = static_cast<SettingTicker*>(obj->user_data);
+    screen->UpdateSelected(obj, event);
+  }
+}
+
+SettingTicker::SettingTicker(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
+  : Screen(app), settingsController {settingsController} {
+
+  lv_obj_t* container1 = lv_cont_create(lv_scr_act(), nullptr);
+
+  // lv_obj_set_style_local_bg_color(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x111111));
+  lv_obj_set_style_local_bg_opa(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
+  lv_obj_set_style_local_pad_all(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
+  lv_obj_set_style_local_pad_inner(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
+  lv_obj_set_style_local_border_width(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
+
+  lv_obj_set_pos(container1, 10, 60);
+  lv_obj_set_width(container1, LV_HOR_RES - 20);
+  lv_obj_set_height(container1, LV_VER_RES - 50);
+  lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
+
+  lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(title, "Ticker");
+  lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 10, 15);
+
+  lv_obj_t* icon = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(icon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
+  lv_label_set_text_static(icon, Symbols::clock);
+  lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
+
+  optionsTotal = 0;
+  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
+  lv_checkbox_set_text_static(cbOption[optionsTotal], " Off");
+  cbOption[optionsTotal]->user_data = this;
+  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
+  if (settingsController.getTickerMode() == Pinetime::Controllers::Settings::TickerMode::Off) {
+    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  }
+  optionsTotal++;
+
+  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
+  lv_checkbox_set_text_static(cbOption[optionsTotal], " Update");
+  cbOption[optionsTotal]->user_data = this;
+  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
+  if (settingsController.getTickerMode() == Pinetime::Controllers::Settings::TickerMode::Update) {
+    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  }
+  optionsTotal++;
+
+  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
+  lv_checkbox_set_text_static(cbOption[optionsTotal], " Keep");
+  cbOption[optionsTotal]->user_data = this;
+  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
+  if (settingsController.getTickerMode() == Pinetime::Controllers::Settings::TickerMode::Keep) {
+    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  }
+  optionsTotal++;
+}
+
+SettingTicker::~SettingTicker() {
+  lv_obj_clean(lv_scr_act());
+  settingsController.SaveSettings();
+}
+
+bool SettingTicker::Refresh() {
+  return running;
+}
+
+void SettingTicker::UpdateSelected(lv_obj_t* object, lv_event_t event) {
+  if (event == LV_EVENT_VALUE_CHANGED) {
+    for (int i = 0; i < optionsTotal; i++) {
+      if (object == cbOption[i]) {
+        lv_checkbox_set_checked(cbOption[i], true);
+
+        if (i == 0) {
+          settingsController.setTickerMode(Pinetime::Controllers::Settings::TickerMode::Off);
+        };
+        if (i == 1) {
+          settingsController.setTickerMode(Pinetime::Controllers::Settings::TickerMode::Update);
+        };
+        if (i == 2) {
+          settingsController.setTickerMode(Pinetime::Controllers::Settings::TickerMode::Keep);
+        };
+
+      } else {
+        lv_checkbox_set_checked(cbOption[i], false);
+      }
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingTicker.h
+++ b/src/displayapp/screens/settings/SettingTicker.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+#include <lvgl/lvgl.h>
+#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
+
+namespace Pinetime {
+
+  namespace Applications {
+    namespace Screens {
+
+      class SettingTicker : public Screen {
+      public:
+        SettingTicker(DisplayApp* app, Pinetime::Controllers::Settings& settingsController);
+        ~SettingTicker() override;
+
+        bool Refresh() override;
+        void UpdateSelected(lv_obj_t* object, lv_event_t event);
+
+      private:
+        Controllers::Settings& settingsController;
+        uint8_t optionsTotal;
+        lv_obj_t* cbOption[2];
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -18,7 +18,11 @@ Settings::Settings(Pinetime::Applications::DisplayApp* app, Pinetime::Controller
               },
               [this]() -> std::unique_ptr<Screen> {
                 return CreateScreen2();
-              }},
+              },
+              [this]() -> std::unique_ptr<Screen> {
+                return CreateScreen3();
+              }
+	     },
              Screens::ScreenListModes::UpDown} {
 }
 
@@ -46,17 +50,26 @@ std::unique_ptr<Screen> Settings::CreateScreen1() {
     {Symbols::clock, "Watch face", Apps::SettingWatchFace},
   }};
 
-  return std::make_unique<Screens::List>(0, 2, app, settingsController, applications);
+  return std::make_unique<Screens::List>(0, 3, app, settingsController, applications);
 }
 
 std::unique_ptr<Screen> Settings::CreateScreen2() {
 
   std::array<Screens::List::Applications, 4> applications {{
     {Symbols::shoe, "Steps", Apps::SettingSteps},
+    {Symbols::clock, "Ticker", Apps::SettingTicker},
     {Symbols::batteryHalf, "Battery", Apps::BatteryInfo},
     {Symbols::check, "Firmware", Apps::FirmwareValidation},
+  }};
+
+  return std::make_unique<Screens::List>(1, 3, app, settingsController, applications);
+}
+
+std::unique_ptr<Screen> Settings::CreateScreen3() {
+
+  std::array<Screens::List::Applications, 4> applications {{
     {Symbols::list, "About", Apps::SysInfo},
   }};
 
-  return std::make_unique<Screens::List>(1, 2, app, settingsController, applications);
+  return std::make_unique<Screens::List>(2, 3, app, settingsController, applications);
 }

--- a/src/displayapp/screens/settings/Settings.h
+++ b/src/displayapp/screens/settings/Settings.h
@@ -21,10 +21,11 @@ namespace Pinetime {
       private:
         Controllers::Settings& settingsController;
 
-        ScreenList<2> screens;
+        ScreenList<3> screens;
 
         std::unique_ptr<Screen> CreateScreen1();
         std::unique_ptr<Screen> CreateScreen2();
+        std::unique_ptr<Screen> CreateScreen3();
       };
     }
   }


### PR DESCRIPTION
Feature add. Added a scrolling ticker on the digital watch face. Ticker has 3 modes controlled by a settings screen.

1. Off: Do not display the ticker.
2. Update: Display the most recent message. As a convenience, the last message can be seen at a glance without the need to swipe up.
3. Keep: Keep the currently displayed message, and do not update it when receiving new messages. Useful for persistent reminders or to help with learning/memorizing facts, Bible verses, quotes, etc. Message can be set manually using GadgetBridge's Debug screen.

Compiled, downloaded OTA to my watch, and tested. 

Pics can be seen on this google shared album: [https://photos.app.goo.gl/HSDs2YWnEf5c1Xk48](https://photos.app.goo.gl/HSDs2YWnEf5c1Xk48)

Ideas for future functionality:

- display news/RSS items
- stock market ticker
- user-programmable filter to show only high priority or certain types of messages on the watch face
- display status from other apps (notify when timer is done, or when step goal met)
- debug/log messages for developers trying to catch rare or hard to repeat bugs