### PR TITLE
Disable sleep while in Paddle app

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -401,7 +401,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       currentScreen = std::make_unique<Screens::InfiniPaint>(this, lvgl);
       break;
     case Apps::Paddle:
-      currentScreen = std::make_unique<Screens::Paddle>(this, lvgl);
+      currentScreen = std::make_unique<Screens::Paddle>(this, *systemTask, lvgl);
       break;
     case Apps::Music:
       currentScreen = std::make_unique<Screens::Music>(this, systemTask->nimble().music());

--- a/src/displayapp/screens/Paddle.cpp
+++ b/src/displayapp/screens/Paddle.cpp
@@ -4,7 +4,15 @@
 
 using namespace Pinetime::Applications::Screens;
 
-Paddle::Paddle(Pinetime::Applications::DisplayApp* app, Pinetime::Components::LittleVgl& lvgl) : Screen(app), lvgl {lvgl} {
+Paddle::Paddle(Pinetime::Applications::DisplayApp* app,
+               System::SystemTask& systemTask,
+               Pinetime::Components::LittleVgl& lvgl)
+
+  : Screen(app),
+    systemTask {systemTask},
+    lvgl {lvgl}
+
+{
   app->SetTouchMode(DisplayApp::TouchModes::Polling);
 
   background = lv_obj_create(lv_scr_act(), nullptr);
@@ -29,12 +37,15 @@ Paddle::Paddle(Pinetime::Applications::DisplayApp* app, Pinetime::Components::Li
   lv_obj_set_style_local_bg_color(ball, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_radius(ball, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
   lv_obj_set_size(ball, ballSize, ballSize);
+
+  systemTask.PushMessage(Pinetime::System::Messages::DisableSleeping);
 }
 
 Paddle::~Paddle() {
   // Reset the touchmode
   app->SetTouchMode(DisplayApp::TouchModes::Gestures);
   lv_obj_clean(lv_scr_act());
+  systemTask.PushMessage(Pinetime::System::Messages::EnableSleeping);
 }
 
 bool Paddle::Refresh() {

--- a/src/displayapp/screens/Paddle.h
+++ b/src/displayapp/screens/Paddle.h
@@ -3,6 +3,7 @@
 #include <lvgl/lvgl.h>
 #include <cstdint>
 #include "Screen.h"
+#include "systemtask/SystemTask.h"
 
 namespace Pinetime {
   namespace Components {
@@ -13,7 +14,7 @@ namespace Pinetime {
 
       class Paddle : public Screen {
       public:
-        Paddle(DisplayApp* app, Pinetime::Components::LittleVgl& lvgl);
+        Paddle(DisplayApp* app, System::SystemTask& systemTask, Pinetime::Components::LittleVgl& lvgl);
         ~Paddle() override;
 
         bool Refresh() override;
@@ -22,6 +23,7 @@ namespace Pinetime {
         bool OnTouchEvent(uint16_t x, uint16_t y) override;
 
       private:
+        Pinetime::System::SystemTask& systemTask;
         Pinetime::Components::LittleVgl& lvgl;
 
         const uint8_t ballSize = 16;


### PR DESCRIPTION
Paddle.cpp: Added systemTask to disable sleeping in the constructor and
re-enable sleeping in the destructor.  Reformatted constructor function
header to match that of FlashLight.cpp due to added length.

Paddle.h: Added include for SystemTask.h.  Added SystemTask parameter to
constructor function prototype and added a private SystemTask variable.

DisplayApp.cpp: Added systemTask pointer to make_unique() function call.