### PR TITLE
Replace lv_label_set_text with better options where possible

### DIFF
--- a/src/displayapp/screens/Brightness.cpp
+++ b/src/displayapp/screens/Brightness.cpp
@@ -21,7 +21,7 @@ Brightness::Brightness(Pinetime::Applications::DisplayApp* app, Controllers::Bri
   lv_slider_set_value(slider, LevelToInt(brightness.Level()), LV_ANIM_OFF);
 
   slider_label = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text(slider_label, LevelToString(brightness.Level()));
+  lv_label_set_text_static(slider_label, LevelToString(brightness.Level()));
   lv_obj_set_auto_realign(slider_label, true);
   lv_obj_align(slider_label, slider, LV_ALIGN_OUT_BOTTOM_MID, 0, 30);
 }
@@ -65,7 +65,7 @@ void Brightness::SetValue(uint8_t value) {
       brightness.Set(Controllers::BrightnessController::Levels::High);
       break;
   }
-  lv_label_set_text(slider_label, LevelToString(brightness.Level()));
+  lv_label_set_text_static(slider_label, LevelToString(brightness.Level()));
 }
 
 uint8_t Brightness::LevelToInt(Pinetime::Controllers::BrightnessController::Levels level) {
@@ -103,5 +103,5 @@ bool Brightness::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
 
 void Brightness::SetValue() {
   lv_slider_set_value(slider, LevelToInt(brightness.Level()), LV_ANIM_OFF);
-  lv_label_set_text(slider_label, LevelToString(brightness.Level()));
+  lv_label_set_text_static(slider_label, LevelToString(brightness.Level()));
 }

--- a/src/displayapp/screens/FirmwareUpdate.cpp
+++ b/src/displayapp/screens/FirmwareUpdate.cpp
@@ -15,7 +15,7 @@ FirmwareUpdate::FirmwareUpdate(Pinetime::Applications::DisplayApp* app, Pinetime
   lv_label_set_text_static(backgroundLabel, "");
 
   titleLabel = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text(titleLabel, "Firmware update");
+  lv_label_set_text_static(titleLabel, "Firmware update");
   lv_obj_set_auto_realign(titleLabel, true);
   lv_obj_align(titleLabel, nullptr, LV_ALIGN_IN_TOP_MID, 0, 50);
 
@@ -27,7 +27,7 @@ FirmwareUpdate::FirmwareUpdate(Pinetime::Applications::DisplayApp* app, Pinetime
   lv_bar_set_value(bar1, 0, LV_ANIM_OFF);
 
   percentLabel = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text(percentLabel, "Waiting...");
+  lv_label_set_text_static(percentLabel, "Waiting...");
   lv_obj_set_auto_realign(percentLabel, true);
   lv_obj_align(percentLabel, bar1, LV_ALIGN_OUT_TOP_MID, 0, 60);
   startTime = xTaskGetTickCount();
@@ -80,20 +80,19 @@ void FirmwareUpdate::DisplayProgression() const {
   float current = bleController.FirmwareUpdateCurrentBytes() / 1024.0f;
   float total = bleController.FirmwareUpdateTotalBytes() / 1024.0f;
   int16_t pc = (current / total) * 100.0f;
-  sprintf(percentStr, "%d %%", pc);
-  lv_label_set_text(percentLabel, percentStr);
+  lv_label_set_text_fmt(percentLabel, "%d %%", pc);
 
   lv_bar_set_value(bar1, pc, LV_ANIM_OFF);
 }
 
 void FirmwareUpdate::UpdateValidated() {
   lv_label_set_recolor(percentLabel, true);
-  lv_label_set_text(percentLabel, "#00ff00 Image Ok!#");
+  lv_label_set_text_static(percentLabel, "#00ff00 Image Ok!#");
 }
 
 void FirmwareUpdate::UpdateError() {
   lv_label_set_recolor(percentLabel, true);
-  lv_label_set_text(percentLabel, "#ff0000 Error!#");
+  lv_label_set_text_static(percentLabel, "#ff0000 Error!#");
   startTime = xTaskGetTickCount();
 }
 

--- a/src/displayapp/screens/FirmwareValidation.cpp
+++ b/src/displayapp/screens/FirmwareValidation.cpp
@@ -33,9 +33,10 @@ FirmwareValidation::FirmwareValidation(Pinetime::Applications::DisplayApp* app, 
   lv_obj_set_width(labelIsValidated, 240);
 
   if (validator.IsValidated())
-    lv_label_set_text(labelIsValidated, "You have already\n#00ff00 validated# this firmware#");
+    lv_label_set_text_static(labelIsValidated, "You have already\n#00ff00 validated# this firmware#");
   else {
-    lv_label_set_text(labelIsValidated, "Please #00ff00 Validate# this version or\n#ff0000 Reset# to rollback to the previous version.");
+    lv_label_set_text_static(labelIsValidated,
+                             "Please #00ff00 Validate# this version or\n#ff0000 Reset# to rollback to the previous version.");
 
     buttonValidate = lv_btn_create(lv_scr_act(), nullptr);
     buttonValidate->user_data = this;

--- a/src/displayapp/screens/FlashLight.cpp
+++ b/src/displayapp/screens/FlashLight.cpp
@@ -34,7 +34,7 @@ FlashLight::FlashLight(Pinetime::Applications::DisplayApp* app,
   lv_label_set_long_mode(backgroundAction, LV_LABEL_LONG_CROP);
   lv_obj_set_size(backgroundAction, 240, 240);
   lv_obj_set_pos(backgroundAction, 0, 0);
-  lv_label_set_text(backgroundAction, "");
+  lv_label_set_text_static(backgroundAction, "");
   lv_obj_set_click(backgroundAction, true);
   backgroundAction->user_data = this;
   lv_obj_set_event_cb(backgroundAction, event_handler);

--- a/src/displayapp/screens/HeartRate.cpp
+++ b/src/displayapp/screens/HeartRate.cpp
@@ -41,16 +41,16 @@ HeartRate::HeartRate(Pinetime::Applications::DisplayApp* app,
   else
     lv_obj_set_style_local_text_color(label_hr, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
 
-  lv_label_set_text(label_hr, "000");
+  lv_label_set_text_static(label_hr, "000");
   lv_obj_align(label_hr, nullptr, LV_ALIGN_CENTER, 0, -40);
 
   label_bpm = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text(label_bpm, "Heart rate BPM");
+  lv_label_set_text_static(label_bpm, "Heart rate BPM");
   lv_obj_align(label_bpm, label_hr, LV_ALIGN_OUT_TOP_MID, 0, -20);
 
   label_status = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(label_status, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x222222));
-  lv_label_set_text(label_status, ToString(Pinetime::Controllers::HeartRateController::States::NotEnoughData));
+  lv_label_set_text_static(label_status, ToString(Pinetime::Controllers::HeartRateController::States::NotEnoughData));
 
   lv_obj_align(label_status, label_hr, LV_ALIGN_OUT_BOTTOM_MID, 0, 10);
 
@@ -78,13 +78,13 @@ bool HeartRate::Refresh() {
     case Controllers::HeartRateController::States::NoTouch:
     case Controllers::HeartRateController::States::NotEnoughData:
       // case Controllers::HeartRateController::States::Stopped:
-      lv_label_set_text(label_hr, "000");
+      lv_label_set_text_static(label_hr, "000");
       break;
     default:
       lv_label_set_text_fmt(label_hr, "%03d", heartRateController.HeartRate());
   }
 
-  lv_label_set_text(label_status, ToString(state));
+  lv_label_set_text_static(label_status, ToString(state));
   lv_obj_align(label_status, label_hr, LV_ALIGN_OUT_BOTTOM_MID, 0, 10);
 
   return running;
@@ -108,7 +108,7 @@ void HeartRate::OnStartStopEvent(lv_event_t event) {
 
 void HeartRate::UpdateStartStopButton(bool isRunning) {
   if (isRunning)
-    lv_label_set_text(label_startStop, "Stop");
+    lv_label_set_text_static(label_startStop, "Stop");
   else
-    lv_label_set_text(label_startStop, "Start");
+    lv_label_set_text_static(label_startStop, "Start");
 }

--- a/src/displayapp/screens/Motion.cpp
+++ b/src/displayapp/screens/Motion.cpp
@@ -35,7 +35,7 @@ Motion::Motion(Pinetime::Applications::DisplayApp* app, Controllers::MotionContr
 
   labelStep = lv_label_create(lv_scr_act(), NULL);
   lv_obj_align(labelStep, chart, LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
-  lv_label_set_text(labelStep, "Steps ---");
+  lv_label_set_text_static(labelStep, "Steps ---");
 }
 
 Motion::~Motion() {

--- a/src/displayapp/screens/Music.cpp
+++ b/src/displayapp/screens/Music.cpp
@@ -62,7 +62,7 @@ Music::Music(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Mus
   lv_obj_align(btnVolDown, nullptr, LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
   lv_obj_add_style(btnVolDown, LV_STATE_DEFAULT, &btn_style);
   label = lv_label_create(btnVolDown, nullptr);
-  lv_label_set_text(label, Symbols::volumDown);
+  lv_label_set_text_static(label, Symbols::volumDown);
   lv_obj_set_hidden(btnVolDown, true);
 
   btnVolUp = lv_btn_create(lv_scr_act(), nullptr);
@@ -72,7 +72,7 @@ Music::Music(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Mus
   lv_obj_align(btnVolUp, nullptr, LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
   lv_obj_add_style(btnVolUp, LV_STATE_DEFAULT, &btn_style);
   label = lv_label_create(btnVolUp, nullptr);
-  lv_label_set_text(label, Symbols::volumUp);
+  lv_label_set_text_static(label, Symbols::volumUp);
   lv_obj_set_hidden(btnVolUp, true);
 
   btnPrev = lv_btn_create(lv_scr_act(), nullptr);
@@ -82,7 +82,7 @@ Music::Music(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Mus
   lv_obj_align(btnPrev, nullptr, LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
   lv_obj_add_style(btnPrev, LV_STATE_DEFAULT, &btn_style);
   label = lv_label_create(btnPrev, nullptr);
-  lv_label_set_text(label, Symbols::stepBackward);
+  lv_label_set_text_static(label, Symbols::stepBackward);
 
   btnNext = lv_btn_create(lv_scr_act(), nullptr);
   btnNext->user_data = this;
@@ -91,7 +91,7 @@ Music::Music(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Mus
   lv_obj_align(btnNext, nullptr, LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
   lv_obj_add_style(btnNext, LV_STATE_DEFAULT, &btn_style);
   label = lv_label_create(btnNext, nullptr);
-  lv_label_set_text(label, Symbols::stepForward);
+  lv_label_set_text_static(label, Symbols::stepForward);
 
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
   btnPlayPause->user_data = this;
@@ -100,12 +100,12 @@ Music::Music(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Mus
   lv_obj_align(btnPlayPause, nullptr, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
   lv_obj_add_style(btnPlayPause, LV_STATE_DEFAULT, &btn_style);
   txtPlayPause = lv_label_create(btnPlayPause, nullptr);
-  lv_label_set_text(txtPlayPause, Symbols::play);
+  lv_label_set_text_static(txtPlayPause, Symbols::play);
 
   txtTrackDuration = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtTrackDuration, LV_LABEL_LONG_SROLL);
   lv_obj_align(txtTrackDuration, nullptr, LV_ALIGN_IN_TOP_LEFT, 12, 20);
-  lv_label_set_text(txtTrackDuration, "--:--/--:--");
+  lv_label_set_text_static(txtTrackDuration, "--:--/--:--");
   lv_label_set_align(txtTrackDuration, LV_ALIGN_IN_LEFT_MID);
   lv_obj_set_width(txtTrackDuration, LV_HOR_RES);
 
@@ -117,7 +117,7 @@ Music::Music(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Mus
   lv_obj_align(txtArtist, nullptr, LV_ALIGN_IN_LEFT_MID, 12, MIDDLE_OFFSET + 1 * FONT_HEIGHT);
   lv_label_set_align(txtArtist, LV_ALIGN_IN_LEFT_MID);
   lv_obj_set_width(txtArtist, LV_HOR_RES - 12);
-  lv_label_set_text(txtArtist, "Artist Name");
+  lv_label_set_text_static(txtArtist, "Artist Name");
 
   txtTrack = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtTrack, LV_LABEL_LONG_SROLL_CIRC);
@@ -125,7 +125,7 @@ Music::Music(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Mus
 
   lv_label_set_align(txtTrack, LV_ALIGN_IN_LEFT_MID);
   lv_obj_set_width(txtTrack, LV_HOR_RES - 12);
-  lv_label_set_text(txtTrack, "This is a very long getTrack name");
+  lv_label_set_text_static(txtTrack, "This is a very long getTrack name");
 
   /** Init animation */
   imgDisc = lv_img_create(lv_scr_act(), nullptr);
@@ -184,7 +184,7 @@ bool Music::Refresh() {
   }
 
   if (playing == Pinetime::Controllers::MusicService::MusicStatus::Playing) {
-    lv_label_set_text(txtPlayPause, Symbols::pause);
+    lv_label_set_text_static(txtPlayPause, Symbols::pause);
     if (xTaskGetTickCount() - 1024 >= lastIncrement) {
 
       if (frameB) {
@@ -208,7 +208,7 @@ bool Music::Refresh() {
       UpdateLength();
     }
   } else {
-    lv_label_set_text(txtPlayPause, Symbols::play);
+    lv_label_set_text_static(txtPlayPause, Symbols::play);
   }
 
   return running;
@@ -216,25 +216,21 @@ bool Music::Refresh() {
 
 void Music::UpdateLength() {
   if (totalLength > (99 * 60 * 60)) {
-    lv_label_set_text(txtTrackDuration, "Inf/Inf");
+    lv_label_set_text_static(txtTrackDuration, "Inf/Inf");
   } else if (totalLength > (99 * 60)) {
-    char timer[12];
-    sprintf(timer,
-            "%02d:%02d/%02d:%02d",
-            (currentLength / (60 * 60)) % 100,
-            ((currentLength % (60 * 60)) / 60) % 100,
-            (totalLength / (60 * 60)) % 100,
-            ((totalLength % (60 * 60)) / 60) % 100);
-    lv_label_set_text(txtTrackDuration, timer);
+    lv_label_set_text_fmt(txtTrackDuration,
+                          "%02d:%02d/%02d:%02d",
+                          (currentLength / (60 * 60)) % 100,
+                          ((currentLength % (60 * 60)) / 60) % 100,
+                          (totalLength / (60 * 60)) % 100,
+                          ((totalLength % (60 * 60)) / 60) % 100);
   } else {
-    char timer[12];
-    sprintf(timer,
-            "%02d:%02d/%02d:%02d",
-            (currentLength / 60) % 100,
-            (currentLength % 60) % 100,
-            (totalLength / 60) % 100,
-            (totalLength % 60) % 100);
-    lv_label_set_text(txtTrackDuration, timer);
+    lv_label_set_text_fmt(txtTrackDuration,
+                          "%02d:%02d/%02d:%02d",
+                          (currentLength / 60) % 100,
+                          (currentLength % 60) % 100,
+                          (totalLength / 60) % 100,
+                          (totalLength % 60) % 100);
   }
 }
 

--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -134,13 +134,13 @@ Navigation::Navigation(Pinetime::Applications::DisplayApp* app, Pinetime::Contro
   imgFlag = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(imgFlag, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_navi_80);
   lv_obj_set_style_local_text_color(imgFlag, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_CYAN);
-  lv_label_set_text(imgFlag, iconForName("flag"));
+  lv_label_set_text_static(imgFlag, iconForName("flag"));
   lv_obj_align(imgFlag, nullptr, LV_ALIGN_CENTER, 0, -60);
 
   txtNarrative = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtNarrative, LV_LABEL_LONG_BREAK);
   lv_obj_set_width(txtNarrative, LV_HOR_RES);
-  lv_label_set_text(txtNarrative, "Navigation");
+  lv_label_set_text_static(txtNarrative, "Navigation");
   lv_label_set_align(txtNarrative, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(txtNarrative, nullptr, LV_ALIGN_CENTER, 0, 10);
 
@@ -148,7 +148,7 @@ Navigation::Navigation(Pinetime::Applications::DisplayApp* app, Pinetime::Contro
   lv_label_set_long_mode(txtManDist, LV_LABEL_LONG_BREAK);
   lv_obj_set_style_local_text_color(txtManDist, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GREEN);
   lv_obj_set_width(txtManDist, LV_HOR_RES);
-  lv_label_set_text(txtManDist, "--M");
+  lv_label_set_text_static(txtManDist, "--M");
   lv_label_set_align(txtManDist, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(txtManDist, nullptr, LV_ALIGN_CENTER, 0, 60);
 
@@ -170,7 +170,7 @@ Navigation::~Navigation() {
 bool Navigation::Refresh() {
   if (flag != navService.getFlag()) {
     flag = navService.getFlag();
-    lv_label_set_text(imgFlag, iconForName(flag));
+    lv_label_set_text_static(imgFlag, iconForName(flag));
   }
 
   if (narrative != navService.getNarrative()) {
@@ -195,5 +195,3 @@ bool Navigation::Refresh() {
 
   return running;
 }
-
-

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -198,7 +198,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
       lv_obj_set_style_local_text_color(alert_subject, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
       lv_label_set_long_mode(alert_subject, LV_LABEL_LONG_BREAK);
       lv_obj_set_width(alert_subject, LV_HOR_RES - 20);
-      lv_label_set_text(alert_subject, "Incoming call from");
+      lv_label_set_text_static(alert_subject, "Incoming call from");
 
       lv_obj_t* alert_caller = lv_label_create(container1, nullptr);
       lv_obj_align(alert_caller, alert_subject, LV_ALIGN_OUT_BOTTOM_LEFT, 0, 0);
@@ -212,7 +212,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
       lv_obj_set_size(bt_accept, 76, 76);
       lv_obj_align(bt_accept, NULL, LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
       label_accept = lv_label_create(bt_accept, nullptr);
-      lv_label_set_text(label_accept, Symbols::phone);
+      lv_label_set_text_static(label_accept, Symbols::phone);
       lv_obj_set_style_local_bg_color(bt_accept, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GREEN);
 
       bt_reject = lv_btn_create(lv_scr_act(), nullptr);
@@ -221,7 +221,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
       lv_obj_set_size(bt_reject, 76, 76);
       lv_obj_align(bt_reject, NULL, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
       label_reject = lv_label_create(bt_reject, nullptr);
-      lv_label_set_text(label_reject, Symbols::phoneSlash);
+      lv_label_set_text_static(label_reject, Symbols::phoneSlash);
       lv_obj_set_style_local_bg_color(bt_reject, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_RED);
 
       bt_mute = lv_btn_create(lv_scr_act(), nullptr);
@@ -230,7 +230,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
       lv_obj_set_size(bt_mute, 76, 76);
       lv_obj_align(bt_mute, NULL, LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
       label_mute = lv_label_create(bt_mute, nullptr);
-      lv_label_set_text(label_mute, Symbols::volumMute);
+      lv_label_set_text_static(label_mute, Symbols::volumMute);
       lv_obj_set_style_local_bg_color(bt_mute, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
     } break;
   }
@@ -239,7 +239,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
   lv_label_set_long_mode(backgroundLabel, LV_LABEL_LONG_CROP);
   lv_obj_set_size(backgroundLabel, 240, 240);
   lv_obj_set_pos(backgroundLabel, 0, 0);
-  lv_label_set_text(backgroundLabel, "");
+  lv_label_set_text_static(backgroundLabel, "");
 }
 
 void Notifications::NotificationItem::OnCallButtonEvent(lv_obj_t* obj, lv_event_t event) {

--- a/src/displayapp/screens/Paddle.cpp
+++ b/src/displayapp/screens/Paddle.cpp
@@ -17,7 +17,7 @@ Paddle::Paddle(Pinetime::Applications::DisplayApp* app, Pinetime::Components::Li
 
   points = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(points, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
-  lv_label_set_text(points, "0000");
+  lv_label_set_text_static(points, "0000");
   lv_obj_align(points, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 10);
 
   paddle = lv_obj_create(lv_scr_act(), nullptr);

--- a/src/displayapp/screens/PineTimeStyle.cpp
+++ b/src/displayapp/screens/PineTimeStyle.cpp
@@ -71,19 +71,19 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
   timeDD1 = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(timeDD1, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &open_sans_light);
   lv_obj_set_style_local_text_color(timeDD1, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x008080));
-  lv_label_set_text(timeDD1, "12");
+  lv_label_set_text_static(timeDD1, "12");
   lv_obj_align(timeDD1, timebar, LV_ALIGN_IN_TOP_MID, 5, 5);
 
   timeDD2 = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(timeDD2, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &open_sans_light);
   lv_obj_set_style_local_text_color(timeDD2, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x008080));
-  lv_label_set_text(timeDD2, "34");
+  lv_label_set_text_static(timeDD2, "34");
   lv_obj_align(timeDD2, timebar, LV_ALIGN_IN_BOTTOM_MID, 5, -5);
 
   timeAMPM = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(timeAMPM, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x008080));
   lv_obj_set_style_local_text_line_space(timeAMPM, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, -3);
-  lv_label_set_text(timeAMPM, "");
+  lv_label_set_text_static(timeAMPM, "");
   lv_obj_align(timeAMPM, timebar, LV_ALIGN_IN_BOTTOM_LEFT, 2, -20);
 
   /* Create a 40px wide bar down the right side of the screen */
@@ -96,7 +96,7 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
   /* Display icons */
   batteryIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(batteryIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
-  lv_label_set_text(batteryIcon, Symbols::batteryFull);
+  lv_label_set_text_static(batteryIcon, Symbols::batteryFull);
   lv_obj_align(batteryIcon, sidebar, LV_ALIGN_IN_TOP_MID, 0, 2);
 
   batteryPlug = lv_label_create(lv_scr_act(), nullptr);
@@ -151,17 +151,17 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
   /* Display date */
   dateDayOfWeek = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(dateDayOfWeek, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
-  lv_label_set_text(dateDayOfWeek, "THU");
+  lv_label_set_text_static(dateDayOfWeek, "THU");
   lv_obj_align(dateDayOfWeek, sidebar, LV_ALIGN_CENTER, 0, -34);
 
   dateDay = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(dateDay, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
-  lv_label_set_text(dateDay, "25");
+  lv_label_set_text_static(dateDay, "25");
   lv_obj_align(dateDay, sidebar, LV_ALIGN_CENTER, 0, 3);
 
   dateMonth = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(dateMonth, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
-  lv_label_set_text(dateMonth, "MAR");
+  lv_label_set_text_static(dateMonth, "MAR");
   lv_obj_align(dateMonth, sidebar, LV_ALIGN_CENTER, 0, 32);
 
   // Step count gauge
@@ -192,7 +192,7 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
   lv_label_set_long_mode(backgroundLabel, LV_LABEL_LONG_CROP);
   lv_obj_set_size(backgroundLabel, 240, 240);
   lv_obj_set_pos(backgroundLabel, 0, 0);
-  lv_label_set_text(backgroundLabel, "");
+  lv_label_set_text_static(backgroundLabel, "");
 }
 
 PineTimeStyle::~PineTimeStyle() {
@@ -205,24 +205,24 @@ bool PineTimeStyle::Refresh() {
     auto batteryPercent = batteryPercentRemaining.Get();
     if (batteryController.IsCharging()) {
       auto isCharging = batteryController.IsCharging() || batteryController.IsPowerPresent();
-      lv_label_set_text(batteryPlug, BatteryIcon::GetPlugIcon(isCharging));
+      lv_label_set_text_static(batteryPlug, BatteryIcon::GetPlugIcon(isCharging));
       lv_obj_realign(batteryPlug);
-      lv_label_set_text(batteryIcon, "");
+      lv_label_set_text_static(batteryIcon, "");
     } else {
-      lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
-      lv_label_set_text(batteryPlug, "");
+      lv_label_set_text_static(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
+      lv_label_set_text_static(batteryPlug, "");
     }
   }
 
   bleState = bleController.IsConnected();
   if (bleState.IsUpdated()) {
-    lv_label_set_text(bleIcon, BleIcon::GetIcon(bleState.Get()));
+    lv_label_set_text_static(bleIcon, BleIcon::GetIcon(bleState.Get()));
     lv_obj_realign(bleIcon);
   }
 
   notificationState = notificatioManager.AreNewNotificationsAvailable();
   if (notificationState.IsUpdated()) {
-    lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
+    lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
     lv_obj_realign(notificationIcon);
   }
 
@@ -248,7 +248,7 @@ bool PineTimeStyle::Refresh() {
     char hoursChar[3];
     char ampmChar[5];
     if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
-        sprintf(hoursChar, "%02d", hour);
+      sprintf(hoursChar, "%02d", hour);
     } else {
       if (hour == 0 && hour != 12) {
         hour = 12;
@@ -276,15 +276,15 @@ bool PineTimeStyle::Refresh() {
         lv_label_set_text(timeAMPM, ampmChar);
       }
 
-      lv_label_set_text_fmt(timeDD1, "%s", hoursChar);
-      lv_label_set_text_fmt(timeDD2, "%s", minutesChar);
+      lv_label_set_text(timeDD1, hoursChar);
+      lv_label_set_text(timeDD2, minutesChar);
     }
 
     if ((year != currentYear) || (month != currentMonth) || (dayOfWeek != currentDayOfWeek) || (day != currentDay)) {
-      lv_label_set_text_fmt(dateDayOfWeek, "%s", dateTimeController.DayOfWeekShortToString());
+      lv_label_set_text_static(dateDayOfWeek, dateTimeController.DayOfWeekShortToString());
       lv_label_set_text_fmt(dateDay, "%d", day);
       lv_obj_realign(dateDay);
-      lv_label_set_text_fmt(dateMonth, "%s", dateTimeController.MonthShortToString());
+      lv_label_set_text_static(dateMonth, dateTimeController.MonthShortToString());
 
       currentYear = year;
       currentMonth = month;

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -59,13 +59,13 @@ StopWatch::StopWatch(DisplayApp* app, System::SystemTask& systemTask)
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
-  lv_label_set_text(time, "00:00");
+  lv_label_set_text_static(time, "00:00");
   lv_obj_align(time, lv_scr_act(), LV_ALIGN_CENTER, 0, -45);
 
   msecTime = lv_label_create(lv_scr_act(), nullptr);
   // lv_obj_set_style_local_text_font(msecTime, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
   lv_obj_set_style_local_text_color(msecTime, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
-  lv_label_set_text(msecTime, "00");
+  lv_label_set_text_static(msecTime, "00");
   lv_obj_align(msecTime, lv_scr_act(), LV_ALIGN_CENTER, 0, 3);
 
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
@@ -75,7 +75,7 @@ StopWatch::StopWatch(DisplayApp* app, System::SystemTask& systemTask)
   lv_obj_set_width(btnPlayPause, 115);
   lv_obj_align(btnPlayPause, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
   txtPlayPause = lv_label_create(btnPlayPause, nullptr);
-  lv_label_set_text(txtPlayPause, Symbols::play);
+  lv_label_set_text_static(txtPlayPause, Symbols::play);
 
   btnStopLap = lv_btn_create(lv_scr_act(), nullptr);
   btnStopLap->user_data = this;
@@ -86,7 +86,7 @@ StopWatch::StopWatch(DisplayApp* app, System::SystemTask& systemTask)
   lv_obj_set_style_local_bg_color(btnStopLap, LV_BTN_PART_MAIN, LV_STATE_DISABLED, lv_color_hex(0x080808));
   txtStopLap = lv_label_create(btnStopLap, nullptr);
   lv_obj_set_style_local_text_color(txtStopLap, LV_BTN_PART_MAIN, LV_STATE_DISABLED, lv_color_hex(0x888888));
-  lv_label_set_text(txtStopLap, Symbols::stop);
+  lv_label_set_text_static(txtStopLap, Symbols::stop);
   lv_obj_set_state(btnStopLap, LV_STATE_DISABLED);
   lv_obj_set_state(txtStopLap, LV_STATE_DISABLED);
 
@@ -94,13 +94,13 @@ StopWatch::StopWatch(DisplayApp* app, System::SystemTask& systemTask)
   // lv_obj_set_style_local_text_font(lapOneText, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
   lv_obj_set_style_local_text_color(lapOneText, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
   lv_obj_align(lapOneText, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 50, 30);
-  lv_label_set_text(lapOneText, "");
+  lv_label_set_text_static(lapOneText, "");
 
   lapTwoText = lv_label_create(lv_scr_act(), nullptr);
   // lv_obj_set_style_local_text_font(lapTwoText, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
   lv_obj_set_style_local_text_color(lapTwoText, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
   lv_obj_align(lapTwoText, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 50, 55);
-  lv_label_set_text(lapTwoText, "");
+  lv_label_set_text_static(lapTwoText, "");
 }
 
 StopWatch::~StopWatch() {
@@ -114,11 +114,11 @@ void StopWatch::reset() {
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
   lv_obj_set_style_local_text_color(msecTime, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
 
-  lv_label_set_text(time, "00:00");
-  lv_label_set_text(msecTime, "00");
+  lv_label_set_text_static(time, "00:00");
+  lv_label_set_text_static(msecTime, "00");
 
-  lv_label_set_text(lapOneText, "");
-  lv_label_set_text(lapTwoText, "");
+  lv_label_set_text_static(lapOneText, "");
+  lv_label_set_text_static(lapTwoText, "");
   lapBuffer.clearBuffer();
   lapNr = 0;
   lv_obj_set_state(btnStopLap, LV_STATE_DISABLED);
@@ -130,8 +130,8 @@ void StopWatch::start() {
   lv_obj_set_state(txtStopLap, LV_STATE_DEFAULT);
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GREEN);
   lv_obj_set_style_local_text_color(msecTime, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GREEN);
-  lv_label_set_text(txtPlayPause, Symbols::pause);
-  lv_label_set_text(txtStopLap, Symbols::lapsFlag);
+  lv_label_set_text_static(txtPlayPause, Symbols::pause);
+  lv_label_set_text_static(txtStopLap, Symbols::lapsFlag);
   startTime = xTaskGetTickCount();
   currentState = States::Running;
   systemTask.PushMessage(Pinetime::System::Messages::DisableSleeping);
@@ -142,8 +142,8 @@ void StopWatch::pause() {
   // Store the current time elapsed in cache
   oldTimeElapsed += timeElapsed;
   currentState = States::Halted;
-  lv_label_set_text(txtPlayPause, Symbols::play);
-  lv_label_set_text(txtStopLap, Symbols::stop);
+  lv_label_set_text_static(txtPlayPause, Symbols::play);
+  lv_label_set_text_static(txtStopLap, Symbols::stop);
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
   lv_obj_set_style_local_text_color(msecTime, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
   systemTask.PushMessage(Pinetime::System::Messages::EnableSleeping);

--- a/src/displayapp/screens/Tile.cpp
+++ b/src/displayapp/screens/Tile.cpp
@@ -39,7 +39,7 @@ Tile::Tile(uint8_t screenID,
 
   // Battery
   batteryIcon = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
+  lv_label_set_text_static(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
   lv_obj_align(batteryIcon, nullptr, LV_ALIGN_IN_TOP_RIGHT, -8, 0);
 
   if (numScreens > 1) {
@@ -119,7 +119,7 @@ Tile::~Tile() {
 
 void Tile::UpdateScreen() {
   lv_label_set_text_fmt(label_time, "%02i:%02i", dateTimeController.Hours(), dateTimeController.Minutes());
-  lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
+  lv_label_set_text_static(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
 }
 
 bool Tile::Refresh() {

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -4,9 +4,7 @@
 #include "Symbols.h"
 #include "lvgl/lvgl.h"
 
-
 using namespace Pinetime::Applications::Screens;
-
 
 static void btnEventHandler(lv_obj_t* obj, lv_event_t event) {
   Timer* screen = static_cast<Timer*>(obj->user_data);
@@ -21,8 +19,8 @@ void Timer::createButtons() {
   lv_obj_set_height(btnMinutesUp, 40);
   lv_obj_set_width(btnMinutesUp, 60);
   txtMUp = lv_label_create(btnMinutesUp, nullptr);
-  lv_label_set_text(txtMUp, "+");
-  
+  lv_label_set_text_static(txtMUp, "+");
+
   btnMinutesDown = lv_btn_create(lv_scr_act(), nullptr);
   btnMinutesDown->user_data = this;
   lv_obj_set_event_cb(btnMinutesDown, btnEventHandler);
@@ -30,8 +28,8 @@ void Timer::createButtons() {
   lv_obj_set_height(btnMinutesDown, 40);
   lv_obj_set_width(btnMinutesDown, 60);
   txtMDown = lv_label_create(btnMinutesDown, nullptr);
-  lv_label_set_text(txtMDown, "-");
-  
+  lv_label_set_text_static(txtMDown, "-");
+
   btnSecondsUp = lv_btn_create(lv_scr_act(), nullptr);
   btnSecondsUp->user_data = this;
   lv_obj_set_event_cb(btnSecondsUp, btnEventHandler);
@@ -39,8 +37,8 @@ void Timer::createButtons() {
   lv_obj_set_height(btnSecondsUp, 40);
   lv_obj_set_width(btnSecondsUp, 60);
   txtSUp = lv_label_create(btnSecondsUp, nullptr);
-  lv_label_set_text(txtSUp, "+");
-  
+  lv_label_set_text_static(txtSUp, "+");
+
   btnSecondsDown = lv_btn_create(lv_scr_act(), nullptr);
   btnSecondsDown->user_data = this;
   lv_obj_set_event_cb(btnSecondsDown, btnEventHandler);
@@ -48,25 +46,21 @@ void Timer::createButtons() {
   lv_obj_set_height(btnSecondsDown, 40);
   lv_obj_set_width(btnSecondsDown, 60);
   txtSDown = lv_label_create(btnSecondsDown, nullptr);
-  lv_label_set_text(txtSDown, "-");
-  
+  lv_label_set_text_static(txtSDown, "-");
 }
 
-
 Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
-    : Screen(app),
-      running{true},
-      timerController{timerController} {
-  
+  : Screen(app), running {true}, timerController {timerController} {
+
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
-  
+
   uint32_t seconds = timerController.GetTimeRemaining() / 1000;
   lv_label_set_text_fmt(time, "%02lu:%02lu", seconds / 60, seconds % 60);
 
   lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, -20);
-  
+
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
   btnPlayPause->user_data = this;
   lv_obj_set_event_cb(btnPlayPause, btnEventHandler);
@@ -74,17 +68,15 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_obj_set_height(btnPlayPause, 40);
   txtPlayPause = lv_label_create(btnPlayPause, nullptr);
   if (timerController.IsRunning()) {
-    lv_label_set_text(txtPlayPause, Symbols::pause);
+    lv_label_set_text_static(txtPlayPause, Symbols::pause);
   } else {
-    lv_label_set_text(txtPlayPause, Symbols::play);
+    lv_label_set_text_static(txtPlayPause, Symbols::play);
     createButtons();
   }
-  
 }
 
 Timer::~Timer() {
   lv_obj_clean(lv_scr_act());
-  
 }
 
 bool Timer::Refresh() {
@@ -99,17 +91,17 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
   if (event == LV_EVENT_CLICKED) {
     if (obj == btnPlayPause) {
       if (timerController.IsRunning()) {
-        lv_label_set_text(txtPlayPause, Symbols::play);
+        lv_label_set_text_static(txtPlayPause, Symbols::play);
         uint32_t seconds = timerController.GetTimeRemaining() / 1000;
         minutesToSet = seconds / 60;
         secondsToSet = seconds % 60;
         timerController.StopTimer();
         createButtons();
-        
+
       } else if (secondsToSet + minutesToSet > 0) {
-        lv_label_set_text(txtPlayPause, Symbols::pause);
+        lv_label_set_text_static(txtPlayPause, Symbols::pause);
         timerController.StartTimer((secondsToSet + minutesToSet * 60) * 1000);
-        
+
         lv_obj_del(btnSecondsDown);
         btnSecondsDown = nullptr;
         lv_obj_del(btnSecondsUp);
@@ -118,7 +110,6 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
         btnMinutesDown = nullptr;
         lv_obj_del(btnMinutesUp);
         btnMinutesUp = nullptr;
-        
       }
     } else {
       if (!timerController.IsRunning()) {
@@ -129,7 +120,7 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
             minutesToSet++;
           }
           lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
-          
+
         } else if (obj == btnMinutesDown) {
           if (minutesToSet == 0) {
             minutesToSet = 59;
@@ -137,7 +128,7 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
             minutesToSet--;
           }
           lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
-          
+
         } else if (obj == btnSecondsUp) {
           if (secondsToSet >= 59) {
             secondsToSet = 0;
@@ -145,7 +136,7 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
             secondsToSet++;
           }
           lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
-          
+
         } else if (obj == btnSecondsDown) {
           if (secondsToSet == 0) {
             secondsToSet = 59;
@@ -153,20 +144,15 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
             secondsToSet--;
           }
           lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
-          
         }
       }
-      
     }
-    
   }
-  
 }
 
-
 void Timer::setDone() {
-  lv_label_set_text(time, "00:00");
-  lv_label_set_text(txtPlayPause, Symbols::play);
+  lv_label_set_text_static(time, "00:00");
+  lv_label_set_text_static(txtPlayPause, Symbols::play);
   secondsToSet = 0;
   minutesToSet = 0;
   createButtons();

--- a/src/displayapp/screens/Twos.cpp
+++ b/src/displayapp/screens/Twos.cpp
@@ -90,7 +90,7 @@ Twos::Twos(Pinetime::Applications::DisplayApp* app) : Screen(app) {
   lv_label_set_long_mode(backgroundLabel, LV_LABEL_LONG_CROP);
   lv_obj_set_size(backgroundLabel, 240, 240);
   lv_obj_set_pos(backgroundLabel, 0, 0);
-  lv_label_set_text(backgroundLabel, "");
+  lv_label_set_text_static(backgroundLabel, "");
 }
 
 Twos::~Twos() {

--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -14,8 +14,8 @@ constexpr int16_t HourLength = 70;
 constexpr int16_t MinuteLength = 90;
 constexpr int16_t SecondLength = 110;
 
-// sin(90) = 1 so the value of _lv_trigo_sin(90) is the scaling factor
-const auto LV_TRIG_SCALE = _lv_trigo_sin(90);
+  // sin(90) = 1 so the value of _lv_trigo_sin(90) is the scaling factor
+  const auto LV_TRIG_SCALE = _lv_trigo_sin(90);
 
 int16_t Cosine(int16_t angle) {
   return _lv_trigo_sin(angle + 90);
@@ -66,12 +66,12 @@ WatchFaceAnalog::WatchFaceAnalog(Pinetime::Applications::DisplayApp* app,
   lv_obj_align(bg_clock_img, NULL, LV_ALIGN_CENTER, 0, 0);
 
   batteryIcon = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text(batteryIcon, Symbols::batteryHalf);
+  lv_label_set_text_static(batteryIcon, Symbols::batteryHalf);
   lv_obj_align(batteryIcon, NULL, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
 
   notificationIcon = lv_label_create(lv_scr_act(), NULL);
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FF00));
-  lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(false));
+  lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(false));
   lv_obj_align(notificationIcon, NULL, LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
 
   // Date - Day / Week day
@@ -177,13 +177,13 @@ bool WatchFaceAnalog::Refresh() {
   batteryPercentRemaining = batteryController.PercentRemaining();
   if (batteryPercentRemaining.IsUpdated()) {
     auto batteryPercent = batteryPercentRemaining.Get();
-    lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
+    lv_label_set_text_static(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
   }
 
   notificationState = notificationManager.AreNewNotificationsAvailable();
 
   if (notificationState.IsUpdated()) {
-    lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
+    lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
   }
 
   currentDateTime = dateTimeController.CurrentDateTime();

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -34,22 +34,22 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   settingsController.SetClockFace(0);
 
   batteryIcon = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text(batteryIcon, Symbols::batteryFull);
+  lv_label_set_text_static(batteryIcon, Symbols::batteryFull);
   lv_obj_align(batteryIcon, lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, 0, 0);
 
   batteryPlug = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(batteryPlug, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFF0000));
-  lv_label_set_text(batteryPlug, Symbols::plug);
+  lv_label_set_text_static(batteryPlug, Symbols::plug);
   lv_obj_align(batteryPlug, batteryIcon, LV_ALIGN_OUT_LEFT_MID, -5, 0);
 
   bleIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(bleIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x0000FF));
-  lv_label_set_text(bleIcon, Symbols::bluetooth);
+  lv_label_set_text_static(bleIcon, Symbols::bluetooth);
   lv_obj_align(bleIcon, batteryPlug, LV_ALIGN_OUT_LEFT_MID, -5, 0);
 
   notificationIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FF00));
-  lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(false));
+  lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(false));
   lv_obj_align(notificationIcon, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 0);
 
   label_date = lv_label_create(lv_scr_act(), nullptr);
@@ -70,26 +70,26 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   lv_label_set_long_mode(backgroundLabel, LV_LABEL_LONG_CROP);
   lv_obj_set_size(backgroundLabel, 240, 240);
   lv_obj_set_pos(backgroundLabel, 0, 0);
-  lv_label_set_text(backgroundLabel, "");
+  lv_label_set_text_static(backgroundLabel, "");
 
   heartbeatIcon = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text(heartbeatIcon, Symbols::heartBeat);
+  lv_label_set_text_static(heartbeatIcon, Symbols::heartBeat);
   lv_obj_set_style_local_text_color(heartbeatIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xCE1B1B));
   lv_obj_align(heartbeatIcon, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
 
   heartbeatValue = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(heartbeatValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xCE1B1B));
-  lv_label_set_text(heartbeatValue, "");
+  lv_label_set_text_static(heartbeatValue, "");
   lv_obj_align(heartbeatValue, heartbeatIcon, LV_ALIGN_OUT_RIGHT_MID, 5, 0);
 
   stepValue = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(stepValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FFE7));
-  lv_label_set_text(stepValue, "0");
+  lv_label_set_text_static(stepValue, "0");
   lv_obj_align(stepValue, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
 
   stepIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(stepIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FFE7));
-  lv_label_set_text(stepIcon, Symbols::shoe);
+  lv_label_set_text_static(stepIcon, Symbols::shoe);
   lv_obj_align(stepIcon, stepValue, LV_ALIGN_OUT_LEFT_MID, -5, 0);
 }
 
@@ -101,14 +101,14 @@ bool WatchFaceDigital::Refresh() {
   batteryPercentRemaining = batteryController.PercentRemaining();
   if (batteryPercentRemaining.IsUpdated()) {
     auto batteryPercent = batteryPercentRemaining.Get();
-    lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
+    lv_label_set_text_static(batteryIcon, BatteryIcon::GetBatteryIcon(batteryPercent));
     auto isCharging = batteryController.IsCharging() or batteryController.IsPowerPresent();
-    lv_label_set_text(batteryPlug, BatteryIcon::GetPlugIcon(isCharging));
+    lv_label_set_text_static(batteryPlug, BatteryIcon::GetPlugIcon(isCharging));
   }
 
   bleState = bleController.IsConnected();
   if (bleState.IsUpdated()) {
-    lv_label_set_text(bleIcon, BleIcon::GetIcon(bleState.Get()));
+    lv_label_set_text_static(bleIcon, BleIcon::GetIcon(bleState.Get()));
   }
   lv_obj_align(batteryIcon, lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, 0, 0);
   lv_obj_align(batteryPlug, batteryIcon, LV_ALIGN_OUT_LEFT_MID, -5, 0);
@@ -116,7 +116,7 @@ bool WatchFaceDigital::Refresh() {
 
   notificationState = notificatioManager.AreNewNotificationsAvailable();
   if (notificationState.IsUpdated()) {
-    lv_label_set_text(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
+    lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
   }
 
   currentDateTime = dateTimeController.CurrentDateTime();

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -40,7 +40,7 @@ QuickSettings::QuickSettings(Pinetime::Applications::DisplayApp* app,
   lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 0, 0);
 
   batteryIcon = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
+  lv_label_set_text_static(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
   lv_obj_align(batteryIcon, nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
 
   static constexpr uint8_t barHeight = 20 + innerDistance;
@@ -124,7 +124,7 @@ QuickSettings::~QuickSettings() {
 
 void QuickSettings::UpdateScreen() {
   lv_label_set_text_fmt(label_time, "%02i:%02i", dateTimeController.Hours(), dateTimeController.Minutes());
-  lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
+  lv_label_set_text_static(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
 }
 
 void QuickSettings::OnButtonEvent(lv_obj_t* object, lv_event_t event) {


### PR DESCRIPTION
If the text being set is static use lv_label_set_text_static to avoid
unnecessary memory allocations. Otherwise if a temporary char buffer is
being sprintf-ed and then set to the label used lv_label_set_text_fmt to
avoid the intermediary data copies.