### PR TITLE
Add docs for app creation and code structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ As of now, here is the list of achievements of this project:
 ## Documentation
 
 ### Develop
-
+ - [Rough structure of the code](doc/code/Intro.md)
+ - [How to implement an application](doc/code/Apps.md)
  - [Generate the fonts and symbols](src/displayapp/fonts/README.md)
  - [Creating a stopwatch in Pinetime(article)](https://pankajraghav.com/2021/04/03/PINETIME-STOPCLOCK.html)
 

--- a/doc/code/Apps.md
+++ b/doc/code/Apps.md
@@ -1,0 +1,70 @@
+# Apps
+This page will teach you:
+- what apps in InfiniTime are
+- how to implement your own app
+
+## Theory
+Apps are the things you can lauch from the app selection you get by swiping down, but also the app launcher itself or the clock. Settings are also implemented as apps. Most screens you see are their own app, except for apps that have multiple screens (settings launcher, app launcher).
+Every app in InfiniTime is it's own class. An object of the class is created when the app is launched and destroyed when the user exits the app. They run inside the "displayapp" task (briefly discussed [here](./Intro.md)). They are responsible for everything drawn on the screen when they are running. By default, apps only do something (as in a function is executed) when they are created or when a touch event is detected.
+
+## Interface
+Every app class is has to be inside the namespace `Pinetime::Applications::Screens` and inherit from `Screen`. The constructor should have at least one parameter `DisplayApp* app`, which it needs for the constructor of its parent class Screen. Other parameters should be references to controllers that the app needs. A deconstructor is needed to clean up LVGL and restore any changes (for example re-enable sleeping). App classes can override `bool OnButtonPushed()`, `bool OnTouchEvent(TouchEvents event)` and `bool OnTouchEvent(uint16_t x, uint16_t y)` to implement their own functionality for those events. If an app only needs to display some text and do something upon a touch screen button press, it does not need to override any of these functions, as LVGL can also handle touch events for you. If your app needs to be updated continuously, yo can do so by adding a `Refresh()` function to your class and calling `lv_task_create` inside the constructor. 
+
+## Creating your own app
+A minimal app could look like this: <br>
+MyApp.h:
+```cpp
+#pragma once
+
+#include <lvgl/lvgl.h>
+#include "displayapp/screens/Screen.h"
+
+namespace PineTime {
+    namespace Applications {
+        namespace Screens {
+            class MyApp : public Screen {
+            public:
+                MyApp(DisplayApp* app);
+                ~MyApp() override;
+            }
+        }
+    }
+}
+```
+
+MyApp.cpp:
+```cpp
+#include "MyApp.h"
+#include "displayapp/DisplayApp.h"
+
+using namespace Pinetime::Applications::Screens;
+
+MyApp::MyApp(DisplayApp* app) : Screen(app) {
+    lv_obj_t * container1 = lv_cont_create(lv_scr_act(), nullptr);
+    lv_obj_set_style_local_bg_opa(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
+    lv_obj_set_style_local_pad_all(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
+    lv_obj_set_style_local_pad_inner(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
+    lv_obj_set_style_local_border_width(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
+    lv_obj_set_pos(container1, 30, 60);
+    lv_obj_set_width(container1, LV_HOR_RES - 50);
+    lv_obj_set_height(container1, LV_VER_RES - 60);
+    lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
+
+    lv_obj_t * title = lv_label_create(lv_scr_act(), NULL);  
+    lv_label_set_text_static(title,"My test application");
+    lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
+    lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 15, 15);
+}
+
+MyApp::~MyApp() {
+    lv_obj_clean(lv_scr_act());
+}
+```
+Both of these files should be in displayapp/screens/ or displayapp/screens/settings if it's a setting app.
+
+Now we have our very own app, but InfiniTime does not know about it yet. The first step is to include it in the compilation by adding it to CMakeLists.txt . The next step to making it launchable is to give your app an id. To do this, add an entry in the enum class `Pinetime::Applications::Apps`. Name this entry after your app. Add `#include "displayapp/screens/MyApp.h"` to the file displayapp/DisplayApp.cpp . Now, go to the function `DisplayApp::LoadApp` and add another case to the switch statement. The case will be the id you gave your app earlier. If your app needs any additional arguments, this is the place to pass them. <br>
+
+If you want your app to be launched from the regular app launcher, go to displayapp/screens/ApplicationList.cpp. Add your app to one of the `CreateScreen` functions, or add another `CreateScreen` function if there are no empty spaces for your app. <br>
+If your app is a setting, do the same procedure in displayapp/screens/settings/Settings.cpp .
+
+You should now be able to [build](../buildAndProgram.md) the firmware and flash it to your PineTime. Yay!

--- a/doc/code/Intro.md
+++ b/doc/code/Intro.md
@@ -1,0 +1,20 @@
+# Introduction to the code
+This page is meant to guide you through the source code, so you can find the relevant files for what you're working on.
+
+## FreeRTOS
+Infinitime is based on FreeRTOS, a real-time operating system. FreeRTOS provides several quality of life abstractions (for example easy software timers) and most importantly supports multiple tasks. You can sort of imagine them as processes or threads on a full operating system. The main "process" creates at least one task and then starts the FreeRTOS task scheduler. This main "process" is the standard main() function inside main.cpp . The task scheduler is responsible for giving every task enough cpu time. As there is only one core on the SoC of the PineTime, real concurrency is impossible and the scheduler has to swap tasks in and out to emulate it.
+
+### Tasks
+Tasks are created by calling `xTaskCreate` and passing a function with the signature `void functionName(void*)`. For more info on task creation see the [FreeRTOS Documentation](https://www.freertos.org/a00125.html).
+In our case, main calls `systemTask.Start()`, which creates the **"MAIN" task**. The function running inside that task is `SystemTask::Work()`. Both functions are located inside systemtask/SystemTask.cpp . `SystemTask::Work()` initializes all the driver and controller objects. It also starts the **task "displayapp"**, which is responsible for launching and running apps, controlling the screen and handling touch events (or forwarding them to the active app). You can find the "displayapp" task inside displayapp/DisplayApp.cpp .
+There are also other tasks that are responsible for Bluetooth ("ll" and "ble" inside libs/mynewt-nimble/porting/npl/freertos/src/nimble_port_freertos.c) and periodic tasks like heartrate measurements (heartratetask/HeartRateTask.cpp).
+
+## Controllers
+Controllers in InfiniTime are singleton objects that can provide access to certain resources to apps. Some of them interface with drivers, others are the driver for the resource. The resources provided don't have to be hardware-based. They are declared in main.cpp and initialized in systemtask/SystemTask.cpp . Some controllers can be passed by reference to apps that need access to the resource (for example vibration motor).
+They reside in components inside their own subfolder.
+
+## Apps
+For more detail see the [Apps page](./Apps.md)
+
+## Bluetooth
+Header files with short documentation for the functions are inside libs/mynewt-nimble/nimble/host/include/host/ .


### PR DESCRIPTION
This adds documentation pages for:
- the rough structure of the code (what runs where, which tasks do what, etc.)
- creating an app (including example code)

I also added links from README.md to my documentation pages.
It's not a lot but I think it will still greatly improve the experience for newcomers. If you can think of anything important that should be added, let me know! I don't think I understand the BLE situation well enough to write any documentation for that though.
Please inform me if anything is inaccurate or incorrect. For example I've always written function and never method, so let me know if this is an issue. 