### PR TITLE
Removed the title prefix from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: File a feature request
-title: "[Feature Request]: "
+title: ""
 labels: ["feature request"]
 body:
   - type: markdown


### PR DESCRIPTION
We have labels for this, there's no need to prefix the title with one.