### PR TITLE
Motion: keep screen awake while showing motion app

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -421,7 +421,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       ReturnApp(Apps::Launcher, FullRefreshDirections::Down, TouchEvents::None);
       break;
     case Apps::Motion:
-      currentScreen = std::make_unique<Screens::Motion>(this, motionController);
+      currentScreen = std::make_unique<Screens::Motion>(this, motionController, *systemTask);
       break;
     case Apps::Steps:
       currentScreen = std::make_unique<Screens::Steps>(this, motionController, settingsController);

--- a/src/displayapp/screens/Motion.cpp
+++ b/src/displayapp/screens/Motion.cpp
@@ -4,8 +4,8 @@
 
 using namespace Pinetime::Applications::Screens;
 
-Motion::Motion(Pinetime::Applications::DisplayApp* app, Controllers::MotionController& motionController)
-  : Screen(app), motionController {motionController} {
+Motion::Motion(Pinetime::Applications::DisplayApp* app, Controllers::MotionController& motionController, System::SystemTask& systemTask)
+  : Screen(app), motionController {motionController}, systemTask {systemTask} {
   chart = lv_chart_create(lv_scr_act(), NULL);
   lv_obj_set_size(chart, 240, 240);
   lv_obj_align(chart, NULL, LV_ALIGN_IN_TOP_MID, 0, 0);
@@ -37,12 +37,15 @@ Motion::Motion(Pinetime::Applications::DisplayApp* app, Controllers::MotionContr
   lv_obj_align(labelStep, chart, LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
   lv_label_set_text(labelStep, "Steps ---");
 
+  systemTask.PushMessage(System::Messages::DisableSleeping);
+
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
 }
 
 Motion::~Motion() {
   lv_task_del(taskRefresh);
   lv_obj_clean(lv_scr_act());
+  systemTask.PushMessage(System::Messages::EnableSleeping);
 }
 
 void Motion::Refresh() {

--- a/src/displayapp/screens/Motion.h
+++ b/src/displayapp/screens/Motion.h
@@ -7,6 +7,7 @@
 #include <libs/lvgl/src/lv_core/lv_style.h>
 #include <libs/lvgl/src/lv_core/lv_obj.h>
 #include <components/motion/MotionController.h>
+#include "systemtask/SystemTask.h"
 
 namespace Pinetime {
   namespace Applications {
@@ -14,13 +15,14 @@ namespace Pinetime {
 
       class Motion : public Screen {
       public:
-        Motion(DisplayApp* app, Controllers::MotionController& motionController);
+        Motion(DisplayApp* app, Controllers::MotionController& motionController, System::SystemTask& systemTask);
         ~Motion() override;
 
         void Refresh() override;
 
       private:
         Controllers::MotionController& motionController;
+        System::SystemTask& systemTask;
         lv_obj_t* chart;
         lv_chart_series_t* ser1;
         lv_chart_series_t* ser2;


### PR DESCRIPTION
Instead of having to manually periodically tap on the phone to keep the
screen awake, just prevent the screen to go to sleep while showing the
motion sensor graph.