### PR TITLE
New appmenu layout

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -418,6 +418,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/BatteryInfo.cpp
         displayapp/screens/Steps.cpp
         displayapp/screens/Timer.cpp
+        displayapp/screens/HoneyComb.cpp
 
         ## Settings
         displayapp/screens/settings/QuickSettings.cpp
@@ -660,6 +661,7 @@ set(INCLUDE_FILES
         components/heartrate/Ptagc.h
         components/heartrate/HeartRateController.h
         components/motor/MotorController.h
+        displayapp/screens/HoneyComb.h
         )
 
 include_directories(

--- a/src/displayapp/screens/ApplicationList.cpp
+++ b/src/displayapp/screens/ApplicationList.cpp
@@ -2,7 +2,7 @@
 #include <lvgl/lvgl.h>
 #include <array>
 #include "Symbols.h"
-#include "Tile.h"
+#include "HoneyComb.h"
 #include "displayapp/Apps.h"
 #include "../DisplayApp.h"
 
@@ -35,9 +35,7 @@ ApplicationList::~ApplicationList() {
 }
 
 bool ApplicationList::Refresh() {
-  if (running)
-    running = screens.Refresh();
-  return running;
+  return screens.Refresh();
 }
 
 bool ApplicationList::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
@@ -45,29 +43,33 @@ bool ApplicationList::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
 }
 
 std::unique_ptr<Screen> ApplicationList::CreateScreen1() {
-  std::array<Screens::Tile::Applications, 6> applications {{
+  std::array<Screens::HoneyComb::Applications, 8> applications {{
     {Symbols::stopWatch, Apps::StopWatch},
     {Symbols::music, Apps::Music},
     {Symbols::map, Apps::Navigation},
     {Symbols::shoe, Apps::Steps},
     {Symbols::heartBeat, Apps::HeartRate},
     {Symbols::hourGlass, Apps::Timer},
+    {Symbols::paintbrush, Apps::Paint},
+    {Symbols::paddle, Apps::Paddle},
   }};
 
-  return std::make_unique<Screens::Tile>(0, 2, app, settingsController, batteryController, dateTimeController, applications);
+  return std::make_unique<Screens::HoneyComb>(0, 2, app, settingsController, batteryController, dateTimeController, applications);
 }
 
 std::unique_ptr<Screen> ApplicationList::CreateScreen2() {
-  std::array<Screens::Tile::Applications, 6> applications {{
-    {Symbols::paintbrush, Apps::Paint},
-    {Symbols::paddle, Apps::Paddle},
+  std::array<Screens::HoneyComb::Applications, 8> applications {{
     {"2", Apps::Twos},
     {"M", Apps::Motion},
     {Symbols::drum, Apps::Metronome},
     {"", Apps::None},
+    {"", Apps::None},
+    {"", Apps::None},
+    {"", Apps::None},
+    {"", Apps::None},
   }};
 
-  return std::make_unique<Screens::Tile>(1, 2, app, settingsController, batteryController, dateTimeController, applications);
+  return std::make_unique<Screens::HoneyComb>(1, 2, app, settingsController, batteryController, dateTimeController, applications);
 }
 
 /*std::unique_ptr<Screen> ApplicationList::CreateScreen3() {

--- a/src/displayapp/screens/HoneyComb.cpp
+++ b/src/displayapp/screens/HoneyComb.cpp
@@ -1,0 +1,128 @@
+#include "HoneyComb.h"
+#include "../DisplayApp.h"
+#include "BatteryIcon.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  static void UpdateTaskCallback(struct _lv_task_t* task) {
+    auto* user_data = static_cast<HoneyComb*>(task->user_data);
+    user_data->UpdateScreen();
+  }
+
+  void EventHandler(lv_obj_t* obj, lv_event_t event) {
+    auto* screen = static_cast<HoneyComb*>(obj->user_data);
+    screen->OnObjectEvent(obj, event);
+  }
+}
+
+HoneyComb::HoneyComb(uint8_t screenID,
+                     uint8_t numScreens,
+                     DisplayApp* app,
+                     Controllers::Settings& settingsController,
+                     Pinetime::Controllers::Battery& batteryController,
+                     Controllers::DateTime& dateTimeController,
+                     std::array<Applications, 8>& applications)
+  : Screen(app), batteryController {batteryController}, dateTimeController {dateTimeController} {
+
+  settingsController.SetAppMenu(screenID);
+
+  labelTime = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_fmt(labelTime, "%02i:%02i", dateTimeController.Hours(), dateTimeController.Minutes());
+  lv_obj_align(labelTime, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 0);
+
+  batteryIcon = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
+  lv_obj_align(batteryIcon, nullptr, LV_ALIGN_IN_TOP_RIGHT, -8, 0);
+
+  if (numScreens > 1) {
+    pageIndicatorBasePoints[0].x = LV_HOR_RES - 1;
+    pageIndicatorBasePoints[0].y = 0;
+    pageIndicatorBasePoints[1].x = LV_HOR_RES - 1;
+    pageIndicatorBasePoints[1].y = LV_VER_RES;
+
+    pageIndicatorBase = lv_line_create(lv_scr_act(), nullptr);
+    lv_obj_set_style_local_line_width(pageIndicatorBase, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, 3);
+    lv_obj_set_style_local_line_color(pageIndicatorBase, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x111111));
+    lv_obj_set_style_local_line_rounded(pageIndicatorBase, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, true);
+    lv_line_set_points(pageIndicatorBase, pageIndicatorBasePoints, 2);
+
+    const uint16_t indicatorSize = LV_VER_RES / numScreens;
+    const uint16_t indicatorPos = indicatorSize * screenID;
+
+    pageIndicatorPoints[0].x = LV_HOR_RES - 1;
+    pageIndicatorPoints[0].y = indicatorPos;
+    pageIndicatorPoints[1].x = LV_HOR_RES - 1;
+    pageIndicatorPoints[1].y = indicatorPos + indicatorSize;
+
+    pageIndicator = lv_line_create(lv_scr_act(), nullptr);
+    lv_obj_set_style_local_line_width(pageIndicator, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, 3);
+    lv_obj_set_style_local_line_color(pageIndicator, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
+    lv_obj_set_style_local_line_rounded(pageIndicator, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, true);
+    lv_line_set_points(pageIndicator, pageIndicatorPoints, 2);
+  }
+
+  for (uint8_t i = 0; i < 8; i++) {
+    buttons[i] = lv_btn_create(lv_scr_act(), nullptr);
+
+    lv_obj_set_style_local_radius(buttons[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
+    lv_obj_set_style_local_bg_opa(buttons[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_20);
+    lv_obj_set_style_local_bg_color(buttons[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_AQUA);
+    lv_obj_set_style_local_bg_opa(buttons[i], LV_BTN_PART_MAIN, LV_STATE_DISABLED, LV_OPA_20);
+    lv_obj_set_style_local_bg_color(buttons[i], LV_BTN_PART_MAIN, LV_STATE_DISABLED, lv_color_hex(0x111111));
+    lv_obj_set_size(buttons[i], 70, 70);
+
+    apps[i] = applications[i].application;
+
+    if (applications[i].application == Apps::None) {
+      lv_obj_set_state(buttons[i], LV_STATE_DISABLED);
+    } else {
+      lv_obj_set_style_local_value_str(buttons[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, applications[i].icon);
+      lv_obj_set_event_cb(buttons[i], EventHandler);
+      buttons[i]->user_data = this;
+    }
+  }
+
+  lv_obj_set_pos(buttons[0],   8,  27);
+  lv_obj_set_pos(buttons[1],  85,  27);
+  lv_obj_set_pos(buttons[2], 162,  27);
+  lv_obj_set_pos(buttons[3],  46,  92);
+  lv_obj_set_pos(buttons[4], 124,  92);
+  lv_obj_set_pos(buttons[5],   8, 157);
+  lv_obj_set_pos(buttons[6],  85, 157);
+  lv_obj_set_pos(buttons[7], 162, 157);
+
+  lv_obj_t* backgroundLabel = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_long_mode(backgroundLabel, LV_LABEL_LONG_CROP);
+  lv_obj_set_size(backgroundLabel, 240, 240);
+  lv_obj_set_pos(backgroundLabel, 0, 0);
+  lv_label_set_text_static(backgroundLabel, "");
+
+  taskUpdate = lv_task_create(UpdateTaskCallback, 5000, LV_TASK_PRIO_MID, this);
+}
+
+HoneyComb::~HoneyComb() {
+  lv_task_del(taskUpdate);
+  lv_obj_clean(lv_scr_act());
+}
+
+void HoneyComb::UpdateScreen() {
+  lv_label_set_text_fmt(labelTime, "%02i:%02i", dateTimeController.Hours(), dateTimeController.Minutes());
+  lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
+}
+
+bool HoneyComb::Refresh() {
+  return running;
+}
+
+void HoneyComb::OnObjectEvent(lv_obj_t* obj, lv_event_t event) {
+  if (event != LV_EVENT_CLICKED) {
+    return;
+  }
+
+  for (uint8_t i = 0; i < 8; i++) {
+    if (buttons[i] == obj) {
+      app->StartApp(apps[i], DisplayApp::FullRefreshDirections::Up);
+    }
+  }
+}

--- a/src/displayapp/screens/HoneyComb.h
+++ b/src/displayapp/screens/HoneyComb.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <lvgl/lvgl.h>
+#include <cstdint>
+#include <memory>
+#include "Screen.h"
+#include "../Apps.h"
+#include "components/datetime/DateTimeController.h"
+#include "components/settings/Settings.h"
+#include "components/datetime/DateTimeController.h"
+#include "components/battery/BatteryController.h"
+
+namespace Pinetime {
+  namespace Applications {
+    namespace Screens {
+      class HoneyComb : public Screen {
+      public:
+        struct Applications {
+          const char* icon;
+          Pinetime::Applications::Apps application;
+        };
+
+        explicit HoneyComb(uint8_t screenID,
+                      uint8_t numScreens,
+                      DisplayApp* app,
+                      Controllers::Settings& settingsController,
+                      Pinetime::Controllers::Battery& batteryController,
+                      Controllers::DateTime& dateTimeController,
+                      std::array<Applications, 8>& applications);
+
+        ~HoneyComb() override;
+
+        bool Refresh() override;
+        void UpdateScreen();
+        void OnObjectEvent(lv_obj_t* obj, lv_event_t event);
+
+      private:
+        Pinetime::Controllers::Battery& batteryController;
+        Controllers::DateTime& dateTimeController;
+
+        lv_task_t* taskUpdate;
+
+        lv_obj_t* labelTime;
+        lv_obj_t* batteryIcon;
+        lv_point_t pageIndicatorBasePoints[2];
+        lv_point_t pageIndicatorPoints[2];
+        lv_obj_t* pageIndicatorBase;
+        lv_obj_t* pageIndicator;
+        lv_obj_t* buttons[8];
+
+        Pinetime::Applications::Apps apps[8];
+      };
+    }
+  }
+}


### PR DESCRIPTION
A more pleasant layout with circular buttons, but the buttons end up being quite small. Is this a worthwhile tradeoff?

A single screen doesn't need to have so many apps, but fewer apps can't be laid out as nicely, unless we have just four apps per page. Seven apps can also produce a nice pattern, but the buttons couldn't be made any larger, so we might as well have eight.

![appmenu](https://user-images.githubusercontent.com/37774658/126898169-fc80c7b1-2bd8-4dea-815c-0ed019ad95d4.jpg)
