### PR TITLE
Fix dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ As of now, here is the list of achievements of this project:
     * **[Experimental]** [WebBLEWatch](https://hubmartin.github.io/WebBLEWatch/) Synchronize time directly from your web browser. [video](https://youtu.be/IakiuhVDdrY)
     * **[Experimental]** [Infini-iOS](https://github.com/xan-m/Infini-iOS) (on iOS)
  - OTA (Over-the-air) update via BLE
- - [Bootloader](https://github.com/JF002/pinetime-mcuboot-bootloader) based on [MCUBoot](https://juullabs-oss.github.io/mcuboot/)
+ - [Bootloader](https://github.com/JF002/pinetime-mcuboot-bootloader) based on [MCUBoot](https://www.mcuboot.com)
 
 ## Documentation
 


### PR DESCRIPTION
The link to the homepage of the [mcuboot project](https://github.com/mcu-tools/mcuboot) has changed to: https://www.mcuboot.com