### PR TITLE
Improve sleep time

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -182,12 +182,10 @@ void DisplayApp::Refresh() {
           brightnessController.Lower();
           vTaskDelay(100);
         }
-        lcd.DisplayOff();
         PushMessageToSystemTask(Pinetime::System::Messages::OnDisplayTaskSleeping);
         state = States::Idle;
         break;
       case Messages::GoToRunning:
-        lcd.DisplayOn();
         brightnessController.Restore();
         state = States::Running;
         break;

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -22,9 +22,6 @@ namespace Pinetime {
 
       void DrawBuffer(uint16_t x, uint16_t y, uint16_t width, uint16_t height, const uint8_t* data, size_t size);
 
-      void DisplayOn();
-      void DisplayOff();
-
       void Sleep();
       void Wakeup();
 
@@ -42,6 +39,9 @@ namespace Pinetime {
       void DisplayInversionOn();
       void NormalModeOn();
       void WriteToRam();
+      void DisplayOn();
+      void DisplayOff();
+
       void SetAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
       void WriteCommand(uint8_t cmd);
       void WriteSpi(const uint8_t* data, size_t size);


### PR DESCRIPTION
DisplayOn() and DisplayOff() are direct lcd commands, it's better to use only Sleep() and Wakeup().

The lcd is already controlled in SystemTask, so these aren't necessary in DisplayApp. SleepIn() puts the lcd into the lowest power mode so DisplayOff() doesn't do anything as far as I can tell.

EDIT: lcd can't be removed from DisplayApp, because DisplayAppRecovery needs it, and DisplayAppRecovery also has a lot of unused parameters. I'll look at this separately.

This eliminates the mysterious 500ms delay that exists in DisplayOff(). https://github.com/JF002/InfiniTime/blob/6f9f0e8b0e42a5526d47ca664534fb6b0ccb6ace/src/drivers/St7789.cpp#L119