### PR TITLE
Improve battery percentage calculation and reporting

### DIFF
--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -69,18 +69,23 @@ void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
     // p_event->data.done.p_buffer[0] = (adc_voltage / reference_voltage) * 1024
     voltage = p_event->data.done.p_buffer[0] * (8 * 600) / 1024;
 
+    uint8_t newPercent;
     if (isFull) {
-      percentRemaining = 100;
+      newPercent = 100;
     } else if (voltage < battery_min) {
-      percentRemaining = 0;
+      newPercent = 0;
     } else {
-      percentRemaining = std::min((voltage - battery_min) * 100 / (battery_max - battery_min), isCharging ? 99 : 100);
+      newPercent = std::min((voltage - battery_min) * 100 / (battery_max - battery_min), isCharging ? 99 : 100);
+    }
+
+    if ((isPowerPresent && newPercent > percentRemaining) || (!isPowerPresent && newPercent < percentRemaining) || firstMeasurement) {
+      firstMeasurement = false;
+      percentRemaining = newPercent;
+      systemTask->PushMessage(System::Messages::BatteryPercentageUpdated);
     }
 
     nrfx_saadc_uninit();
     isReading = false;
-
-    systemTask->PushMessage(System::Messages::BatteryMeasurementDone);
   }
 }
 

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -42,6 +42,7 @@ namespace Pinetime {
       bool isFull = false;
       bool isCharging = false;
       bool isPowerPresent = false;
+      bool firstMeasurement = true;
 
       void SaadcInit();
 

--- a/src/systemtask/Messages.h
+++ b/src/systemtask/Messages.h
@@ -24,7 +24,7 @@ namespace Pinetime {
         SetOffAlarm,
         StopRinging,
         MeasureBatteryTimerExpired,
-        BatteryMeasurementDone,
+        BatteryPercentageUpdated,
       };
     }
 }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -349,14 +349,10 @@ void SystemTask::Work() {
           motorController.RunForDuration(15);
           break;
         case Messages::MeasureBatteryTimerExpired:
-          sendBatteryNotification = true;
           batteryController.Update();
           break;
-        case Messages::BatteryMeasurementDone:
-          if (sendBatteryNotification) {
-            sendBatteryNotification = false;
-            nimbleController.NotifyBatteryLevel(batteryController.PercentRemaining());
-          }
+        case Messages::BatteryPercentageUpdated:
+          nimbleController.NotifyBatteryLevel(batteryController.PercentRemaining());
           break;
 
         default:

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -133,14 +133,12 @@ namespace Pinetime {
       TimerHandle_t dimTimer;
       TimerHandle_t idleTimer;
       TimerHandle_t measureBatteryTimer;
-      bool sendBatteryNotification = false;
       bool doNotGoToSleep = false;
 
       void GoToRunning();
       void UpdateMotion();
       bool stepCounterMustBeReset = false;
       static constexpr TickType_t batteryMeasurementPeriod = pdMS_TO_TICKS(10 * 60 * 1000);
-      TickType_t lastBatteryNotificationTime = 0;
 
 #if configUSE_TRACE_FACILITY == 1
       SystemMonitor<FreeRtosMonitor> monitor;


### PR DESCRIPTION
While charging, percentage should only go up, and while discharging, percentage should only go down.

This is simpler than a proper filter and achieves practically the same thing. Should reduce, or even eliminate the noise that's visible in Gadgetbridge battery graph.

Also notify the battery level over ble only when it has changed. This should make the graph smoother.

I would have liked to test this more and provide screenshots, but I want to work on other things as well and not wait for the battery to drain.