### PR TITLE
Added Trip meter to Steps app

### DIFF
--- a/src/components/motion/MotionController.cpp
+++ b/src/components/motion/MotionController.cpp
@@ -8,7 +8,7 @@ void MotionController::Update(int16_t x, int16_t y, int16_t z, uint32_t nbSteps)
   this->z = z;
   int32_t deltaSteps = nbSteps - this->nbSteps;
   this->nbSteps = nbSteps;
-  if(deltaSteps > 0){
+  if (deltaSteps > 0) {
     currentTripSteps += deltaSteps;
   }
 }
@@ -39,9 +39,15 @@ void MotionController::IsSensorOk(bool isOk) {
   isSensorOk = isOk;
 }
 void MotionController::Init(Pinetime::Drivers::Bma421::DeviceTypes types) {
-  switch(types){
-    case Drivers::Bma421::DeviceTypes::BMA421: this->deviceType = DeviceTypes::BMA421; break;
-    case Drivers::Bma421::DeviceTypes::BMA425: this->deviceType = DeviceTypes::BMA425; break;
-    default: this->deviceType = DeviceTypes::Unknown; break;
+  switch (types) {
+    case Drivers::Bma421::DeviceTypes::BMA421:
+      this->deviceType = DeviceTypes::BMA421;
+      break;
+    case Drivers::Bma421::DeviceTypes::BMA425:
+      this->deviceType = DeviceTypes::BMA425;
+      break;
+    default:
+      this->deviceType = DeviceTypes::Unknown;
+      break;
   }
 }

--- a/src/components/motion/MotionController.cpp
+++ b/src/components/motion/MotionController.cpp
@@ -6,7 +6,7 @@ void MotionController::Update(int16_t x, int16_t y, int16_t z, uint32_t nbSteps)
   this->x = x;
   this->y = y;
   this->z = z;
-  deltaSteps = nbSteps - this->nbSteps;
+  int32_t deltaSteps = nbSteps - this->nbSteps;
   this->nbSteps = nbSteps;
   if(deltaSteps > 0){
     currentTripSteps += deltaSteps;

--- a/src/components/motion/MotionController.cpp
+++ b/src/components/motion/MotionController.cpp
@@ -6,7 +6,11 @@ void MotionController::Update(int16_t x, int16_t y, int16_t z, uint32_t nbSteps)
   this->x = x;
   this->y = y;
   this->z = z;
+  deltaSteps = nbSteps - this->nbSteps;
   this->nbSteps = nbSteps;
+  if(deltaSteps > 0){
+    currentTripSteps += deltaSteps;
+  }
 }
 
 bool MotionController::ShouldWakeUp(bool isSleeping) {

--- a/src/components/motion/MotionController.h
+++ b/src/components/motion/MotionController.h
@@ -7,7 +7,7 @@ namespace Pinetime {
   namespace Controllers {
     class MotionController {
     public:
-      enum class DeviceTypes{
+      enum class DeviceTypes {
         Unknown,
         BMA421,
         BMA425,
@@ -27,7 +27,7 @@ namespace Pinetime {
       uint32_t NbSteps() const {
         return nbSteps;
       }
-    
+
       void ResetTrip() {
         currentTripSteps = 0;
       }

--- a/src/components/motion/MotionController.h
+++ b/src/components/motion/MotionController.h
@@ -27,6 +27,12 @@ namespace Pinetime {
       uint32_t NbSteps() const {
         return nbSteps;
       }
+      void SetPrevTotalSteps(uint32_t steps) {
+        stepsAtLastLap = steps;
+      }
+      uint32_t GetPrevTotalSteps() const {
+        return stepsAtLastLap;
+      }
       bool ShouldWakeUp(bool isSleeping);
 
       void IsSensorOk(bool isOk);
@@ -42,6 +48,7 @@ namespace Pinetime {
 
     private:
       uint32_t nbSteps;
+      uint32_t stepsAtLastLap = 0;
       int16_t x;
       int16_t y;
       int16_t z;

--- a/src/components/motion/MotionController.h
+++ b/src/components/motion/MotionController.h
@@ -27,11 +27,11 @@ namespace Pinetime {
       uint32_t NbSteps() const {
         return nbSteps;
       }
-      void SetPrevTotalSteps(uint32_t steps) {
-        stepsAtLastLap = steps;
+      void SetTripSteps(uint32_t steps) {
+        stepsAtLastTrip = steps;
       }
-      uint32_t GetPrevTotalSteps() const {
-        return stepsAtLastLap;
+      uint32_t GetTripSteps() const {
+        return stepsAtLastTrip;
       }
       bool ShouldWakeUp(bool isSleeping);
 
@@ -48,7 +48,7 @@ namespace Pinetime {
 
     private:
       uint32_t nbSteps;
-      uint32_t stepsAtLastLap = 0;
+      uint32_t stepsAtLastTrip = 0;
       int16_t x;
       int16_t y;
       int16_t z;

--- a/src/components/motion/MotionController.h
+++ b/src/components/motion/MotionController.h
@@ -27,11 +27,12 @@ namespace Pinetime {
       uint32_t NbSteps() const {
         return nbSteps;
       }
-      void SetTripSteps(uint32_t steps) {
-        stepsAtLastTrip = steps;
+    
+      void ResetTrip() {
+        currentTripSteps = 0;
       }
       uint32_t GetTripSteps() const {
-        return stepsAtLastTrip;
+        return currentTripSteps;
       }
       bool ShouldWakeUp(bool isSleeping);
 
@@ -48,7 +49,8 @@ namespace Pinetime {
 
     private:
       uint32_t nbSteps;
-      uint32_t stepsAtLastTrip = 0;
+      int32_t deltaSteps = 0;
+      uint32_t currentTripSteps = 0;
       int16_t x;
       int16_t y;
       int16_t z;

--- a/src/components/motion/MotionController.h
+++ b/src/components/motion/MotionController.h
@@ -49,7 +49,6 @@ namespace Pinetime {
 
     private:
       uint32_t nbSteps;
-      int32_t deltaSteps = 0;
       uint32_t currentTripSteps = 0;
       int16_t x;
       int16_t y;

--- a/src/displayapp/screens/Steps.cpp
+++ b/src/displayapp/screens/Steps.cpp
@@ -54,23 +54,21 @@ Steps::Steps(Pinetime::Applications::DisplayApp* app,
   lv_obj_set_pos(backgroundLabel, 0, 0);
   lv_label_set_text_static(backgroundLabel, "");
 
-  btnTrip = lv_btn_create(lv_scr_act(), nullptr);
-  btnTrip->user_data = this;
-  lv_obj_set_event_cb(btnTrip, lap_event_handler);
-  lv_obj_set_height(btnTrip, 50);
-  lv_obj_set_width(btnTrip, 115);
-  lv_obj_align(btnTrip, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
-  lv_obj_set_style_local_bg_color(btnTrip, LV_BTN_PART_MAIN, LV_STATE_DISABLED, lv_color_hex(0x080808));
-  txtTrip = lv_label_create(btnTrip, nullptr);
-  lv_obj_set_style_local_text_color(btnTrip, LV_BTN_PART_MAIN, LV_STATE_DISABLED, lv_color_hex(0x888888));
-  lv_label_set_text(txtTrip, "Reset");
+  resetBtn = lv_btn_create(lv_scr_act(), nullptr);
+  resetBtn->user_data = this;
+  lv_obj_set_event_cb(resetBtn, lap_event_handler);
+  lv_obj_set_height(resetBtn, 50);
+  lv_obj_set_width(resetBtn, 115);
+  lv_obj_align(resetBtn, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
+  resetButtonLabel = lv_label_create(resetBtn, nullptr);
+  lv_label_set_text(resetButtonLabel, "Reset");
 
   currentTripSteps = motionController.GetTripSteps();
 
-  tripText = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(tripText, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
-  lv_label_set_text_fmt(tripText, "Trip: %5li", currentTripSteps);
-  lv_obj_align(tripText, lstepsGoal, LV_ALIGN_IN_LEFT_MID, 0, 20);
+  tripLabel = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(tripLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
+  lv_label_set_text_fmt(tripLabel, "Trip: %5li", currentTripSteps);
+  lv_obj_align(tripLabel, lstepsGoal, LV_ALIGN_IN_LEFT_MID, 0, 20);
 
   taskRefresh = lv_task_create(RefreshTaskCallback, 100, LV_TASK_PRIO_MID, this);
 }
@@ -88,9 +86,9 @@ void Steps::Refresh() {
   lv_obj_align(lSteps, nullptr, LV_ALIGN_CENTER, 0, -40);
 
   if (currentTripSteps < 100000){
-    lv_label_set_text_fmt(tripText, "Trip: %5li", currentTripSteps);
+    lv_label_set_text_fmt(tripLabel, "Trip: %5li", currentTripSteps);
   } else {
-    lv_label_set_text_fmt(tripText, "Trip: 99999+");
+    lv_label_set_text_fmt(tripLabel, "Trip: 99999+");
   }
   lv_arc_set_value(stepsArc, int16_t(500 * stepsCount / settingsController.GetStepsGoal()));
 }

--- a/src/displayapp/screens/Steps.cpp
+++ b/src/displayapp/screens/Steps.cpp
@@ -65,11 +65,7 @@ Steps::Steps(Pinetime::Applications::DisplayApp* app,
   lv_obj_set_style_local_text_color(btnTrip, LV_BTN_PART_MAIN, LV_STATE_DISABLED, lv_color_hex(0x888888));
   lv_label_set_text(txtTrip, "Reset");
 
-  if(stepsCount >= motionController.GetTripSteps()){
-    currentTripSteps = stepsCount - motionController.GetTripSteps();
-  } else {
-    currentTripSteps = stepsCount + motionController.GetTripSteps();
-  }
+  currentTripSteps = motionController.GetTripSteps();
 
   tripText = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(tripText, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
@@ -86,11 +82,7 @@ Steps::~Steps() {
 
 void Steps::Refresh() {
   stepsCount = motionController.NbSteps();
-  if(stepsCount >= motionController.GetTripSteps()){
-    currentTripSteps = stepsCount - motionController.GetTripSteps();
-  } else {
-    currentTripSteps = stepsCount + motionController.GetTripSteps();
-  }
+  currentTripSteps = motionController.GetTripSteps();
 
   lv_label_set_text_fmt(lSteps, "%li", stepsCount);
   lv_obj_align(lSteps, nullptr, LV_ALIGN_CENTER, 0, -40);
@@ -106,7 +98,7 @@ void Steps::lapBtnEventHandler(lv_event_t event) {
     return;
   }
   stepsCount = motionController.NbSteps();
-  motionController.SetTripSteps(stepsCount);
+  motionController.ResetTrip();
   Refresh();
 }
 

--- a/src/displayapp/screens/Steps.cpp
+++ b/src/displayapp/screens/Steps.cpp
@@ -85,7 +85,7 @@ void Steps::Refresh() {
   lv_label_set_text_fmt(lSteps, "%li", stepsCount);
   lv_obj_align(lSteps, nullptr, LV_ALIGN_CENTER, 0, -40);
 
-  if (currentTripSteps < 100000){
+  if (currentTripSteps < 100000) {
     lv_label_set_text_fmt(tripLabel, "Trip: %5li", currentTripSteps);
   } else {
     lv_label_set_text_fmt(tripLabel, "Trip: 99999+");
@@ -101,4 +101,3 @@ void Steps::lapBtnEventHandler(lv_event_t event) {
   motionController.ResetTrip();
   Refresh();
 }
-

--- a/src/displayapp/screens/Steps.cpp
+++ b/src/displayapp/screens/Steps.cpp
@@ -44,9 +44,9 @@ Steps::Steps(Pinetime::Applications::DisplayApp* app,
 
   lv_obj_t* lstepsGoal = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(lstepsGoal, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_CYAN);
-  lv_label_set_text_fmt(lstepsGoal, "Goal: %lu", settingsController.GetStepsGoal());
+  lv_label_set_text_fmt(lstepsGoal, "Goal: %5lu", settingsController.GetStepsGoal());
   lv_label_set_align(lstepsGoal, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(lstepsGoal, lSteps, LV_ALIGN_OUT_BOTTOM_MID, 0, 30);
+  lv_obj_align(lstepsGoal, lSteps, LV_ALIGN_OUT_BOTTOM_MID, 0, 40);
 
   lv_obj_t* backgroundLabel = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(backgroundLabel, LV_LABEL_LONG_CROP);
@@ -69,8 +69,8 @@ Steps::Steps(Pinetime::Applications::DisplayApp* app,
 
   tripText = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(tripText, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
-  lv_label_set_text_fmt(tripText, "Trip: %li", currentTripSteps);
-  lv_obj_align(tripText, lSteps, LV_ALIGN_OUT_BOTTOM_MID, 0, 50);
+  lv_label_set_text_fmt(tripText, "Trip: %5li", currentTripSteps);
+  lv_obj_align(tripText, lstepsGoal, LV_ALIGN_IN_LEFT_MID, 0, 20);
 
   taskRefresh = lv_task_create(RefreshTaskCallback, 100, LV_TASK_PRIO_MID, this);
 }
@@ -87,9 +87,11 @@ void Steps::Refresh() {
   lv_label_set_text_fmt(lSteps, "%li", stepsCount);
   lv_obj_align(lSteps, nullptr, LV_ALIGN_CENTER, 0, -40);
 
-  lv_label_set_text_fmt(tripText, "Trip: %li", currentTripSteps);
-  lv_obj_align(tripText, lSteps, LV_ALIGN_OUT_BOTTOM_MID, 0, 50);
-
+  if (currentTripSteps < 100000){
+    lv_label_set_text_fmt(tripText, "Trip: %5li", currentTripSteps);
+  } else {
+    lv_label_set_text_fmt(tripText, "Trip: 99999+");
+  }
   lv_arc_set_value(stepsArc, int16_t(500 * stepsCount / settingsController.GetStepsGoal()));
 }
 

--- a/src/displayapp/screens/Steps.cpp
+++ b/src/displayapp/screens/Steps.cpp
@@ -5,6 +5,11 @@
 
 using namespace Pinetime::Applications::Screens;
 
+static void lap_event_handler(lv_obj_t* obj, lv_event_t event) {
+  auto* steps = static_cast<Steps*>(obj->user_data);
+  steps->lapBtnEventHandler(event);
+}
+
 Steps::Steps(Pinetime::Applications::DisplayApp* app,
              Controllers::MotionController& motionController,
              Controllers::Settings& settingsController)
@@ -17,36 +22,53 @@ Steps::Steps(Pinetime::Applications::DisplayApp* app,
   lv_obj_set_style_local_radius(stepsArc, LV_ARC_PART_BG, LV_STATE_DEFAULT, 0);
   lv_obj_set_style_local_line_color(stepsArc, LV_ARC_PART_INDIC, LV_STATE_DEFAULT, lv_color_hex(0x0000FF));
   lv_arc_set_end_angle(stepsArc, 200);
-  lv_obj_set_size(stepsArc, 220, 220);
+  lv_obj_set_size(stepsArc, 200, 200);
   lv_arc_set_range(stepsArc, 0, 500);
-  lv_obj_align(stepsArc, nullptr, LV_ALIGN_CENTER, 0, 0);
+  lv_obj_align(stepsArc, nullptr, LV_ALIGN_CENTER, 0, -20);
 
   stepsCount = motionController.NbSteps();
+  currentLapSteps = stepsCount - motionController.GetPrevTotalSteps();
 
   lv_arc_set_value(stepsArc, int16_t(500 * stepsCount / settingsController.GetStepsGoal()));
 
   lSteps = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(lSteps, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FF00));
   lv_obj_set_style_local_text_font(lSteps, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
-  lv_label_set_text_fmt(lSteps, "%li", stepsCount);
-  lv_obj_align(lSteps, nullptr, LV_ALIGN_CENTER, 0, -20);
+  lv_label_set_text_fmt(lSteps, "%li", currentLapSteps);
+  lv_obj_align(lSteps, nullptr, LV_ALIGN_CENTER, 0, -40);
 
   lv_obj_t* lstepsL = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(lstepsL, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x111111));
   lv_label_set_text_static(lstepsL, "Steps");
-  lv_obj_align(lstepsL, lSteps, LV_ALIGN_OUT_BOTTOM_MID, 0, 10);
+  lv_obj_align(lstepsL, lSteps, LV_ALIGN_OUT_BOTTOM_MID, 0, 5);
 
   lv_obj_t* lstepsGoal = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(lstepsGoal, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_CYAN);
   lv_label_set_text_fmt(lstepsGoal, "Goal\n%lu", settingsController.GetStepsGoal());
   lv_label_set_align(lstepsGoal, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(lstepsGoal, lSteps, LV_ALIGN_OUT_BOTTOM_MID, 0, 60);
+  lv_obj_align(lstepsGoal, lSteps, LV_ALIGN_OUT_BOTTOM_MID, 0, 30);
 
   lv_obj_t* backgroundLabel = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(backgroundLabel, LV_LABEL_LONG_CROP);
   lv_obj_set_size(backgroundLabel, 240, 240);
   lv_obj_set_pos(backgroundLabel, 0, 0);
   lv_label_set_text_static(backgroundLabel, "");
+
+  btnLap = lv_btn_create(lv_scr_act(), nullptr);
+  btnLap->user_data = this;
+  lv_obj_set_event_cb(btnLap, lap_event_handler);
+  lv_obj_set_height(btnLap, 50);
+  lv_obj_set_width(btnLap, 115);
+  lv_obj_align(btnLap, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
+  lv_obj_set_style_local_bg_color(btnLap, LV_BTN_PART_MAIN, LV_STATE_DISABLED, lv_color_hex(0x080808));
+  txtLap = lv_label_create(btnLap, nullptr);
+  lv_obj_set_style_local_text_color(btnLap, LV_BTN_PART_MAIN, LV_STATE_DISABLED, lv_color_hex(0x888888));
+  lv_label_set_text(txtLap, Symbols::lapsFlag);
+
+  totalStepsText = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(totalStepsText, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
+  lv_label_set_text_fmt(totalStepsText, "Total\n%li", motionController.GetPrevTotalSteps());
+  lv_obj_align(totalStepsText, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
 
   taskRefresh = lv_task_create(RefreshTaskCallback, 100, LV_TASK_PRIO_MID, this);
 }
@@ -58,9 +80,23 @@ Steps::~Steps() {
 
 void Steps::Refresh() {
   stepsCount = motionController.NbSteps();
+  currentLapSteps = stepsCount - motionController.GetPrevTotalSteps();
 
-  lv_label_set_text_fmt(lSteps, "%li", stepsCount);
-  lv_obj_align(lSteps, nullptr, LV_ALIGN_CENTER, 0, -20);
+  lv_label_set_text_fmt(lSteps, "%li", currentLapSteps);
+  lv_obj_align(lSteps, nullptr, LV_ALIGN_CENTER, 0, -40);
+
+  lv_label_set_text_fmt(totalStepsText, "Total\n%li", stepsCount);
+  lv_obj_align(totalStepsText, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
 
   lv_arc_set_value(stepsArc, int16_t(500 * stepsCount / settingsController.GetStepsGoal()));
 }
+
+void Steps::lapBtnEventHandler(lv_event_t event) {
+  if (event != LV_EVENT_CLICKED) {
+    return;
+  }
+  stepsCount = motionController.NbSteps();
+  motionController.SetPrevTotalSteps(stepsCount);
+  Refresh();
+}
+

--- a/src/displayapp/screens/Steps.h
+++ b/src/displayapp/screens/Steps.h
@@ -26,14 +26,14 @@ namespace Pinetime {
         Controllers::MotionController& motionController;
         Controllers::Settings& settingsController;
 
-        uint32_t currentLapSteps = 0;
+        uint32_t currentTripSteps = 0;
 
         lv_obj_t* lSteps;
         lv_obj_t* lStepsIcon;
         lv_obj_t* stepsArc;
-        lv_obj_t* btnLap;
-        lv_obj_t* txtLap;
-        lv_obj_t* totalStepsText;
+        lv_obj_t* btnTrip;
+        lv_obj_t* txtTrip;
+        lv_obj_t* tripText;
 
         uint32_t stepsCount;
 

--- a/src/displayapp/screens/Steps.h
+++ b/src/displayapp/screens/Steps.h
@@ -20,14 +20,20 @@ namespace Pinetime {
         ~Steps() override;
 
         void Refresh() override;
+        void lapBtnEventHandler(lv_event_t event);
 
       private:
         Controllers::MotionController& motionController;
         Controllers::Settings& settingsController;
 
+        uint32_t currentLapSteps = 0;
+
         lv_obj_t* lSteps;
         lv_obj_t* lStepsIcon;
         lv_obj_t* stepsArc;
+        lv_obj_t* btnLap;
+        lv_obj_t* txtLap;
+        lv_obj_t* totalStepsText;
 
         uint32_t stepsCount;
 

--- a/src/displayapp/screens/Steps.h
+++ b/src/displayapp/screens/Steps.h
@@ -31,9 +31,9 @@ namespace Pinetime {
         lv_obj_t* lSteps;
         lv_obj_t* lStepsIcon;
         lv_obj_t* stepsArc;
-        lv_obj_t* btnTrip;
-        lv_obj_t* txtTrip;
-        lv_obj_t* tripText;
+        lv_obj_t* resetBtn;
+        lv_obj_t* resetButtonLabel;
+        lv_obj_t* tripLabel;
 
         uint32_t stepsCount;
 


### PR DESCRIPTION
Fixes #694 

- Added a lap button (similar to the lap button in Stopwatch) to reset the step counter.
- Added a total step count in that does not get reset in the bottom right corner.
- Moved/shrank existing Steps UI to fit the new button and total step count
- Added a variable to MotionController to save the steps since the last lap.

Note that using the lap button does not reset the progress to the daily step goal. The progress bar uses the total step count.

The image below demos the new button after fresh boot with (1) 0 steps, (2) the watch after taking some steps (step count and total updated and equal), (3) pressing the lap button (step count reset, no change to total), and (4) after walking again (step count and total updated, but not equal).

![image](https://user-images.githubusercontent.com/10466537/138031131-6ff4be85-5b27-4284-9c45-7e97d2e705cd.png)

I also checked that large step counts do not cause display issues.

![image](https://user-images.githubusercontent.com/10466537/138032311-0af0a4a9-bc5e-461a-a91d-96c0d40c7b5f.png)