### PR TITLE
Improved StopWatch laps

### DIFF
--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -5,22 +5,20 @@ using namespace Pinetime::Applications::Screens;
 
 namespace {
   TimeSeparated_t convertTicksToTimeSegments(const TickType_t timeElapsed) {
-    TickType_t timeElapsedCentis = timeElapsed * 100 / configTICK_RATE_HZ;
-
-    const uint8_t hundredths = (timeElapsedCentis % 100);
-    const uint8_t secs = (timeElapsedCentis / 100) % 60;
-    const uint32_t mins = (timeElapsedCentis / 100) / 60;
+    const uint8_t hundredths = timeElapsed * 100 / configTICK_RATE_HZ % 100;
+    const uint8_t secs = (timeElapsed / configTICK_RATE_HZ) % 60;
+    const uint32_t mins = (timeElapsed / configTICK_RATE_HZ) / 60;
     return TimeSeparated_t {mins, secs, hundredths};
   }
 
   void play_pause_event_handler(lv_obj_t* obj, lv_event_t event) {
     auto* stopWatch = static_cast<StopWatch*>(obj->user_data);
-    stopWatch->playPauseBtnEventHandler(event);
+    stopWatch->PlayPauseBtnEventHandler(event);
   }
 
   void stop_lap_event_handler(lv_obj_t* obj, lv_event_t event) {
     auto* stopWatch = static_cast<StopWatch*>(obj->user_data);
-    stopWatch->stopLapBtnEventHandler(event);
+    stopWatch->StopLapBtnEventHandler(event);
   }
 }
 
@@ -119,8 +117,8 @@ void StopWatch::Pause() {
 void StopWatch::DisplayLaps(uint8_t startLap) {
   char buffer[22];
   std::string allLapsText = "";
-  TimeSeparated_t lapTime;
-  TimeSeparated_t runTime;
+  TimeSeparated_t lapTime = {0};
+  TimeSeparated_t runTime = {0};
   for (uint8_t i = startLap; i < savedLapsCount && i < startLap + 5 && i < maxLapCount; i++) {
     runTime = convertTicksToTimeSegments(lapTimes[i]);
     if (i > 0) {
@@ -131,10 +129,10 @@ void StopWatch::DisplayLaps(uint8_t startLap) {
     sprintf(buffer,
             "#%-2d %2d:%02d.%1d %2d:%02d.%1d\n",
             i + 1,
-            std::min(lapTime.mins, 99),
+            static_cast<uint8_t>(std::min(lapTime.mins, static_cast<uint32_t>(99))),
             lapTime.secs,
             lapTime.hundredths / 10,
-            std::min(runTime.mins, 99),
+            static_cast<uint8_t>(std::min(runTime.mins, static_cast<uint32_t>(99))),
             runTime.secs,
             runTime.hundredths / 10);
 
@@ -157,7 +155,7 @@ void StopWatch::Refresh() {
   }
 }
 
-void StopWatch::playPauseBtnEventHandler(lv_event_t event) {
+void StopWatch::PlayPauseBtnEventHandler(lv_event_t event) {
   if (event != LV_EVENT_CLICKED) {
     return;
   }
@@ -170,7 +168,7 @@ void StopWatch::playPauseBtnEventHandler(lv_event_t event) {
   }
 }
 
-void StopWatch::stopLapBtnEventHandler(lv_event_t event) {
+void StopWatch::StopLapBtnEventHandler(lv_event_t event) {
   if (event != LV_EVENT_CLICKED) {
     return;
   }

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -1,91 +1,53 @@
 #pragma once
 
 #include "displayapp/screens/Screen.h"
-#include "components/datetime/DateTimeController.h"
-#include "displayapp/LittleVgl.h"
-
-#include <FreeRTOS.h>
-#include "portmacro_cmsis.h"
-
-#include <array>
+#include "lvgl/lvgl.h"
 #include "systemtask/SystemTask.h"
 
-namespace Pinetime::Applications::Screens {
+namespace Pinetime {
+  namespace Applications {
+    namespace Screens {
 
-  enum class States { Init, Running, Halted };
+      enum class States { Init, Running, Halted };
 
-  struct TimeSeparated_t {
-    int mins;
-    int secs;
-    int hundredths;
-  };
+      struct TimeSeparated_t {
+        int mins;
+        int secs;
+        int hundredths;
+      };
 
-  // A simple buffer to hold the latest two laps
-  template <int N> struct LapTextBuffer_t {
-    LapTextBuffer_t() : buffer {}, currentSize {}, capacity {N}, head {-1} {
+      class StopWatch : public Screen {
+      public:
+        StopWatch(DisplayApp* app, System::SystemTask& systemTask);
+        ~StopWatch() override;
+        void Refresh() override;
+
+        void playPauseBtnEventHandler(lv_event_t event);
+        void stopLapBtnEventHandler(lv_event_t event);
+        bool OnButtonPushed() override;
+        void BackgroundEventHandler(lv_event_t event);
+
+      private:
+        void DisplayLaps(uint8_t startLap);
+        void SetTime(TickType_t timeToSet);
+
+        void Reset();
+        void Start();
+        void Pause();
+
+        Pinetime::System::SystemTask& systemTask;
+        States currentState = States::Init;
+        TickType_t startTime;
+        TickType_t oldTimeElapsed = 0;
+
+        static constexpr uint8_t maxLapCount = 20;
+        TickType_t lapTimes[maxLapCount + 1] = {0};
+
+        uint8_t savedLapsCount = 0;
+
+        lv_obj_t *time, *msecTime, *btnPlayPause, *btnStopLap, *txtPlayPause, *txtStopLap;
+        lv_obj_t* lapText;
+      };
     }
-
-    void addLaps(const TimeSeparated_t& timeVal) {
-      head++;
-      head %= capacity;
-      buffer[head] = timeVal;
-
-      if (currentSize < capacity) {
-        currentSize++;
-      }
-    }
-
-    void clearBuffer() {
-      buffer = {};
-      currentSize = 0;
-      head = -1;
-    }
-
-    TimeSeparated_t* operator[](std::size_t idx) {
-      // Sanity check for out-of-bounds
-      if (idx >= 0 && idx < capacity) {
-        if (idx < currentSize) {
-          // This transformation is to ensure that head is always pointing to index 0.
-          const auto transformed_idx = (head - idx) % capacity;
-          return (&buffer[transformed_idx]);
-        }
-      }
-      return nullptr;
-    }
-
-  private:
-    std::array<TimeSeparated_t, N> buffer;
-    uint8_t currentSize;
-    uint8_t capacity;
-    int8_t head;
-  };
-
-  class StopWatch : public Screen {
-  public:
-    StopWatch(DisplayApp* app, System::SystemTask& systemTask);
-    ~StopWatch() override;
-    void Refresh() override;
-
-    void playPauseBtnEventHandler(lv_event_t event);
-    void stopLapBtnEventHandler(lv_event_t event);
-    bool OnButtonPushed() override;
-
-    void reset();
-    void start();
-    void pause();
-
-  private:
-    Pinetime::System::SystemTask& systemTask;
-    TickType_t timeElapsed;
-    States currentState;
-    TickType_t startTime;
-    TickType_t oldTimeElapsed;
-    TimeSeparated_t currentTimeSeparated; // Holds Mins, Secs, millisecs
-    LapTextBuffer_t<2> lapBuffer;
-    int lapNr = 0;
-    lv_obj_t *time, *msecTime, *btnPlayPause, *btnStopLap, *txtPlayPause, *txtStopLap;
-    lv_obj_t *lapOneText, *lapTwoText;
-
-    lv_task_t* taskRefresh;
-  };
+  }
 }

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -11,9 +11,9 @@ namespace Pinetime {
       enum class States { Init, Running, Halted };
 
       struct TimeSeparated_t {
-        int mins;
-        int secs;
-        int hundredths;
+        uint32_t mins;
+        uint8_t secs;
+        uint8_t hundredths;
       };
 
       class StopWatch : public Screen {
@@ -25,7 +25,7 @@ namespace Pinetime {
         void playPauseBtnEventHandler(lv_event_t event);
         void stopLapBtnEventHandler(lv_event_t event);
         bool OnButtonPushed() override;
-        void BackgroundEventHandler(lv_event_t event);
+        bool OnTouchEvent(Pinetime::Applications::TouchEvents event) override;
 
       private:
         void DisplayLaps(uint8_t startLap);
@@ -44,8 +44,9 @@ namespace Pinetime {
         TickType_t lapTimes[maxLapCount + 1] = {0};
 
         uint8_t savedLapsCount = 0;
+        uint8_t displayedLapsStart = 0;
 
-        lv_obj_t *time, *msecTime, *btnPlayPause, *btnStopLap, *txtPlayPause, *txtStopLap;
+        lv_obj_t *time, *msecTime, *btnPlayPause, *btnStopLap;
         lv_obj_t* lapText;
       };
     }

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -22,8 +22,8 @@ namespace Pinetime {
         ~StopWatch() override;
         void Refresh() override;
 
-        void playPauseBtnEventHandler(lv_event_t event);
-        void stopLapBtnEventHandler(lv_event_t event);
+        void PlayPauseBtnEventHandler(lv_event_t event);
+        void StopLapBtnEventHandler(lv_event_t event);
         bool OnButtonPushed() override;
         bool OnTouchEvent(Pinetime::Applications::TouchEvents event) override;
 
@@ -37,7 +37,7 @@ namespace Pinetime {
 
         Pinetime::System::SystemTask& systemTask;
         States currentState = States::Init;
-        TickType_t startTime;
+        TickType_t startTime = 0;
         TickType_t oldTimeElapsed = 0;
 
         static constexpr uint8_t maxLapCount = 20;

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -48,6 +48,7 @@ namespace Pinetime {
 
         lv_obj_t *time, *msecTime, *btnPlayPause, *btnStopLap;
         lv_obj_t* lapText;
+        lv_task_t* taskRefresh;
       };
     }
   }


### PR DESCRIPTION
Now StopWatch can store up to 20 laps and they can be viewed while paused.

While showing laps, the centisecond counter is hidden. If only four laps were on screen at once, it could fit. Which would be better? EDIT: The time label could separately be made to automatically adapt to size requirements, which would make showing hours possible as well.

Fixes #392

https://user-images.githubusercontent.com/37774658/130828623-3f1d189e-e7b3-4e0a-9f53-a40ec681290d.mp4