### PR TITLE
Issue templates to tame the wilderness

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,0 +1,59 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thanks for taking the time to fill out this bug report!**
+        *Please, before opening a bug report, check if similar issues already exist. In that case, use those issues to provide your feedback instead.*
+  - type: checkboxes
+    attributes:
+      options:
+      - label: I searched for similar bug reports and found none was relevant.
+        required: true
+  - type: input
+    id: desc-brief
+    attributes:
+      label: What happened?
+      description: A one-line description of the bug.
+      placeholder: "Ex. I woke up as a Kafkian insect this morning."
+    validations:
+      required: true
+  - type: input
+    id: desc-expected
+    attributes:
+      label: What should happen instead?
+      description: The behaviour you were expecting to see.
+      placeholder: "Ex. I was expecting to wake up as a human."
+  - type: textarea
+    id: desc-steps
+    attributes:
+      label: Reproduction steps
+      description: "How do you trigger this bug? Please walk us through it step by step."
+    validations:
+      required: true
+  - type: textarea
+    id: desc-long
+    attributes:
+      label: More details?
+      description: Give us more details about the bug and any personal attempts you made to fix it.
+      placeholder: Tell us more!
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: |
+        What [version of the firmware](https://github.com/JF002/InfiniTime/blob/develop/doc/gettingStarted/gettingStarted-1.0.md#how-to-check-the-version-of-infinitime-and-the-bootloader) are you running?
+        If you are running an older version, please consider [updating to the latest firmware](https://github.com/JF002/InfiniTime/blob/develop/doc/gettingStarted/gettingStarted-1.0.md#how-to-update-your-pinetime).
+        If you are running directly from git, specify the branch or the commit hash directly.
+      placeholder: "Ex. v1.6.0 or develop or fc922b60"
+    validations:
+      required: true
+  - type: input
+    id: companion-app
+    attributes:
+      label: Companion app
+      description: Which companion app are you using (if relevant)?
+      placeholder: "Ex. Gadgetbridge v0.60.0, Siglo v0.9.4"

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: File a feature request
+title: "[Feature Request]: "
+labels: ["feature-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thanks for taking the time to fill out this feature request!**
+        *Please, before opening a feature request, check if similar issues already exist. In that case, use those issues to provide your feedback instead.*
+  - type: checkboxes
+    attributes:
+      options:
+      - label: I searched for similar feature request and found none was relevant.
+        required: true
+  - type: markdown
+    attributes:
+      value: |
+        **Note:** keep in mind that, while InfiniTime is usable, it is still under heavy development and as such it is continuously evolving.
+        Some features you want to see implemented might not be compatible with the current state of the project, or might not even be suitable to include *in the firmware* of the watch.
+  - type: input
+    id: desc-brief
+    attributes:
+      label: Pitch us your idea!
+      description: A one-line elevator pitch of the feature you'd like to see implemented.
+      placeholder: "Ex. My dog wants InfiniTime on its smart collar."
+    validations:
+      required: true
+  - type: textarea
+    id: desc-long
+    attributes:
+      label: Description
+      description: |
+        Give us a detailed description of the feature you are proposing. Mockups or a description of the possible use cases are highly appreciated.
+        Tell us why this should be included in the firmware.
+      placeholder: "Ex. Here is a drawing of my dog wearing an InfiniTime collar and smiling."
+  - type: markdown
+    id: companion-app
+    attributes:
+      value: |
+        If this requires features missing from other software (for example a companion app), please take care of opening any relevant feature request over there as well.


### PR DESCRIPTION
This is an example of what can be done with issue template forms in Github. With some autolabelling and a form structure it might be possible to get better structured bug reports and feature requests and avoid duplicates.

Feedback on existing or new templates appreciated.

_I haven't included PR templates but those are an option as well._