### PR TITLE
Simplify systemtask states

### DIFF
--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -52,6 +52,7 @@ namespace Pinetime {
   namespace System {
     class SystemTask {
     public:
+      enum SystemTaskState { Sleeping, Running, GoingToSleep, WakingUp };
       SystemTask(Drivers::SpiMaster& spi,
                  Drivers::St7789& lcd,
                  Pinetime::Drivers::SpiNorFlash& spiNorFlash,
@@ -90,7 +91,7 @@ namespace Pinetime {
       };
 
       bool IsSleeping() const {
-        return isSleeping;
+        return state == Sleeping || state == WakingUp;
       }
 
     private:
@@ -109,10 +110,6 @@ namespace Pinetime {
       Pinetime::Controllers::TimerController& timerController;
       Pinetime::Controllers::AlarmController& alarmController;
       QueueHandle_t systemTasksMsgQueue;
-      std::atomic<bool> isSleeping {false};
-      std::atomic<bool> isGoingToSleep {false};
-      std::atomic<bool> isWakingUp {false};
-      std::atomic<bool> isDimmed {false};
       Pinetime::Drivers::Watchdog& watchdog;
       Pinetime::Controllers::NotificationManager& notificationManager;
       Pinetime::Controllers::MotorController& motorController;
@@ -138,6 +135,8 @@ namespace Pinetime {
       TimerHandle_t idleTimer;
       TimerHandle_t measureBatteryTimer;
       bool doNotGoToSleep = false;
+      bool isDimmed = false;
+      SystemTaskState state = Running;
 
       void HandleButtonAction(Controllers::ButtonActions action);
       bool fastWakeUpDone = false;


### PR DESCRIPTION
Instead of having three separate booleans, have just a single state variable.
Now we don't need to worry about checking if it's going to sleep or waking up. If the state is sleeping, it is sleeping and if the state is running, it is running.
This simplified many checks and made the code easier to read.