### PR TITLE
Add stopwatch setting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -436,6 +436,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/settings/SettingPineTimeStyle.cpp
         displayapp/screens/settings/SettingSetDate.cpp
         displayapp/screens/settings/SettingSetTime.cpp
+        displayapp/screens/settings/SettingStopWatch.cpp
 
         ## Watch faces
         displayapp/icons/bg_clock.c

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -20,6 +20,7 @@ namespace Pinetime {
       enum class Colors : uint8_t {
         White, Silver, Gray, Black, Red, Maroon, Yellow, Olive, Lime, Green, Cyan, Teal, Blue, Navy, Magenta, Purple, Orange
       };
+      enum class StopWatchSleepMode : uint8_t { Enable, Disable };
       struct PineTimeStyle {
         Colors ColorTime = Colors::Teal;
         Colors ColorBar = Colors::Teal;
@@ -160,6 +161,15 @@ namespace Pinetime {
       
       uint32_t GetStepsGoal() const { return settings.stepsGoal; };
 
+      void SetStopWatchSleepMode(StopWatchSleepMode mode) { 
+        if ( mode != settings.stopWatchSleepMode ) {
+          settingsChanged = true;
+        }
+        settings.stopWatchSleepMode = mode; 
+      };
+
+      StopWatchSleepMode GetStopWatchSleepMode() const { return settings.stopWatchSleepMode; };
+
     private:
       Pinetime::Controllers::FS& fs;
 
@@ -179,6 +189,8 @@ namespace Pinetime {
         std::bitset<3> wakeUpMode {0};
 
         Controllers::BrightnessController::Levels brightLevel = Controllers::BrightnessController::Levels::Medium;
+
+        StopWatchSleepMode stopWatchSleepMode = StopWatchSleepMode::Disable;
       };
 
       SettingsData settings;

--- a/src/displayapp/Apps.h
+++ b/src/displayapp/Apps.h
@@ -35,6 +35,7 @@ namespace Pinetime {
       SettingPineTimeStyle,
       SettingSetDate,
       SettingSetTime,
+      SettingStopWatch,
       Error,
     };
   }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -47,6 +47,7 @@
 #include "displayapp/screens/settings/SettingPineTimeStyle.h"
 #include "displayapp/screens/settings/SettingSetDate.h"
 #include "displayapp/screens/settings/SettingSetTime.h"
+#include "displayapp/screens/settings/SettingStopWatch.h"
 
 #include "libs/lv_conf.h"
 
@@ -378,6 +379,10 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       currentScreen = std::make_unique<Screens::SettingSteps>(this, settingsController);
       ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
+    case Apps::SettingStopWatch:
+      currentScreen = std::make_unique<Screens::SettingStopWatch>(this, settingsController);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      break;
     case Apps::SettingSetDate:
       currentScreen = std::make_unique<Screens::SettingSetDate>(this, dateTimeController);
       ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
@@ -404,7 +409,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       ReturnApp(Apps::Clock, FullRefreshDirections::Down, TouchEvents::None);
       break;
     case Apps::StopWatch:
-      currentScreen = std::make_unique<Screens::StopWatch>(this, *systemTask);
+      currentScreen = std::make_unique<Screens::StopWatch>(this, *systemTask, settingsController);
       break;
     case Apps::Twos:
       currentScreen = std::make_unique<Screens::Twos>(this);

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -10,82 +10,90 @@
 #include <array>
 #include "systemtask/SystemTask.h"
 
-namespace Pinetime::Applications::Screens {
+namespace Pinetime {
 
-  enum class States { Init, Running, Halted };
+  namespace Controllers {
+    class Settings;
+  }
 
-  struct TimeSeparated_t {
-    int mins;
-    int secs;
-    int hundredths;
-  };
+  namespace Applications::Screens {
 
-  // A simple buffer to hold the latest two laps
-  template <int N> struct LapTextBuffer_t {
-    LapTextBuffer_t() : buffer {}, currentSize {}, capacity {N}, head {-1} {
-    }
+    enum class States { Init, Running, Halted };
 
-    void addLaps(const TimeSeparated_t& timeVal) {
-      head++;
-      head %= capacity;
-      buffer[head] = timeVal;
+    struct TimeSeparated_t {
+      int mins;
+      int secs;
+      int hundredths;
+    };
 
-      if (currentSize < capacity) {
-        currentSize++;
+    // A simple buffer to hold the latest two laps
+    template <int N> struct LapTextBuffer_t {
+      LapTextBuffer_t() : buffer {}, currentSize {}, capacity {N}, head {-1} {
       }
-    }
 
-    void clearBuffer() {
-      buffer = {};
-      currentSize = 0;
-      head = -1;
-    }
+      void addLaps(const TimeSeparated_t& timeVal) {
+        head++;
+        head %= capacity;
+        buffer[head] = timeVal;
 
-    TimeSeparated_t* operator[](std::size_t idx) {
-      // Sanity check for out-of-bounds
-      if (idx >= 0 && idx < capacity) {
-        if (idx < currentSize) {
-          // This transformation is to ensure that head is always pointing to index 0.
-          const auto transformed_idx = (head - idx) % capacity;
-          return (&buffer[transformed_idx]);
+        if (currentSize < capacity) {
+          currentSize++;
         }
       }
-      return nullptr;
-    }
 
-  private:
-    std::array<TimeSeparated_t, N> buffer;
-    uint8_t currentSize;
-    uint8_t capacity;
-    int8_t head;
-  };
+      void clearBuffer() {
+        buffer = {};
+        currentSize = 0;
+        head = -1;
+      }
 
-  class StopWatch : public Screen {
-  public:
-    StopWatch(DisplayApp* app, System::SystemTask& systemTask);
-    ~StopWatch() override;
-    void Refresh() override;
+      TimeSeparated_t* operator[](std::size_t idx) {
+        // Sanity check for out-of-bounds
+        if (idx >= 0 && idx < capacity) {
+          if (idx < currentSize) {
+            // This transformation is to ensure that head is always pointing to index 0.
+            const auto transformed_idx = (head - idx) % capacity;
+            return (&buffer[transformed_idx]);
+          }
+        }
+        return nullptr;
+      }
 
-    void playPauseBtnEventHandler(lv_event_t event);
-    void stopLapBtnEventHandler(lv_event_t event);
-    bool OnButtonPushed() override;
+    private:
+      std::array<TimeSeparated_t, N> buffer;
+      uint8_t currentSize;
+      uint8_t capacity;
+      int8_t head;
+    };
 
-    void reset();
-    void start();
-    void pause();
+    class StopWatch : public Screen {
+    public:
+      StopWatch(DisplayApp* app, System::SystemTask& systemTask, Controllers::Settings& settingsController);
+      ~StopWatch() override;
+      void Refresh() override;
 
-  private:
-    Pinetime::System::SystemTask& systemTask;
-    TickType_t timeElapsed;
-    States currentState;
-    TickType_t startTime;
-    TickType_t oldTimeElapsed;
-    TimeSeparated_t currentTimeSeparated; // Holds Mins, Secs, millisecs
-    LapTextBuffer_t<2> lapBuffer;
-    int lapNr = 0;
-    lv_obj_t *time, *msecTime, *btnPlayPause, *btnStopLap, *txtPlayPause, *txtStopLap;
-    lv_obj_t *lapOneText, *lapTwoText;
+      void playPauseBtnEventHandler(lv_event_t event);
+      void stopLapBtnEventHandler(lv_event_t event);
+      bool OnButtonPushed() override;
 
-    lv_task_t* taskRefresh;
-  };
+      void reset();
+      void start();
+      void pause();
+
+    private:
+      Pinetime::System::SystemTask& systemTask;
+      Controllers::Settings& settingsController;
+      TickType_t timeElapsed;
+      States currentState;
+      TickType_t startTime;
+      TickType_t oldTimeElapsed;
+      TimeSeparated_t currentTimeSeparated; // Holds Mins, Secs, millisecs
+      LapTextBuffer_t<2> lapBuffer;
+      int lapNr = 0;
+      lv_obj_t *time, *msecTime, *btnPlayPause, *btnStopLap, *txtPlayPause, *txtStopLap;
+      lv_obj_t *lapOneText, *lapTwoText;
+
+      lv_task_t* taskRefresh;
+    };
+  }
 }

--- a/src/displayapp/screens/settings/SettingStopWatch.cpp
+++ b/src/displayapp/screens/settings/SettingStopWatch.cpp
@@ -48,7 +48,7 @@ SettingStopWatch::SettingStopWatch(Pinetime::Applications::DisplayApp* app, Pine
                         "#444444 the stopwatch#\n" 
                         "#444444 is running.#");
   lv_label_set_align(description, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(description, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 40);
+  lv_obj_align(description, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 30);
 
   optionsTotal = 0;
   cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);

--- a/src/displayapp/screens/settings/SettingStopWatch.cpp
+++ b/src/displayapp/screens/settings/SettingStopWatch.cpp
@@ -1,0 +1,97 @@
+#include "SettingStopWatch.h"
+#include <lvgl/lvgl.h>
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  static void event_handler(lv_obj_t* obj, lv_event_t event) {
+    SettingStopWatch* screen = static_cast<SettingStopWatch*>(obj->user_data);
+    screen->UpdateSelected(obj, event);
+  }
+}
+
+SettingStopWatch::SettingStopWatch(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
+  : Screen(app), settingsController {settingsController} {
+
+  lv_obj_t* container1 = lv_cont_create(lv_scr_act(), nullptr);
+
+  lv_obj_set_style_local_bg_opa(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
+  lv_obj_set_style_local_pad_all(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
+  lv_obj_set_style_local_pad_inner(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
+  lv_obj_set_style_local_border_width(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
+
+  lv_obj_set_pos(container1, 10, 150);
+  lv_obj_set_width(container1, LV_HOR_RES - 20);
+  lv_obj_set_height(container1, LV_VER_RES - 50);
+  lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
+
+  lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(title, 
+                            "Stopwatch\n" 
+                            "sleep mode");
+  lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 15, 15);
+
+  lv_obj_t* icon = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(icon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
+  lv_label_set_text_static(icon, Symbols::clock);
+  lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
+
+  lv_obj_t* description = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_recolor(description, true);
+  lv_label_set_text_static(description, 
+                        "#444444 Sleep screen while#\n" 
+                        "#444444 the stopwatch#\n" 
+                        "#444444 is running.#");
+  lv_label_set_align(description, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(description, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 40);
+
+  optionsTotal = 0;
+  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
+  lv_checkbox_set_text_static(cbOption[optionsTotal], " Disable");
+  lv_obj_align(description, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
+  cbOption[optionsTotal]->user_data = this;
+  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
+  if (settingsController.GetStopWatchSleepMode() == Controllers::Settings::StopWatchSleepMode::Disable) {
+    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  }
+
+  optionsTotal++;
+  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
+  lv_checkbox_set_text_static(cbOption[optionsTotal], " Enable");
+  cbOption[optionsTotal]->user_data = this;
+  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
+  if (settingsController.GetStopWatchSleepMode() == Controllers::Settings::StopWatchSleepMode::Enable) {
+    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  }
+  optionsTotal++;
+}
+
+SettingStopWatch::~SettingStopWatch() {
+  lv_obj_clean(lv_scr_act());
+  settingsController.SaveSettings();
+}
+
+void SettingStopWatch::UpdateSelected(lv_obj_t* object, lv_event_t event) {
+  if (event == LV_EVENT_VALUE_CHANGED) {
+    for (int i = 0; i < optionsTotal; i++) {
+      if (object == cbOption[i]) {
+        lv_checkbox_set_checked(cbOption[i], true);
+
+        if (i == 0) {
+          settingsController.SetStopWatchSleepMode(Controllers::Settings::StopWatchSleepMode::Disable);
+        };
+        if (i == 1) {
+          settingsController.SetStopWatchSleepMode(Controllers::Settings::StopWatchSleepMode::Enable);
+        };
+
+      } else {
+        lv_checkbox_set_checked(cbOption[i], false);
+      }
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingStopWatch.cpp
+++ b/src/displayapp/screens/settings/SettingStopWatch.cpp
@@ -23,7 +23,7 @@ SettingStopWatch::SettingStopWatch(Pinetime::Applications::DisplayApp* app, Pine
   lv_obj_set_style_local_pad_inner(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
   lv_obj_set_style_local_border_width(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
 
-  lv_obj_set_pos(container1, 10, 150);
+  lv_obj_set_pos(container1, 10, 140);
   lv_obj_set_width(container1, LV_HOR_RES - 20);
   lv_obj_set_height(container1, LV_VER_RES - 50);
   lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
@@ -48,12 +48,11 @@ SettingStopWatch::SettingStopWatch(Pinetime::Applications::DisplayApp* app, Pine
                         "#444444 the stopwatch#\n" 
                         "#444444 is running.#");
   lv_label_set_align(description, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(description, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 30);
+  lv_obj_align(description, lv_scr_act(), LV_ALIGN_CENTER, 0, -20);
 
   optionsTotal = 0;
   cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
   lv_checkbox_set_text_static(cbOption[optionsTotal], " Disable");
-  lv_obj_align(description, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
   cbOption[optionsTotal]->user_data = this;
   lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
   if (settingsController.GetStopWatchSleepMode() == Controllers::Settings::StopWatchSleepMode::Disable) {

--- a/src/displayapp/screens/settings/SettingStopWatch.h
+++ b/src/displayapp/screens/settings/SettingStopWatch.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+#include <lvgl/lvgl.h>
+#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
+
+namespace Pinetime {
+
+  namespace Applications {
+    namespace Screens {
+
+      class SettingStopWatch : public Screen {
+      public:
+        SettingStopWatch(DisplayApp* app, Pinetime::Controllers::Settings& settingsController);
+        ~SettingStopWatch() override;
+
+        void UpdateSelected(lv_obj_t* object, lv_event_t event);
+
+      private:
+        Controllers::Settings& settingsController;
+        uint8_t optionsTotal;
+        lv_obj_t* cbOption[2];
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -49,9 +49,9 @@ std::unique_ptr<Screen> Settings::CreateScreen2() {
 
   std::array<Screens::List::Applications, 4> applications {{
     {Symbols::shoe, "Steps", Apps::SettingSteps},
+    {Symbols::clock, "Stopwatch", Apps::SettingStopWatch},
     {Symbols::clock, "Set date", Apps::SettingSetDate},
     {Symbols::clock, "Set time", Apps::SettingSetTime},
-    {Symbols::batteryHalf, "Battery", Apps::BatteryInfo}
   }};
 
   return std::make_unique<Screens::List>(1, 3, app, settingsController, applications);
@@ -60,10 +60,10 @@ std::unique_ptr<Screen> Settings::CreateScreen2() {
 std::unique_ptr<Screen> Settings::CreateScreen3() {
 
   std::array<Screens::List::Applications, 4> applications {{
+    {Symbols::batteryHalf, "Battery", Apps::BatteryInfo},
     {Symbols::paintbrush, "PTS Colors", Apps::SettingPineTimeStyle},
     {Symbols::check, "Firmware", Apps::FirmwareValidation},
     {Symbols::list, "About", Apps::SysInfo},
-    {Symbols::none, "None", Apps::None},
   }};
 
   return std::make_unique<Screens::List>(2, 3, app, settingsController, applications);

--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -49,7 +49,7 @@ std::unique_ptr<Screen> Settings::CreateScreen2() {
 
   std::array<Screens::List::Applications, 4> applications {{
     {Symbols::shoe, "Steps", Apps::SettingSteps},
-    {Symbols::clock, "Stopwatch", Apps::SettingStopWatch},
+    {Symbols::stopWatch, "Stopwatch", Apps::SettingStopWatch},
     {Symbols::clock, "Set date", Apps::SettingSetDate},
     {Symbols::clock, "Set time", Apps::SettingSetTime},
   }};


### PR DESCRIPTION
This adds a setting page to control whether the stopwatch screen sleeps or not while the stopwatch is running. 

I am a runner and often use the stopwatch to time workouts. I didn't like how the screen remained on while the stopwatch was running as I do not want to drain the battery, especially on longer runs.

The settings page allows the user to enable or disable the watch from sleeping. It also offers a brief explanation of the setting.

**Demo video** 

https://user-images.githubusercontent.com/22477298/138088529-ce71b03f-0206-4463-b6fd-1269e265df8b.mp4

The instruction positioning on the settings page has been moved up a bit than what is seen on the video. Feel free to change the UI positioning if further tuning is required.