### PR TITLE
Style checkboxes as radio buttons

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -423,6 +423,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/Timer.cpp
         displayapp/screens/Error.cpp
         displayapp/screens/Alarm.cpp
+        displayapp/screens/Styles.cpp
         displayapp/Colors.cpp
 
         ## Settings

--- a/src/displayapp/lv_pinetime_theme.c
+++ b/src/displayapp/lv_pinetime_theme.c
@@ -119,7 +119,6 @@ static void basic_init(void) {
   lv_style_set_bg_color(&style_btn, LV_STATE_DISABLED | LV_STATE_CHECKED, lv_color_hex3(0x888));
   lv_style_set_border_color(&style_btn, LV_STATE_DEFAULT, theme.color_primary);
   lv_style_set_border_width(&style_btn, LV_STATE_DEFAULT, 0);
-  lv_style_set_border_opa(&style_btn, LV_STATE_CHECKED, LV_OPA_TRANSP);
 
   lv_style_set_text_color(&style_btn, LV_STATE_DEFAULT, lv_color_hex(0xffffff));
   lv_style_set_text_color(&style_btn, LV_STATE_CHECKED, lv_color_hex(0xffffff));

--- a/src/displayapp/screens/Styles.cpp
+++ b/src/displayapp/screens/Styles.cpp
@@ -1,0 +1,8 @@
+#include "Styles.h"
+
+void Pinetime::Applications::Screens::SetRadioButtonStyle(lv_obj_t* checkbox) {
+  lv_obj_set_style_local_radius(checkbox, LV_CHECKBOX_PART_BULLET, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
+  lv_obj_set_style_local_border_width(checkbox, LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, 9);
+  lv_obj_set_style_local_border_color(checkbox, LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_GREEN);
+  lv_obj_set_style_local_bg_color(checkbox, LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_WHITE);
+}

--- a/src/displayapp/screens/Styles.h
+++ b/src/displayapp/screens/Styles.h
@@ -1,0 +1,9 @@
+#include <lvgl/lvgl.h>
+
+namespace Pinetime {
+  namespace Applications {
+    namespace Screens {
+      void SetRadioButtonStyle(lv_obj_t* checkbox);
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingDisplay.cpp
+++ b/src/displayapp/screens/settings/SettingDisplay.cpp
@@ -40,39 +40,24 @@ SettingDisplay::SettingDisplay(Pinetime::Applications::DisplayApp* app, Pinetime
   lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
-  optionsTotal = 0;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], "  5 seconds");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetScreenTimeOut() == 5000) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  char buffer[12];
+  for (unsigned int i = 0; i < options.size(); i++) {
+    cbOption[i] = lv_checkbox_create(container1, nullptr);
+    sprintf(buffer, "%3d seconds",  options[i] / 1000);
+    lv_checkbox_set_text(cbOption[i], buffer);
+    cbOption[i]->user_data = this;
+    lv_obj_set_event_cb(cbOption[i], event_handler);
+
+    // radio button style
+    lv_obj_set_style_local_radius(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
+    lv_obj_set_style_local_border_width(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, 9);
+    lv_obj_set_style_local_border_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_GREEN);
+    lv_obj_set_style_local_bg_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_WHITE);
+
+    if (settingsController.GetScreenTimeOut() == options[i]) {
+      lv_checkbox_set_checked(cbOption[i], true);
+    }
   }
-  optionsTotal++;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " 15 seconds");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetScreenTimeOut() == 15000) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  }
-  optionsTotal++;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " 20 seconds");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetScreenTimeOut() == 20000) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  }
-  optionsTotal++;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " 30 seconds");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetScreenTimeOut() == 30000) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  }
-  optionsTotal++;
 }
 
 SettingDisplay::~SettingDisplay() {
@@ -82,25 +67,11 @@ SettingDisplay::~SettingDisplay() {
 
 void SettingDisplay::UpdateSelected(lv_obj_t* object, lv_event_t event) {
   if (event == LV_EVENT_CLICKED) {
-    for (int i = 0; i < optionsTotal; i++) {
+    for (unsigned int i = 0; i < options.size(); i++) {
       if (object == cbOption[i]) {
         lv_checkbox_set_checked(cbOption[i], true);
-
-        if (i == 0) {
-          settingsController.SetScreenTimeOut(5000);
-        };
-        if (i == 1) {
-          settingsController.SetScreenTimeOut(15000);
-        };
-        if (i == 2) {
-          settingsController.SetScreenTimeOut(20000);
-        };
-        if (i == 3) {
-          settingsController.SetScreenTimeOut(30000);
-        };
-
+        settingsController.SetScreenTimeOut(options[i]);
         app->PushMessage(Applications::Display::Messages::UpdateTimeOut);
-
       } else {
         lv_checkbox_set_checked(cbOption[i], false);
       }

--- a/src/displayapp/screens/settings/SettingDisplay.cpp
+++ b/src/displayapp/screens/settings/SettingDisplay.cpp
@@ -14,6 +14,8 @@ namespace {
   }
 }
 
+constexpr std::array<uint16_t, 4> SettingDisplay::options;
+
 SettingDisplay::SettingDisplay(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
   : Screen(app), settingsController {settingsController} {
 

--- a/src/displayapp/screens/settings/SettingDisplay.cpp
+++ b/src/displayapp/screens/settings/SettingDisplay.cpp
@@ -2,6 +2,7 @@
 #include <lvgl/lvgl.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/Messages.h"
+#include "displayapp/screens/Styles.h"
 #include "displayapp/screens/Screen.h"
 #include "displayapp/screens/Symbols.h"
 
@@ -49,12 +50,7 @@ SettingDisplay::SettingDisplay(Pinetime::Applications::DisplayApp* app, Pinetime
     lv_checkbox_set_text(cbOption[i], buffer);
     cbOption[i]->user_data = this;
     lv_obj_set_event_cb(cbOption[i], event_handler);
-
-    // radio button style
-    lv_obj_set_style_local_radius(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
-    lv_obj_set_style_local_border_width(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, 9);
-    lv_obj_set_style_local_border_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_GREEN);
-    lv_obj_set_style_local_bg_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_WHITE);
+    SetRadioButtonStyle(cbOption[i]);
 
     if (settingsController.GetScreenTimeOut() == options[i]) {
       lv_checkbox_set_checked(cbOption[i], true);

--- a/src/displayapp/screens/settings/SettingDisplay.h
+++ b/src/displayapp/screens/settings/SettingDisplay.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <cstdint>
-#include <lvgl/lvgl.h>
 #include "components/settings/Settings.h"
 #include "displayapp/screens/Screen.h"
+#include <array>
+#include <cstdint>
+#include <lvgl/lvgl.h>
 
 namespace Pinetime {
 
@@ -18,8 +19,8 @@ namespace Pinetime {
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
+        const std::array<uint16_t, 4> options = {5000, 15000, 20000, 30000};
         Controllers::Settings& settingsController;
-        uint8_t optionsTotal;
         lv_obj_t* cbOption[4];
       };
     }

--- a/src/displayapp/screens/settings/SettingDisplay.h
+++ b/src/displayapp/screens/settings/SettingDisplay.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "components/settings/Settings.h"
-#include "displayapp/screens/Screen.h"
 #include <array>
 #include <cstdint>
 #include <lvgl/lvgl.h>
+
+#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
 
 namespace Pinetime {
 

--- a/src/displayapp/screens/settings/SettingDisplay.h
+++ b/src/displayapp/screens/settings/SettingDisplay.h
@@ -19,9 +19,10 @@ namespace Pinetime {
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
-        const std::array<uint16_t, 4> options = {5000, 15000, 20000, 30000};
+        static constexpr std::array<uint16_t, 4> options = {5000, 15000, 20000, 30000};
+
         Controllers::Settings& settingsController;
-        lv_obj_t* cbOption[4];
+        lv_obj_t* cbOption[options.size()];
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingTimeFormat.cpp
+++ b/src/displayapp/screens/settings/SettingTimeFormat.cpp
@@ -39,24 +39,24 @@ SettingTimeFormat::SettingTimeFormat(Pinetime::Applications::DisplayApp* app, Pi
   lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
-  optionsTotal = 0;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " 12-hour");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  for (unsigned int i = 0; i < options.size(); i++) {
+    cbOption[i] = lv_checkbox_create(container1, nullptr);
+    lv_checkbox_set_text(cbOption[i], options[i].c_str());
+    cbOption[i]->user_data = this;
+    lv_obj_set_event_cb(cbOption[i], event_handler);
+
+    // radio button style
+    lv_obj_set_style_local_radius(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
+    lv_obj_set_style_local_border_width(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, 9);
+    lv_obj_set_style_local_border_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_GREEN);
+    lv_obj_set_style_local_bg_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_WHITE);
   }
 
-  optionsTotal++;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " 24-hour");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
+    lv_checkbox_set_checked(cbOption[0], true);
+  } else if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
+    lv_checkbox_set_checked(cbOption[1], true);
   }
-  optionsTotal++;
 }
 
 SettingTimeFormat::~SettingTimeFormat() {
@@ -66,7 +66,7 @@ SettingTimeFormat::~SettingTimeFormat() {
 
 void SettingTimeFormat::UpdateSelected(lv_obj_t* object, lv_event_t event) {
   if (event == LV_EVENT_VALUE_CHANGED) {
-    for (int i = 0; i < optionsTotal; i++) {
+    for (unsigned int i = 0; i < options.size(); i++) {
       if (object == cbOption[i]) {
         lv_checkbox_set_checked(cbOption[i], true);
 

--- a/src/displayapp/screens/settings/SettingTimeFormat.cpp
+++ b/src/displayapp/screens/settings/SettingTimeFormat.cpp
@@ -13,6 +13,8 @@ namespace {
   }
 }
 
+constexpr std::array<const char*, 2> SettingTimeFormat::options;
+
 SettingTimeFormat::SettingTimeFormat(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
   : Screen(app), settingsController {settingsController} {
 
@@ -41,7 +43,7 @@ SettingTimeFormat::SettingTimeFormat(Pinetime::Applications::DisplayApp* app, Pi
 
   for (unsigned int i = 0; i < options.size(); i++) {
     cbOption[i] = lv_checkbox_create(container1, nullptr);
-    lv_checkbox_set_text(cbOption[i], options[i].c_str());
+    lv_checkbox_set_text(cbOption[i], options[i]);
     cbOption[i]->user_data = this;
     lv_obj_set_event_cb(cbOption[i], event_handler);
 

--- a/src/displayapp/screens/settings/SettingTimeFormat.cpp
+++ b/src/displayapp/screens/settings/SettingTimeFormat.cpp
@@ -1,6 +1,7 @@
 #include "displayapp/screens/settings/SettingTimeFormat.h"
 #include <lvgl/lvgl.h>
 #include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Styles.h"
 #include "displayapp/screens/Screen.h"
 #include "displayapp/screens/Symbols.h"
 
@@ -46,12 +47,7 @@ SettingTimeFormat::SettingTimeFormat(Pinetime::Applications::DisplayApp* app, Pi
     lv_checkbox_set_text(cbOption[i], options[i]);
     cbOption[i]->user_data = this;
     lv_obj_set_event_cb(cbOption[i], event_handler);
-
-    // radio button style
-    lv_obj_set_style_local_radius(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
-    lv_obj_set_style_local_border_width(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, 9);
-    lv_obj_set_style_local_border_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_GREEN);
-    lv_obj_set_style_local_bg_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_WHITE);
+    SetRadioButtonStyle(cbOption[i]);
   }
 
   if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {

--- a/src/displayapp/screens/settings/SettingTimeFormat.h
+++ b/src/displayapp/screens/settings/SettingTimeFormat.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <cstdint>
-#include <lvgl/lvgl.h>
 #include "components/settings/Settings.h"
 #include "displayapp/screens/Screen.h"
+#include <array>
+#include <cstdint>
+#include <lvgl/lvgl.h>
 
 namespace Pinetime {
 
@@ -18,8 +19,9 @@ namespace Pinetime {
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
+        const std::array<std::string, 2> options = {" 12-hour", " 24-hour"};
+
         Controllers::Settings& settingsController;
-        uint8_t optionsTotal;
         lv_obj_t* cbOption[2];
       };
     }

--- a/src/displayapp/screens/settings/SettingTimeFormat.h
+++ b/src/displayapp/screens/settings/SettingTimeFormat.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "components/settings/Settings.h"
-#include "displayapp/screens/Screen.h"
 #include <array>
 #include <cstdint>
 #include <lvgl/lvgl.h>
+
+#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
 
 namespace Pinetime {
 

--- a/src/displayapp/screens/settings/SettingTimeFormat.h
+++ b/src/displayapp/screens/settings/SettingTimeFormat.h
@@ -19,10 +19,9 @@ namespace Pinetime {
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
-        const std::array<std::string, 2> options = {" 12-hour", " 24-hour"};
-
+        static constexpr std::array<const char*, 2> options = {" 12-hour", " 24-hour"};
         Controllers::Settings& settingsController;
-        lv_obj_t* cbOption[2];
+        lv_obj_t* cbOption[options.size()];
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -40,34 +40,22 @@ SettingWatchFace::SettingWatchFace(Pinetime::Applications::DisplayApp* app, Pine
   lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
-  optionsTotal = 0;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " Digital face");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetClockFace() == 0) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  }
+  for (unsigned int i = 0; i < options.size(); i++) {
+    cbOption[i] = lv_checkbox_create(container1, nullptr);
+    lv_checkbox_set_text(cbOption[i], options[i].c_str());
+    cbOption[i]->user_data = this;
+    lv_obj_set_event_cb(cbOption[i], event_handler);
 
-  optionsTotal++;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " Analog face");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetClockFace() == 1) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  }
+    // radio button style
+    lv_obj_set_style_local_radius(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
+    lv_obj_set_style_local_border_width(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, 9);
+    lv_obj_set_style_local_border_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_GREEN);
+    lv_obj_set_style_local_bg_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_WHITE);
 
-  optionsTotal++;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " PineTimeStyle");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  if (settingsController.GetClockFace() == 2) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+    if (settingsController.GetClockFace() == i) {
+      lv_checkbox_set_checked(cbOption[i], true);
+    }
   }
-
-  optionsTotal++;
 }
 
 SettingWatchFace::~SettingWatchFace() {
@@ -77,7 +65,7 @@ SettingWatchFace::~SettingWatchFace() {
 
 void SettingWatchFace::UpdateSelected(lv_obj_t* object, lv_event_t event) {
   if (event == LV_EVENT_VALUE_CHANGED) {
-    for (uint8_t i = 0; i < optionsTotal; i++) {
+    for (unsigned int i = 0; i < options.size(); i++) {
       if (object == cbOption[i]) {
         lv_checkbox_set_checked(cbOption[i], true);
         settingsController.SetClockFace(i);

--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -2,6 +2,7 @@
 #include <lvgl/lvgl.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Styles.h"
 #include "displayapp/screens/Symbols.h"
 
 using namespace Pinetime::Applications::Screens;
@@ -47,12 +48,7 @@ SettingWatchFace::SettingWatchFace(Pinetime::Applications::DisplayApp* app, Pine
     lv_checkbox_set_text(cbOption[i], options[i]);
     cbOption[i]->user_data = this;
     lv_obj_set_event_cb(cbOption[i], event_handler);
-
-    // radio button style
-    lv_obj_set_style_local_radius(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
-    lv_obj_set_style_local_border_width(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, 9);
-    lv_obj_set_style_local_border_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_GREEN);
-    lv_obj_set_style_local_bg_color(cbOption[i], LV_CHECKBOX_PART_BULLET, LV_STATE_CHECKED, LV_COLOR_WHITE);
+    SetRadioButtonStyle(cbOption[i]);
 
     if (settingsController.GetClockFace() == i) {
       lv_checkbox_set_checked(cbOption[i], true);

--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -13,6 +13,8 @@ namespace {
   }
 }
 
+constexpr std::array<const char*, 3> SettingWatchFace::options;
+
 SettingWatchFace::SettingWatchFace(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
   : Screen(app), settingsController {settingsController} {
 
@@ -42,7 +44,7 @@ SettingWatchFace::SettingWatchFace(Pinetime::Applications::DisplayApp* app, Pine
 
   for (unsigned int i = 0; i < options.size(); i++) {
     cbOption[i] = lv_checkbox_create(container1, nullptr);
-    lv_checkbox_set_text(cbOption[i], options[i].c_str());
+    lv_checkbox_set_text(cbOption[i], options[i]);
     cbOption[i]->user_data = this;
     lv_obj_set_event_cb(cbOption[i], event_handler);
 

--- a/src/displayapp/screens/settings/SettingWatchFace.h
+++ b/src/displayapp/screens/settings/SettingWatchFace.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#include <cstdint>
-#include <lvgl/lvgl.h>
 #include "components/settings/Settings.h"
 #include "displayapp/screens/Screen.h"
+#include <array>
+#include <cstdint>
+#include <lvgl/lvgl.h>
 
 namespace Pinetime {
 
@@ -18,8 +19,9 @@ namespace Pinetime {
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
+        const std::array<std::string, 3> options = {" Digital face", " Analog face", " PineTimeStyle"};
         Controllers::Settings& settingsController;
-        uint8_t optionsTotal;
+
         lv_obj_t* cbOption[2];
       };
     }

--- a/src/displayapp/screens/settings/SettingWatchFace.h
+++ b/src/displayapp/screens/settings/SettingWatchFace.h
@@ -22,7 +22,7 @@ namespace Pinetime {
         const std::array<std::string, 3> options = {" Digital face", " Analog face", " PineTimeStyle"};
         Controllers::Settings& settingsController;
 
-        lv_obj_t* cbOption[2];
+        lv_obj_t* cbOption[3];
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingWatchFace.h
+++ b/src/displayapp/screens/settings/SettingWatchFace.h
@@ -19,10 +19,10 @@ namespace Pinetime {
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
-        const std::array<std::string, 3> options = {" Digital face", " Analog face", " PineTimeStyle"};
+        static constexpr std::array<const char*, 3> options = {" Digital face", " Analog face", " PineTimeStyle"};
         Controllers::Settings& settingsController;
 
-        lv_obj_t* cbOption[3];
+        lv_obj_t* cbOption[options.size()];
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingWatchFace.h
+++ b/src/displayapp/screens/settings/SettingWatchFace.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "components/settings/Settings.h"
-#include "displayapp/screens/Screen.h"
 #include <array>
 #include <cstdint>
 #include <lvgl/lvgl.h>
+
+#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
 
 namespace Pinetime {
 


### PR DESCRIPTION
Some checkboxes act like radio buttons. Update the style to match the behaviour.
Also create checkboxes in loops.

![radiobutton](https://user-images.githubusercontent.com/37774658/134000440-2757472d-c10a-420d-8e85-8e6ce05ce68a.jpg)