### PR TITLE
Improve gesture consistency across the firmware

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -380,7 +380,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       break;
     case Apps::FlashLight:
       currentScreen = std::make_unique<Screens::FlashLight>(this, *systemTask, brightnessController);
-      ReturnApp(Apps::Clock, FullRefreshDirections::Down, TouchEvents::None);
+      ReturnApp(Apps::QuickSettings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::StopWatch:
       currentScreen = std::make_unique<Screens::StopWatch>(this, *systemTask);

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -113,9 +113,15 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
           lv_label_set_text_fmt(bpmValue, "%03d", bpm);
         }
         tappedTime = xTaskGetTickCount();
+        allowExit = true;
       }
       break;
     }
+    case LV_EVENT_RELEASED:
+    case LV_EVENT_PRESS_LOST:
+      if (obj == bpmTap) {
+        allowExit = false;
+      }
     case LV_EVENT_CLICKED: {
       if (obj == playPause) {
         metronomeStarted = !metronomeStarted;
@@ -134,4 +140,12 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
     default:
       break;
   }
+}
+
+bool Metronome::OnTouchEvent(TouchEvents event) {
+  if (event == TouchEvents::SwipeDown && allowExit) {
+    running = false;
+    return true;
+  }
+  return false;
 }

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -122,6 +122,7 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
       if (obj == bpmTap) {
         allowExit = false;
       }
+      break;
     case LV_EVENT_CLICKED: {
       if (obj == playPause) {
         metronomeStarted = !metronomeStarted;

--- a/src/displayapp/screens/Metronome.h
+++ b/src/displayapp/screens/Metronome.h
@@ -13,6 +13,7 @@ namespace Pinetime {
         ~Metronome() override;
         void Refresh() override;
         void OnEvent(lv_obj_t* obj, lv_event_t event);
+        bool OnTouchEvent(TouchEvents event) override;
 
       private:
         TickType_t startTime = 0;
@@ -24,6 +25,7 @@ namespace Pinetime {
         uint8_t counter = 1;
 
         bool metronomeStarted = false;
+        bool allowExit = false;
 
         lv_obj_t *bpmArc, *bpmTap, *bpmValue;
         lv_obj_t *bpbDropdown, *currentBpbText;

--- a/src/displayapp/screens/Music.cpp
+++ b/src/displayapp/screens/Music.cpp
@@ -277,12 +277,14 @@ bool Music::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
       return true;
     }
     case TouchEvents::SwipeDown: {
-      lv_obj_set_hidden(btnNext, false);
-      lv_obj_set_hidden(btnPrev, false);
-
-      lv_obj_set_hidden(btnVolDown, true);
-      lv_obj_set_hidden(btnVolUp, true);
-      return true;
+      if (lv_obj_get_hidden(btnNext)) {
+        lv_obj_set_hidden(btnNext, false);
+        lv_obj_set_hidden(btnPrev, false);
+        lv_obj_set_hidden(btnVolDown, true);
+        lv_obj_set_hidden(btnVolUp, true);
+        return true;
+      }
+      return false;
     }
     case TouchEvents::SwipeLeft: {
       musicService.event(Controllers::MusicService::EVENT_MUSIC_NEXT);

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -131,7 +131,7 @@ void QuickSettings::OnButtonEvent(lv_obj_t* object, lv_event_t event) {
   if (object == btn2 && event == LV_EVENT_CLICKED) {
 
     running = false;
-    app->StartApp(Apps::FlashLight, DisplayApp::FullRefreshDirections::None);
+    app->StartApp(Apps::FlashLight, DisplayApp::FullRefreshDirections::Up);
 
   } else if (object == btn1 && event == LV_EVENT_CLICKED) {
 


### PR DESCRIPTION
Metronome can be closed by swiping down from the center. I could make it not close while dragging the arc, but I couldn't make it not close while dragging the dropdown menu, so this is the next best thing.

Music app shows volume buttons on swipe up and swiping down goes back to next/prev. now swiping down in the default state will close the app.

Flashlight can now be closed by swiping down. Also the transitions animation was changed to match other apps and returnapp is quicksettings instead of watchface.

The last apps that can't be closed through the touchscreen are Paint, Paddle and Twos, but they can't easily be made to use swipes for closing, so they would need some other solution.

Closes #651, unless we keep it open for these three.

https://user-images.githubusercontent.com/37774658/135816670-bd3f3c3a-bd4f-43f5-86ec-e5b1c018c050.mp4