### PR TITLE
Tilt to reload idle timer

### DIFF
--- a/src/components/motion/MotionController.cpp
+++ b/src/components/motion/MotionController.cpp
@@ -9,17 +9,8 @@ void MotionController::Update(int16_t x, int16_t y, int16_t z, uint32_t nbSteps)
   this->nbSteps = nbSteps;
 }
 
-bool MotionController::ShouldWakeUp(bool isSleeping) {
-  if ((x + 335) <= 670 && z < 0) {
-    if (not isSleeping) {
-      if (y <= 0) {
-        return false;
-      } else {
-        lastYForWakeUp = 0;
-        return false;
-      }
-    }
-
+bool MotionController::ShouldWakeUp() {
+  if (x <= 335 && z < 0) {
     if (y >= 0) {
       lastYForWakeUp = 0;
       return false;

--- a/src/components/motion/MotionController.h
+++ b/src/components/motion/MotionController.h
@@ -27,7 +27,7 @@ namespace Pinetime {
       uint32_t NbSteps() const {
         return nbSteps;
       }
-      bool ShouldWakeUp(bool isSleeping);
+      bool ShouldWakeUp();
 
       void IsSensorOk(bool isOk);
       bool IsSensorOk() const {

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -381,8 +381,12 @@ void SystemTask::UpdateMotion() {
 
   motionController.IsSensorOk(motionSensor.IsOk());
   motionController.Update(motionValues.x, motionValues.y, motionValues.z, motionValues.steps);
-  if (motionController.ShouldWakeUp(isSleeping)) {
-    GoToRunning();
+  if (motionController.ShouldWakeUp()) {
+    if (isSleeping) {
+      GoToRunning();
+    } else {
+      ReloadIdleTimer();
+    }
   }
 }
 


### PR DESCRIPTION
Reload the idle timer with the same wrist gesture as wake up. This way it can be refreshed single handed if the screen dimmed.
Simplified and adjusted `ShouldWakeUp()` to work the same way regardless of whether the watch was sleeping or not.