### PR TITLE
Removed the accept call button from the call notification screen

### DIFF
--- a/src/components/ble/AlertNotificationService.cpp
+++ b/src/components/ble/AlertNotificationService.cpp
@@ -86,19 +86,6 @@ int AlertNotificationService::OnAlert(uint16_t conn_handle, uint16_t attr_handle
   return 0;
 }
 
-void AlertNotificationService::AcceptIncomingCall() {
-  auto response = IncomingCallResponses::Answer;
-  auto* om = ble_hs_mbuf_from_flat(&response, 1);
-
-  uint16_t connectionHandle = systemTask.nimble().connHandle();
-
-  if (connectionHandle == 0 || connectionHandle == BLE_HS_CONN_HANDLE_NONE) {
-    return;
-  }
-
-  ble_gattc_notify_custom(connectionHandle, eventHandle, om);
-}
-
 void AlertNotificationService::RejectIncomingCall() {
   auto response = IncomingCallResponses::Reject;
   auto* om = ble_hs_mbuf_from_flat(&response, 1);

--- a/src/components/ble/AlertNotificationService.h
+++ b/src/components/ble/AlertNotificationService.h
@@ -26,7 +26,6 @@ namespace Pinetime {
 
       int OnAlert(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt);
 
-      void AcceptIncomingCall();
       void RejectIncomingCall();
       void MuteIncomingCall();
 

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -206,20 +206,11 @@ Notifications::NotificationItem::NotificationItem(const char* title,
       lv_obj_set_width(alert_caller, LV_HOR_RES - 20);
       lv_label_set_text(alert_caller, msg);
 
-      bt_accept = lv_btn_create(lv_scr_act(), nullptr);
-      bt_accept->user_data = this;
-      lv_obj_set_event_cb(bt_accept, CallEventHandler);
-      lv_obj_set_size(bt_accept, 76, 76);
-      lv_obj_align(bt_accept, NULL, LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
-      label_accept = lv_label_create(bt_accept, nullptr);
-      lv_label_set_text(label_accept, Symbols::phone);
-      lv_obj_set_style_local_bg_color(bt_accept, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GREEN);
-
       bt_reject = lv_btn_create(lv_scr_act(), nullptr);
       bt_reject->user_data = this;
       lv_obj_set_event_cb(bt_reject, CallEventHandler);
-      lv_obj_set_size(bt_reject, 76, 76);
-      lv_obj_align(bt_reject, NULL, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
+      lv_obj_set_size(bt_reject, 116, 76);
+      lv_obj_align(bt_reject, NULL, LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
       label_reject = lv_label_create(bt_reject, nullptr);
       lv_label_set_text(label_reject, Symbols::phoneSlash);
       lv_obj_set_style_local_bg_color(bt_reject, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_RED);
@@ -227,7 +218,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
       bt_mute = lv_btn_create(lv_scr_act(), nullptr);
       bt_mute->user_data = this;
       lv_obj_set_event_cb(bt_mute, CallEventHandler);
-      lv_obj_set_size(bt_mute, 76, 76);
+      lv_obj_set_size(bt_mute, 116, 76);
       lv_obj_align(bt_mute, NULL, LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
       label_mute = lv_label_create(bt_mute, nullptr);
       lv_label_set_text(label_mute, Symbols::volumMute);
@@ -249,9 +240,7 @@ void Notifications::NotificationItem::OnCallButtonEvent(lv_obj_t* obj, lv_event_
 
   Controllers::MotorController::StopRinging();
 
-  if (obj == bt_accept) {
-    alertNotificationService.AcceptIncomingCall();
-  } else if (obj == bt_reject) {
+  if (obj == bt_reject) {
     alertNotificationService.RejectIncomingCall();
   } else if (obj == bt_mute) {
     alertNotificationService.MuteIncomingCall();

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -51,7 +51,6 @@ namespace Pinetime {
           lv_obj_t* t1;
           lv_obj_t* l1;
           lv_obj_t* l2;
-          lv_obj_t* bt_accept;
           lv_obj_t* bt_mute;
           lv_obj_t* bt_reject;
           lv_obj_t* label_accept;


### PR DESCRIPTION
This PR removes the accept call button from the call notification screen.

IMO it is pretty useless. Every headset you can connect to a phone (wired, Bluetooth, car radio) provides a button to accept the call. When the phone has no headset connected and is in the pocket or lying on the table, you want to take it into the hand before taking the call. So you do it on the phone.

I can't think of any situation where I would accept a call on the watch. (For what it's worth: I've been using the Pebble watch since it was first released on Kickstarter in 2013; it has exactly these two buttons: reject and ignore. I never missed an accept button.)

Downsides:

- none I can think of

Updsides:

- the other buttons can be larger and are easier to press

<img src="https://user-images.githubusercontent.com/401729/130942418-fbea9622-682c-4f36-94fb-2084046dede8.png" width="300">
