### PR TITLE
Flashlight brightness control

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -390,7 +390,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       break;
     case Apps::FlashLight:
       currentScreen = std::make_unique<Screens::FlashLight>(this, *systemTask, brightnessController);
-      ReturnApp(Apps::Clock, FullRefreshDirections::Down, TouchEvents::None);
+      ReturnApp(Apps::QuickSettings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::StopWatch:
       currentScreen = std::make_unique<Screens::StopWatch>(this, *systemTask);

--- a/src/displayapp/screens/FlashLight.cpp
+++ b/src/displayapp/screens/FlashLight.cpp
@@ -5,30 +5,41 @@
 using namespace Pinetime::Applications::Screens;
 
 namespace {
-  static void event_handler(lv_obj_t* obj, lv_event_t event) {
-    FlashLight* screen = static_cast<FlashLight*>(obj->user_data);
+  void event_handler(lv_obj_t* obj, lv_event_t event) {
+    auto* screen = static_cast<FlashLight*>(obj->user_data);
     screen->OnClickEvent(obj, event);
   }
 }
 
 FlashLight::FlashLight(Pinetime::Applications::DisplayApp* app,
                        System::SystemTask& systemTask,
-                       Controllers::BrightnessController& brightness)
+                       Controllers::BrightnessController& brightnessController)
   : Screen(app),
     systemTask {systemTask},
-    brightness {brightness}
+    brightnessController {brightnessController}
 
 {
-  brightness.Backup();
-  brightness.Set(Controllers::BrightnessController::Levels::High);
-  // Set the background
-  lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFFFFFF));
+  brightnessController.Backup();
 
-  flashLight = lv_label_create(lv_scr_act(), NULL);
-  lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
+  brightnessLevel = brightnessController.Level();
+
+  flashLight = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_sys_48);
   lv_label_set_text_static(flashLight, Symbols::highlight);
-  lv_obj_align(flashLight, NULL, LV_ALIGN_CENTER, 0, 0);
+  lv_obj_align(flashLight, nullptr, LV_ALIGN_CENTER, 0, 0);
+
+  for (auto & i : indicators) {
+    i = lv_obj_create(lv_scr_act(), nullptr);
+    lv_obj_set_size(i, 15, 10);
+    lv_obj_set_style_local_border_width(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, 2);
+  }
+
+  lv_obj_align(indicators[1], flashLight, LV_ALIGN_OUT_BOTTOM_MID, 0, 5);
+  lv_obj_align(indicators[0], indicators[1], LV_ALIGN_OUT_LEFT_MID, -8, 0);
+  lv_obj_align(indicators[2], indicators[1], LV_ALIGN_OUT_RIGHT_MID, 8, 0);
+
+  SetIndicators();
+  SetColors();
 
   backgroundAction = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(backgroundAction, LV_LABEL_LONG_CROP);
@@ -44,27 +55,80 @@ FlashLight::FlashLight(Pinetime::Applications::DisplayApp* app,
 
 FlashLight::~FlashLight() {
   lv_obj_clean(lv_scr_act());
-  lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
-  brightness.Restore();
+  lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  brightnessController.Restore();
   systemTask.PushMessage(Pinetime::System::Messages::EnableSleeping);
 }
 
-void FlashLight::OnClickEvent(lv_obj_t* obj, lv_event_t event) {
-  if (obj == backgroundAction) {
-    if (event == LV_EVENT_CLICKED) {
-      isOn = !isOn;
-
-      if (isOn) {
-        lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFFFFFF));
-        lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
-      } else {
-        lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
-        lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFFFFFF));
-      }
+void FlashLight::SetColors() {
+  if (isOn) {
+    lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+    lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
+    for (auto & i : indicators) {
+      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
+      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DISABLED, LV_COLOR_WHITE);
+      lv_obj_set_style_local_border_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
+    }
+  } else {
+    lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+    lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+    for (auto & i : indicators) {
+      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DISABLED, LV_COLOR_BLACK);
+      lv_obj_set_style_local_border_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
     }
   }
 }
 
+void FlashLight::SetIndicators() {
+  using namespace Pinetime::Controllers;
+
+  if (brightnessLevel == BrightnessController::Levels::High) {
+    lv_obj_set_state(indicators[1], LV_STATE_DEFAULT);
+    lv_obj_set_state(indicators[2], LV_STATE_DEFAULT);
+  } else if (brightnessLevel == BrightnessController::Levels::Medium) {
+    lv_obj_set_state(indicators[1], LV_STATE_DEFAULT);
+    lv_obj_set_state(indicators[2], LV_STATE_DISABLED);
+  } else {
+    lv_obj_set_state(indicators[1], LV_STATE_DISABLED);
+    lv_obj_set_state(indicators[2], LV_STATE_DISABLED);
+  }
+}
+
+void FlashLight::OnClickEvent(lv_obj_t* obj, lv_event_t event) {
+  if (obj == backgroundAction && event == LV_EVENT_CLICKED) {
+    isOn = !isOn;
+    SetColors();
+  }
+}
+
 bool FlashLight::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
+  using namespace Pinetime::Controllers;
+
+  if (event == TouchEvents::SwipeLeft) {
+    if (brightnessLevel == BrightnessController::Levels::High) {
+      brightnessLevel = BrightnessController::Levels::Medium;
+      brightnessController.Set(brightnessLevel);
+      SetIndicators();
+    } else if (brightnessLevel == BrightnessController::Levels::Medium) {
+      brightnessLevel = BrightnessController::Levels::Low;
+      brightnessController.Set(brightnessLevel);
+      SetIndicators();
+    }
+    return true;
+  }
+  if (event == TouchEvents::SwipeRight) {
+    if (brightnessLevel == BrightnessController::Levels::Low) {
+      brightnessLevel = BrightnessController::Levels::Medium;
+      brightnessController.Set(brightnessLevel);
+      SetIndicators();
+    } else if (brightnessLevel == BrightnessController::Levels::Medium) {
+      brightnessLevel = BrightnessController::Levels::High;
+      brightnessController.Set(brightnessLevel);
+      SetIndicators();
+    }
+    return true;
+  }
+
   return false;
 }

--- a/src/displayapp/screens/FlashLight.h
+++ b/src/displayapp/screens/FlashLight.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <cstdint>
 #include "Screen.h"
-#include <lvgl/lvgl.h>
-#include "systemtask/SystemTask.h"
 #include "components/brightness/BrightnessController.h"
+#include "systemtask/SystemTask.h"
+#include <cstdint>
+#include <lvgl/lvgl.h>
 
 namespace Pinetime {
 
@@ -20,12 +20,18 @@ namespace Pinetime {
         void OnClickEvent(lv_obj_t* obj, lv_event_t event);
 
       private:
+        void SetIndicators();
+        void SetColors();
+
         Pinetime::System::SystemTask& systemTask;
-        Controllers::BrightnessController& brightness;
+        Controllers::BrightnessController& brightnessController;
+
+        Controllers::BrightnessController::Levels brightnessLevel;
 
         lv_obj_t* flashLight;
         lv_obj_t* backgroundAction;
-        bool isOn = true;
+        lv_obj_t* indicators[3];
+        bool isOn = false;
       };
     }
   }

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -131,7 +131,7 @@ void QuickSettings::OnButtonEvent(lv_obj_t* object, lv_event_t event) {
   if (object == btn2 && event == LV_EVENT_CLICKED) {
 
     running = false;
-    app->StartApp(Apps::FlashLight, DisplayApp::FullRefreshDirections::None);
+    app->StartApp(Apps::FlashLight, DisplayApp::FullRefreshDirections::Up);
 
   } else if (object == btn1 && event == LV_EVENT_CLICKED) {
 


### PR DESCRIPTION
At first I was planning on fixing #702 a different way https://github.com/InfiniTimeOrg/InfiniTime/pull/735#issuecomment-939448961, but then I found that brightness control can actually be useful in pitch black https://github.com/InfiniTimeOrg/InfiniTime/pull/735#issuecomment-940883632.

This PR adds adjustable brightness control to the flashlight app. The default brightness level will be the current backlight level.

By default the flashlight will be off, so it won't blind the user on launch.

The brightness control affects the backlight while the flashlight is disabled, which should make the icon dim enough that it isn't an issue.

Also added swipe down to exit and changed return app to QuickSettings.

If we find that a red flashlight color is actually usable and beneficial in some use case, that could be added behind a long press.

After recording this video, I changed the opening animation to a slide up, like the other apps.

Fixes half of #702. Shake algorithm should be added later.

https://user-images.githubusercontent.com/37774658/137112986-f5f60875-d6ad-4922-8062-dfe2b71ac82b.mp4



