### PR TITLE
Add wake-up on charge event

### DIFF
--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -347,6 +347,7 @@ void SystemTask::Work() {
         case Messages::OnChargingEvent:
           batteryController.Update();
           motorController.RunForDuration(15);
+          ReloadIdleTimer();
           if (isSleeping && !isWakingUp) {
             GoToRunning();
           }


### PR DESCRIPTION
Closes #727

I also missed that the display does not turn on when connected to the charger.

I added wake-up on charge change. So it will wake-up when placed to the charger and also when removed.

This could be discussed whether it is desirable, but I think it allows you to see the state of charge.