### PR TITLE
Fix the size of the filesystem.

### DIFF
--- a/src/components/fs/FS.h
+++ b/src/components/fs/FS.h
@@ -53,7 +53,7 @@ namespace Pinetime {
       *
       */
       static constexpr size_t startAddress = 0x0B4000;
-      static constexpr size_t size = 0x3C0000;
+      static constexpr size_t size = 0x34C000;
       static constexpr size_t blockSize = 4096;
 
       bool resourcesValid = false;


### PR DESCRIPTION
Unless I've made a mistake in my understanding, I think the current filesystem size has a typo and is too large.  

I think it should be (0x400000 - 0x0B4000 =) 0x34C000, but is currently 464kB larger than this.  Writing data to the filesystem will eventually attempt to write past the end of the memory.

I'm not sure whether SPINOR memory would wrap back to the start (whether it ignores the high bits of the address).  If it does, perhaps the driver should additionally check the range to prevent accidental modification of the bootloader assets?