### PR TITLE
Paddle: add a little randomization in the dy speed

### DIFF
--- a/src/displayapp/screens/Paddle.cpp
+++ b/src/displayapp/screens/Paddle.cpp
@@ -2,6 +2,8 @@
 #include "../DisplayApp.h"
 #include "../LittleVgl.h"
 
+#include <cstdlib> // for rand()
+
 using namespace Pinetime::Applications::Screens;
 
 Paddle::Paddle(Pinetime::Applications::DisplayApp* app, Pinetime::Components::LittleVgl& lvgl) : Screen(app), lvgl {lvgl} {
@@ -50,6 +52,13 @@ void Paddle::Refresh() {
   // checks if it has touched the side (right side)
   if (ballX >= LV_HOR_RES - ballSize - 1) {
     dx *= -1;
+    dy += rand() % 3 - 1; // add a little randomization in wall bounce direction, one of [-1, 0, 1]
+    if (dy > 5) { // limit dy to be in range [-5 to 5]
+      dy = 5;
+    }
+    if (dy < -5) {
+      dy = -5;
+    }
   }
 
   // checks if it is in the position of the paddle


### PR DESCRIPTION
To make the game a bit more challenging an less predictable add a little
bit of randomness to the `dy` value. When hitting the right wall add a random
number (one of [-1, 0, 1]) to the `dy` value.

To keep the difficulty level managable limit the dy value to be in the
range from -5 to 5.

Tested on `lv_simulation` branch #743 not on actual hardware