### PR TITLE
Removed the prefix from bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report
-title: "[Bug]: "
 labels: ["bug"]
 body:
   - type: markdown


### PR DESCRIPTION
Removed the prefix from the bug report template as well, because we have labels and those are sufficient for searching and filtering without any of the clutter.