### PR TITLE
CI: add pintime-recovery to build jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -153,6 +153,14 @@ jobs:
           name: pinetime-app.out
           path: build/src/pinetime-app*.out
 
+        #########################################################################################
+        # Make but don't Upload the Recovery Firmware to be sure it builds correctly
+
+      - name: Make pinetime-recovery
+        run:  |
+          cd build
+          make pinetime-recovery
+
       #########################################################################################
       # Finish
 


### PR DESCRIPTION
The recovery image "it is the last chance before a brick",
as described in https://github.com/InfiniTimeOrg/InfiniTime/issues/742#issuecomment-943665960

So just build it to make sure it doesn't silently break, but don't upload it.