### PR TITLE
Approximate discharge curve using linear line segments

### DIFF
--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -142,7 +142,7 @@ uint8_t Battery::GetBatteryPercentageFromVoltage(float voltage) {
   
   for (int i = 0; i < LINE_SEGMENT_COUNT; i++)
     if (voltage > voltageOffsets[i + 1])
-      return static_cast<uint8_t>(round(percentageOffsets[i] + percentageSlopes[i] * (voltage - voltageOffsets[i])));
+      return static_cast<uint8_t>(roundf(percentageOffsets[i] + percentageSlopes[i] * (voltage - voltageOffsets[i])));
   
   return 0;
 }

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -96,7 +96,7 @@ void Battery::Register(Pinetime::System::SystemTask* systemTask) {
 }
 
 // The number of line segments used to approximate the battery discharge curve.
-static const int LINE_SEGMENT_COUNT = 7;
+static const uint8_t LINE_SEGMENT_COUNT = 7;
 
 // The voltages (mV) at the endpoints of the line segments. Any two consecutive
 // values represent the start and end voltage of a line segment.

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -101,13 +101,13 @@ static const uint8_t LINE_SEGMENT_COUNT = 7;
 // The voltages (mV) at the endpoints of the line segments. Any two consecutive
 // values represent the start and end voltage of a line segment.
 static const uint16_t voltageOffsets[LINE_SEGMENT_COUNT + 1] {
-  4180,
-  4084,
-  3912,
-  3763,
-  3721,
-  3672,
-  3613,
+  4157,
+  4063,
+  3882,
+  3747,
+  3716,
+  3678,
+  3583,
   3500
 };
 
@@ -116,25 +116,25 @@ static const uint16_t voltageOffsets[LINE_SEGMENT_COUNT + 1] {
 // the start of each line segment.
 static const float percentageOffsets[LINE_SEGMENT_COUNT] {
   100.000,
-  96.362,
-  76.664,
-  51.908,
-  40.905,
-  19.343,
-  9.139
+  95.197,
+  70.429,
+  48.947,
+  35.158,
+  18.971,
+  5.801
   //0.000
 };
 
 // The pre-calculated slopes (in battery percentage points per millivolt) of the
 // line segments.
 static const float percentageSlopes[LINE_SEGMENT_COUNT] {
-  0.031940,
-  0.119893,
-  0.166148,
-  0.261976,
-  0.440041,
-  0.191537,
-  0.076271
+  0.05109,
+  0.13684,
+  0.15913,
+  0.44481,
+  0.42595,
+  0.13863,
+  0.06989
 };
 
 uint8_t Battery::GetBatteryPercentageFromVoltage(uint16_t voltage) {

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -142,7 +142,7 @@ int Battery::GetBatteryPercentageFromVoltage(float voltage) {
   
   for (int i = 0; i < LINE_SEGMENT_COUNT; i++)
     if (voltage > voltageOffsets[i + 1])
-      return static_cast<uint_8>(round(percentageOffsets[i] + percentageSlopes[i] * (voltage - voltageOffsets[i])));
+      return static_cast<uint8_t>(round(percentageOffsets[i] + percentageSlopes[i] * (voltage - voltageOffsets[i])));
   
   return 0;
 }

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -142,7 +142,7 @@ int Battery::GetBatteryPercentageFromVoltage(float voltage) {
   
   for (int i = 0; i < LINE_SEGMENT_COUNT; i++)
     if (voltage > voltageOffsets[i + 1])
-      return percentageOffsets[i] + percentageSlopes[i] * (voltage - voltageOffsets[i]);
+      return static_cast<uint_8>(round(percentageOffsets[i] + percentageSlopes[i] * (voltage - voltageOffsets[i])));
   
   return 0;
 }

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -98,22 +98,22 @@ void Battery::Register(Pinetime::System::SystemTask* systemTask) {
 // The number of line segments used to approximate the battery discharge curve.
 static const int LINE_SEGMENT_COUNT = 7;
 
-// The voltages at the endpoints of the line segments. Any two consecutive values
-// represent the start and end voltage of a line segment.
-static const float voltageOffsets[LINE_SEGMENT_COUNT + 1] {
-  4.180,
-  4.084,
-  3.912,
-  3.763,
-  3.721,
-  3.672,
-  3.613,
-  3.500
+// The voltages (mV) at the endpoints of the line segments. Any two consecutive
+// values represent the start and end voltage of a line segment.
+static const uint16_t voltageOffsets[LINE_SEGMENT_COUNT + 1] {
+  4180,
+  4084,
+  3912,
+  3763,
+  3721,
+  3672,
+  3613,
+  3500
 };
 
 // The battery percentages at the endpoints of the line segments. Note that last
-// value is omitted: It is not needed because we only need the percentages at the
-// start of each line segment.
+// value is omitted: It is not needed because we only need the percentages at
+// the start of each line segment.
 static const float percentageOffsets[LINE_SEGMENT_COUNT] {
   100.000,
   96.362,
@@ -125,22 +125,23 @@ static const float percentageOffsets[LINE_SEGMENT_COUNT] {
   //0.000
 };
 
-// The pre-calculated slopes (in battery percentage per volt) of the line segments.
+// The pre-calculated slopes (in battery percentage points per millivolt) of the
+// line segments.
 static const float percentageSlopes[LINE_SEGMENT_COUNT] {
-  31.940,
-  119.893,
-  166.148,
-  261.976,
-  440.041,
-  191.537,
-  76.271
+  0.031940,
+  0.119893,
+  0.166148,
+  0.261976,
+  0.440041,
+  0.191537,
+  0.076271
 };
 
-uint8_t Battery::GetBatteryPercentageFromVoltage(float voltage) {
+uint8_t Battery::GetBatteryPercentageFromVoltage(uint16_t voltage) {
   if (voltage > voltageOffsets[0])
     return 100;
   
-  for (int i = 0; i < LINE_SEGMENT_COUNT; i++)
+  for (uint8_t i = 0; i < LINE_SEGMENT_COUNT; i++)
     if (voltage > voltageOffsets[i + 1])
       return static_cast<uint8_t>(roundf(percentageOffsets[i] + percentageSlopes[i] * (voltage - voltageOffsets[i])));
   

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -136,7 +136,7 @@ static const float percentageSlopes[LINE_SEGMENT_COUNT] {
   76.271
 };
 
-int Battery::GetBatteryPercentageFromVoltage(float voltage) {
+uint8_t Battery::GetBatteryPercentageFromVoltage(float voltage) {
   if (voltage > voltageOffsets[0])
     return 100;
   

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -49,7 +49,7 @@ namespace Pinetime {
 
       void SaadcEventHandler(nrfx_saadc_evt_t const* p_event);
       static void AdcCallbackStatic(nrfx_saadc_evt_t const* event);
-      static int GetBatteryPercentageFromVoltage(float voltage);
+      static uint8_t GetBatteryPercentageFromVoltage(float voltage);
 
       bool isReading = false;
 

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -49,7 +49,7 @@ namespace Pinetime {
 
       void SaadcEventHandler(nrfx_saadc_evt_t const* p_event);
       static void AdcCallbackStatic(nrfx_saadc_evt_t const* event);
-      static uint8_t GetBatteryPercentageFromVoltage(float voltage);
+      static uint8_t GetBatteryPercentageFromVoltage(uint16_t voltage);
 
       bool isReading = false;
 

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -49,6 +49,7 @@ namespace Pinetime {
 
       void SaadcEventHandler(nrfx_saadc_evt_t const* p_event);
       static void AdcCallbackStatic(nrfx_saadc_evt_t const* event);
+      static int GetBatteryPercentageFromVoltage(float voltage);
 
       bool isReading = false;
 


### PR DESCRIPTION
This PR builds on the work of [PR 443](https://github.com/JF002/InfiniTime/pull/443) by approximating the discharge curve using multiple linear line segments.

Things to note:

* [As suggested](https://github.com/JF002/InfiniTime/pull/443#issuecomment-890351442) by @Riksu9000, 3.5v (instead of 2.98v) is now defined as 0% battery charge. This is to encourage users to charge their device before the battery fully drains, to prevent excessive strain on the battery.

* [Also noted](https://github.com/JF002/InfiniTime/pull/443#issuecomment-865077387) by @Riksu9000, the implementation of [PR 443](https://github.com/JF002/InfiniTime/pull/443) can use at most two decimal digits of precision of the supplied voltage value (that is, decivolt precision), causing jumps in the resulting battery percentage of almost 5 percentage points around the 50%-35% battery charge range. Increasing the precision of the voltage (to e.g. millivolts), combined with approximating the discharge curve using multiple linear line segments, should reduce those jumps.

* This implementation uses 7 linear line segments to approximate the observed discharge curve. Figure
"Approximation using linear line segments" below illustrates this by plotting the 7 line segments (in red) against the observed discharge values (in blue). In this figure, the error of the approximated curve with respect to the observed curve is, on average, about 0.6 percentage points of battery charge. The maximum error is about 1.6 percentage points.

![line-segments](https://user-images.githubusercontent.com/85612141/129477863-3e78d747-2ad0-4ca8-98e8-fecccc6d0f41.png)
_Approximation using linear line segments_

* The figure "Battery percentages rounded to integers" displays the resulting battery percentages when rounded to integers. This is how the percentages would be presented to the user. As you can see, there are no big drops in battery percentage. Do note however, that the voltage value supplied as input to this implementation needs to have sufficient precision, otherwise jumps in the battery percentage along the curve will still occur.

![rounded-percentages](https://user-images.githubusercontent.com/85612141/129477958-c1584ea1-e3ca-4ccd-b418-67bea28be52f.png)
_Battery percentages rounded to integers_

* The implementation uses a table of pre-calculated line segment slopes (percentageSlopes), to save a floating point division during calculation of the battery percentage. This table could be removed in favor of calculating the slopes on the fly, if we would feel that the additional memory costs do not outweigh the saved floating point division. The percentageOffsets table would need to hold an extra value, though, to be able to calculate the slope of the last line segment.
