### PR TITLE
Simplify touch event handling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,7 +166,7 @@ Pinetime::System::SystemTask systemTask(spi,
 
 void nrfx_gpiote_evt_handler(nrfx_gpiote_pin_t pin, nrf_gpiote_polarity_t action) {
   if (pin == pinTouchIrq) {
-    systemTask.OnTouchEvent();
+    systemTask.PushMessage(Pinetime::System::Messages::OnTouchEvent);
     return;
   }
 

--- a/src/systemtask/Messages.h
+++ b/src/systemtask/Messages.h
@@ -5,7 +5,6 @@ namespace Pinetime {
       enum class Messages {
         GoToSleep,
         GoToRunning,
-        TouchWakeUp,
         OnNewTime,
         OnNewNotification,
         OnTimerDone,

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -73,7 +73,6 @@ namespace Pinetime {
       void PushMessage(Messages msg);
 
       void OnButtonPushed();
-      void OnTouchEvent();
 
       void OnIdle();
       void OnDim();


### PR DESCRIPTION
(In this PR) main.cpp only pushes an `OnTouchEvent` message to SystemTask, spending less time in ISR. The logic was moved to `OnTouchEvent`.
`TouchWakeUp` and `OnTouchEvent()` were combined to `OnTouchEvent` message.