### PR TITLE
Heart rate sensor - HRS gain changed to x8

### DIFF
--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -36,8 +36,8 @@ void Hrs3300::Init() {
   // HRS and ALS both in 16-bit mode
   WriteRegister(static_cast<uint8_t>(Registers::Res), 0x88);
 
-  // 64x gain
-  WriteRegister(static_cast<uint8_t>(Registers::Hgain), 0x10);
+  // 8x gain, non default, reduced value for better readings
+  WriteRegister(static_cast<uint8_t>(Registers::Hgain), 0xc);
 }
 
 void Hrs3300::Enable() {


### PR DESCRIPTION
TL/DR Heart rate sensor doesn't work for me, its random. Changed HRS gain from x64 to 4x and now it works much better. However I don't know if this is good/proper value, so I created a setting to let everyone customize it.

So as for few other people ( https://forum.pine64.org/showthread.php?tid=13727 and https://github.com/JF002/InfiniTime/issues/397 ) heart rate sensor was not working for me. Actually it wasn't working at all, I could leave the clock on the desk and the desk would have pulse ranging from 40 to 220. To me it was completely random no matter if I had it on hand or not. Though it seems like some folks have it working about fine, so it probably depends on something.

Checking documentation from here: http://www.tianyihexin.com/pic/file/20170627/20170627154877337733.pdf I've noticed that there is a gain setting for HRS. Current setting was 0x10, which means its x64, kinda extreme to me - seems far away from the last "sane" value - 8x. Though, worth noting, x64 seems to be recommended value. 

I changed gain to 4x and for me it fixed HRS, now I have measurements that I would expect. Its a one line change in `Hrs3300.cpp`

However to better tinker with gain and test more values I created an option to customize it. All values seem to me to be working almost the same, as I have no real reference. I can only say that my cheap tomtom wristband show almost the same results now, +/- 5.

So my proposal is to use/test this new setting, and maybe it will be possible to find better compromise (because as I read, few people are happy with x64). After testing and picking the "good" value, the setting will probably be obsolete. Well maybe even can be removed from this PR... If my change will really help.

PS. I also have some debug showings implemented, but decided to not commit them here...