### PR TITLE
Fixed Apps tutorial to compile properly

### DIFF
--- a/doc/code/Apps.md
+++ b/doc/code/Apps.md
@@ -58,7 +58,7 @@ namespace Pinetime {
       public:
         MyApp(DisplayApp* app);
         ~MyApp() override;
-      }
+      };
     }
   }
 }


### PR DESCRIPTION
Changed case in minimal example to properly reference Pinetime namespace