### PR TITLE
Reduce repeated code for watchface list render

### DIFF
--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -41,33 +41,50 @@ SettingWatchFace::SettingWatchFace(Pinetime::Applications::DisplayApp* app, Pine
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
   optionsTotal = 0;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " Digital face");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetClockFace() == 0) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  constexpr int8_t watchFaceCount = 3;
+  const char * watchFaceNames[watchFaceCount] = {" Digital face",
+                                            " Analog face",
+                                            " PineTimeStyle"};
+
+  for (int i = 0; i < watchFaceCount; ++i) {
+    cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
+    lv_checkbox_set_text_static(cbOption[optionsTotal], watchFaceNames[i]);
+    cbOption[optionsTotal]->user_data = this;
+    lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
+    if (settingsController.GetClockFace() == i) {
+      lv_checkbox_set_checked(cbOption[optionsTotal], true);
+    }
+    ++optionsTotal;
   }
 
-  optionsTotal++;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " Analog face");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetClockFace() == 1) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  }
 
-  optionsTotal++;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " PineTimeStyle");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetClockFace() == 2) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  }
+  // cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
+  // lv_checkbox_set_text_static(cbOption[optionsTotal], " Digital face");
+  // cbOption[optionsTotal]->user_data = this;
+  // lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
+  // if (settingsController.GetClockFace() == 0) {
+  //   lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  // }
 
-  optionsTotal++;
+  // optionsTotal++;
+  // cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
+  // lv_checkbox_set_text_static(cbOption[optionsTotal], " Analog face");
+  // cbOption[optionsTotal]->user_data = this;
+  // lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
+  // if (settingsController.GetClockFace() == 1) {
+  //   lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  // }
+
+  // optionsTotal++;
+  // cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
+  // lv_checkbox_set_text_static(cbOption[optionsTotal], " PineTimeStyle");
+  // cbOption[optionsTotal]->user_data = this;
+  // lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
+  // if (settingsController.GetClockFace() == 2) {
+  //   lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  // }
+
+  // optionsTotal++;
 }
 
 SettingWatchFace::~SettingWatchFace() {

--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -39,22 +39,20 @@ SettingWatchFace::SettingWatchFace(Pinetime::Applications::DisplayApp* app, Pine
   lv_label_set_text_static(icon, Symbols::clock);
   lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
-
-  optionsTotal = 0;
+  
   constexpr uint8_t watchFaceCount = 3;
   const char * watchFaceNames[watchFaceCount] = {" Digital face",
-                                            " Analog face",
-                                            " PineTimeStyle"};
+                                                " Analog face",
+                                                " PineTimeStyle"};
 
-  for (uint8_t i = 0; i < watchFaceCount; ++i) {
+  for (; optionsTotal < watchFaceCount; ++optionsTotal) {
     cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-    lv_checkbox_set_text_static(cbOption[optionsTotal], watchFaceNames[i]);
+    lv_checkbox_set_text_static(cbOption[optionsTotal], watchFaceNames[optionsTotal]);
     cbOption[optionsTotal]->user_data = this;
     lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-    if (settingsController.GetClockFace() == i) {
+    if (settingsController.GetClockFace() == optionsTotal) {
       lv_checkbox_set_checked(cbOption[optionsTotal], true);
     }
-    ++optionsTotal;
   }
 }
 

--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -56,35 +56,6 @@ SettingWatchFace::SettingWatchFace(Pinetime::Applications::DisplayApp* app, Pine
     }
     ++optionsTotal;
   }
-
-
-  // cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  // lv_checkbox_set_text_static(cbOption[optionsTotal], " Digital face");
-  // cbOption[optionsTotal]->user_data = this;
-  // lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  // if (settingsController.GetClockFace() == 0) {
-  //   lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  // }
-
-  // optionsTotal++;
-  // cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  // lv_checkbox_set_text_static(cbOption[optionsTotal], " Analog face");
-  // cbOption[optionsTotal]->user_data = this;
-  // lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  // if (settingsController.GetClockFace() == 1) {
-  //   lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  // }
-
-  // optionsTotal++;
-  // cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  // lv_checkbox_set_text_static(cbOption[optionsTotal], " PineTimeStyle");
-  // cbOption[optionsTotal]->user_data = this;
-  // lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  // if (settingsController.GetClockFace() == 2) {
-  //   lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  // }
-
-  // optionsTotal++;
 }
 
 SettingWatchFace::~SettingWatchFace() {

--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -41,12 +41,12 @@ SettingWatchFace::SettingWatchFace(Pinetime::Applications::DisplayApp* app, Pine
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
   optionsTotal = 0;
-  constexpr int8_t watchFaceCount = 3;
+  constexpr uint8_t watchFaceCount = 3;
   const char * watchFaceNames[watchFaceCount] = {" Digital face",
                                             " Analog face",
                                             " PineTimeStyle"};
 
-  for (int i = 0; i < watchFaceCount; ++i) {
+  for (uint8_t i = 0; i < watchFaceCount; ++i) {
     cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
     lv_checkbox_set_text_static(cbOption[optionsTotal], watchFaceNames[i]);
     cbOption[optionsTotal]->user_data = this;

--- a/src/displayapp/screens/settings/SettingWatchFace.h
+++ b/src/displayapp/screens/settings/SettingWatchFace.h
@@ -20,7 +20,7 @@ namespace Pinetime {
 
       private:
         Controllers::Settings& settingsController;
-        uint8_t optionsTotal;
+        uint8_t optionsTotal = 0;
         lv_obj_t* cbOption[2];
       };
     }


### PR DESCRIPTION
I reduced the amount of code in SettingWatchFace.cpp to improve code readability and convenience, so now when adding a new watchface, you won't have to copy many lines of code.