### PR TITLE
Let LVGL control queueTimeout

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -141,19 +141,15 @@ uint32_t count = 0;
 bool toggle = true;
 void DisplayApp::Refresh() {
   TickType_t queueTimeout;
-  TickType_t delta;
   switch (state) {
     case States::Idle:
-      IdleState();
       queueTimeout = portMAX_DELAY;
       break;
     case States::Running:
-      RunningState();
-      delta = xTaskGetTickCount() - lastWakeTime;
-      if (delta > LV_DISP_DEF_REFR_PERIOD) {
-        delta = LV_DISP_DEF_REFR_PERIOD;
+      if (!currentScreen->IsRunning()) {
+        LoadApp(returnToApp, returnDirection);
       }
-      queueTimeout = LV_DISP_DEF_REFR_PERIOD - delta;
+      queueTimeout = lv_task_handler();
       break;
     default:
       queueTimeout = portMAX_DELAY;
@@ -161,9 +157,7 @@ void DisplayApp::Refresh() {
   }
 
   Messages msg;
-  bool messageReceived = xQueueReceive(msgQueue, &msg, queueTimeout);
-  lastWakeTime = xTaskGetTickCount();
-  if (messageReceived) {
+  if (xQueueReceive(msgQueue, &msg, queueTimeout)) {
     switch (msg) {
       case Messages::DimScreen:
         // Backup brightness is the brightness to return to after dimming or sleeping
@@ -273,13 +267,6 @@ void DisplayApp::Refresh() {
   if (touchHandler.IsTouching()) {
     currentScreen->OnTouchEvent(touchHandler.GetX(), touchHandler.GetY());
   }
-}
-
-void DisplayApp::RunningState() {
-  if (!currentScreen->IsRunning()) {
-    LoadApp(returnToApp, returnDirection);
-  }
-  lv_task_handler();
 }
 
 void DisplayApp::StartApp(Apps app, DisplayApp::FullRefreshDirections direction) {
@@ -421,9 +408,6 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       break;
   }
   currentApp = app;
-}
-
-void DisplayApp::IdleState() {
 }
 
 void DisplayApp::PushMessage(Messages msg) {

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -103,8 +103,6 @@ namespace Pinetime {
       TouchEvents returnTouchEvent = TouchEvents::None;
 
       TouchEvents GetGesture();
-      void RunningState();
-      void IdleState();
       static void Process(void* instance);
       void InitHw();
       void Refresh();

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -112,7 +112,6 @@ namespace Pinetime {
 
       Apps nextApp = Apps::None;
       DisplayApp::FullRefreshDirections nextDirection;
-      TickType_t lastWakeTime;
     };
   }
 }


### PR DESCRIPTION
`lv_task_handler()` returns the time in ticks to the next task it needs to run.

This can now be used now that DisplayApp isn't locked to a certain refresh period to refresh apps consistently. #497

Using this time as the queueTimeout is more accurate, as messages can still cause slight delays. This also makes it possible to have tasks that run even more often than the refresh period.