### PR TITLE
Improve BLE documentation

### DIFF
--- a/doc/ble.md
+++ b/doc/ble.md
@@ -254,7 +254,7 @@ Enabling notifications on this characteristic gives you a single byte upon any e
 
 #### Status
 
-The status characteristic allows setting the playing status of music. Send `0x01` to the status characteristic for playing, and `0x01` for paused.
+The status characteristic allows setting the playing status of music. Send `0x01` to the status characteristic for playing, and `0x00` for paused.
 
 #### Artist, Track, and Album
 


### PR DESCRIPTION
I have noticed, during my development of [`itd`](https://gitea.arsenm.dev/Arsen6331/itd) and [`infinitime`](https://gitea.arsenm.dev/Arsen6331/infinitime), that the BLE documentation for InfiniTime is lacking. I had to spend over 2 hours scouring through Nordic documentation and InfiniTime source code just to find a couple UUIDs and a message format table. I decided to make some documentation. I posted it in my repo: [docs.md](https://gitea.arsenm.dev/Arsen6331/infinitime/src/branch/master/docs.md). I wanted more people to be able to see it, so I merged it with the existing BLE docs and fixed some spelling and grammar mistakes.