### PR TITLE
Add configurable push button function (back or watchface)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -433,6 +433,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/settings/SettingDisplay.cpp
         displayapp/screens/settings/SettingSteps.cpp
         displayapp/screens/settings/SettingPineTimeStyle.cpp
+        displayapp/screens/settings/SettingPushButtonAction.cpp
 
         ## Watch faces
         displayapp/icons/bg_clock.c

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -25,6 +25,7 @@ namespace Pinetime {
         Colors ColorBar = Colors::Teal;
         Colors ColorBG = Colors::Black;
       };
+      enum class SettingPushButtonAction { BACK, WATCHFACE };
 
       Settings(Pinetime::Controllers::FS& fs);
 
@@ -151,6 +152,15 @@ namespace Pinetime {
         return settings.brightLevel;
       };
 
+      void SetSettingPushButtonAction(SettingPushButtonAction pushButtonAction) {
+        if (pushButtonAction != settings.pushButtonAction)
+          settingsChanged = true;
+        settings.pushButtonAction = pushButtonAction;
+      };
+      SettingPushButtonAction GetSettingPushButtonAction() const {
+        return settings.pushButtonAction;
+      };
+
       void SetStepsGoal( uint32_t goal ) { 
         if ( goal != settings.stepsGoal ) {
           settingsChanged = true;
@@ -179,6 +189,8 @@ namespace Pinetime {
         std::bitset<3> wakeUpMode {0};
 
         Controllers::BrightnessController::Levels brightLevel = Controllers::BrightnessController::Levels::Medium;
+
+        SettingPushButtonAction pushButtonAction = SettingPushButtonAction::BACK;
       };
 
       SettingsData settings;

--- a/src/displayapp/Apps.h
+++ b/src/displayapp/Apps.h
@@ -32,7 +32,8 @@ namespace Pinetime {
       SettingDisplay,
       SettingWakeUp,
       SettingSteps,
-      SettingPineTimeStyle
+      SettingPineTimeStyle,
+      SettingPushButtonAction
     };
   }
 }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -44,6 +44,8 @@
 #include "displayapp/screens/settings/SettingDisplay.h"
 #include "displayapp/screens/settings/SettingSteps.h"
 #include "displayapp/screens/settings/SettingPineTimeStyle.h"
+#include "displayapp/screens/settings/SettingPushButtonAction.h"
+
 
 #include "libs/lv_conf.h"
 
@@ -246,9 +248,19 @@ void DisplayApp::Refresh() {
           PushMessageToSystemTask(System::Messages::GoToSleep);
         } else {
           if (!currentScreen->OnButtonPushed()) {
-            LoadApp(returnToApp, returnDirection);
-            brightnessController.Set(settingsController.GetBrightness());
-            brightnessController.Backup();
+            switch (settingsController.GetSettingPushButtonAction())
+            {
+            case Pinetime::Controllers::Settings::SettingPushButtonAction::BACK:
+              LoadApp(returnToApp, returnDirection);
+              brightnessController.Set(settingsController.GetBrightness());
+              brightnessController.Backup();              
+              break;
+            case Pinetime::Controllers::Settings::SettingPushButtonAction::WATCHFACE:
+              LoadApp(Apps::Clock, DisplayApp::FullRefreshDirections::LeftAnim);
+              break;            
+            default:
+              break;
+            }            
           }
         }
         break;
@@ -369,6 +381,10 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       currentScreen = std::make_unique<Screens::SettingPineTimeStyle>(this, settingsController);
       ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
+    case Apps::SettingPushButtonAction:
+      currentScreen = std::make_unique<Screens::SettingPushButtonAction>(this, settingsController);     
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      break;       
     case Apps::BatteryInfo:
       currentScreen = std::make_unique<Screens::BatteryInfo>(this, batteryController);
       ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);

--- a/src/displayapp/screens/settings/SettingPushButtonAction.cpp
+++ b/src/displayapp/screens/settings/SettingPushButtonAction.cpp
@@ -1,0 +1,86 @@
+#include "SettingPushButtonAction.h"
+#include <lvgl/lvgl.h>
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  static void event_handler(lv_obj_t* obj, lv_event_t event) {
+    SettingPushButtonAction* screen = static_cast<SettingPushButtonAction*>(obj->user_data);
+    screen->UpdateSelected(obj, event);
+  }
+}
+
+SettingPushButtonAction::SettingPushButtonAction(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
+  : Screen(app), settingsController {settingsController} {
+
+  lv_obj_t* container1 = lv_cont_create(lv_scr_act(), nullptr);
+
+  lv_obj_set_style_local_bg_opa(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
+  lv_obj_set_style_local_pad_all(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
+  lv_obj_set_style_local_pad_inner(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
+  lv_obj_set_style_local_border_width(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
+
+  lv_obj_set_pos(container1, 10, 60);
+  lv_obj_set_width(container1, LV_HOR_RES - 20);
+  lv_obj_set_height(container1, LV_VER_RES - 50);
+  lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
+
+  lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(title, "Button action");
+  lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 15, 15);
+
+  lv_obj_t* icon = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(icon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
+  lv_label_set_text_static(icon, Symbols::list);
+  lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
+
+  optionsTotal = 0;
+  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
+  lv_checkbox_set_text_static(cbOption[optionsTotal], " Go Back");
+  cbOption[optionsTotal]->user_data = this;
+  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
+  if (settingsController.GetSettingPushButtonAction() == Controllers::Settings::SettingPushButtonAction::BACK) {
+    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  }
+
+
+  optionsTotal++;
+  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
+  lv_checkbox_set_text_static(cbOption[optionsTotal], " Watchface");
+  cbOption[optionsTotal]->user_data = this;
+  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
+  if (settingsController.GetSettingPushButtonAction() == Controllers::Settings::SettingPushButtonAction::WATCHFACE) {
+    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  }
+  optionsTotal++;
+}
+
+SettingPushButtonAction::~SettingPushButtonAction() {
+  lv_obj_clean(lv_scr_act());
+  settingsController.SaveSettings();
+}
+
+void SettingPushButtonAction::UpdateSelected(lv_obj_t* object, lv_event_t event) {
+  if (event == LV_EVENT_VALUE_CHANGED) {
+    for (int i = 0; i < optionsTotal; i++) {
+      if (object == cbOption[i]) {
+        lv_checkbox_set_checked(cbOption[i], true);
+
+        if (i == 0) {
+          settingsController.SetSettingPushButtonAction(Controllers::Settings::SettingPushButtonAction::BACK);
+        };
+        if (i == 1) {
+          settingsController.SetSettingPushButtonAction(Controllers::Settings::SettingPushButtonAction::WATCHFACE);
+        };
+
+      } else {
+        lv_checkbox_set_checked(cbOption[i], false);
+      }
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingPushButtonAction.h
+++ b/src/displayapp/screens/settings/SettingPushButtonAction.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+#include <lvgl/lvgl.h>
+#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
+
+namespace Pinetime {
+
+  namespace Applications {
+    namespace Screens {
+
+      class SettingPushButtonAction : public Screen {
+      public:
+        SettingPushButtonAction(DisplayApp* app, Pinetime::Controllers::Settings& settingsController);
+        ~SettingPushButtonAction() override;
+
+        void UpdateSelected(lv_obj_t* object, lv_event_t event);
+
+      private:
+        Controllers::Settings& settingsController;
+        uint8_t optionsTotal;
+        lv_obj_t* cbOption[2];
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<Screen> Settings::CreateScreen3() {
 
   std::array<Screens::List::Applications, 4> applications {{
     {Symbols::list, "About", Apps::SysInfo},
-    {Symbols::none, "None", Apps::None},
+    {Symbols::list, "Button Action", Apps::SettingPushButtonAction},
     {Symbols::none, "None", Apps::None},
     {Symbols::none, "None", Apps::None},
   }};


### PR DESCRIPTION
This PR adds the option to configure the action of the pushbutton (back or watchface
![PXL_20211003_185333721](https://user-images.githubusercontent.com/7712562/135767547-de694c8b-55ad-4f0f-94b7-68b031e1f0f8.jpg)
).