### PR TITLE
InfiniPaint vibrate on colorchange, fix color rotation

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -410,7 +410,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       currentScreen = std::make_unique<Screens::Twos>(this);
       break;
     case Apps::Paint:
-      currentScreen = std::make_unique<Screens::InfiniPaint>(this, lvgl,motorController);
+      currentScreen = std::make_unique<Screens::InfiniPaint>(this, lvgl, motorController);
       break;
     case Apps::Paddle:
       currentScreen = std::make_unique<Screens::Paddle>(this, lvgl);

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -410,7 +410,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       currentScreen = std::make_unique<Screens::Twos>(this);
       break;
     case Apps::Paint:
-      currentScreen = std::make_unique<Screens::InfiniPaint>(this, lvgl);
+      currentScreen = std::make_unique<Screens::InfiniPaint>(this, lvgl,motorController);
       break;
     case Apps::Paddle:
       currentScreen = std::make_unique<Screens::Paddle>(this, lvgl);

--- a/src/displayapp/screens/InfiniPaint.cpp
+++ b/src/displayapp/screens/InfiniPaint.cpp
@@ -51,7 +51,7 @@ bool InfiniPaint::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
       }
 
       std::fill(b, b + bufferSize, selectColor);
-      motor.RunForDuration(50);
+      motor.RunForDuration(35);
       return true;
     default:
       return true;

--- a/src/displayapp/screens/InfiniPaint.cpp
+++ b/src/displayapp/screens/InfiniPaint.cpp
@@ -4,7 +4,7 @@
 
 using namespace Pinetime::Applications::Screens;
 
-InfiniPaint::InfiniPaint(Pinetime::Applications::DisplayApp* app, Pinetime::Components::LittleVgl& lvgl) : Screen(app), lvgl {lvgl} {
+InfiniPaint::InfiniPaint(Pinetime::Applications::DisplayApp* app, Pinetime::Components::LittleVgl& lvgl, Pinetime::Controllers::MotorController& motor) : Screen(app), lvgl {lvgl}, motor{motor} {
   std::fill(b, b + bufferSize, selectColor);
 }
 
@@ -16,9 +16,6 @@ bool InfiniPaint::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
   switch (event) {
     case Pinetime::Applications::TouchEvents::LongTap:
       switch (color) {
-        case 0:
-          selectColor = LV_COLOR_MAGENTA;
-          break;
         case 1:
           selectColor = LV_COLOR_GREEN;
           break;
@@ -43,11 +40,13 @@ bool InfiniPaint::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
 
         default:
           color = 0;
+          selectColor = LV_COLOR_MAGENTA;
           break;
       }
 
       std::fill(b, b + bufferSize, selectColor);
       color++;
+      motor.RunForDuration(50);
       return true;
     default:
       return true;

--- a/src/displayapp/screens/InfiniPaint.cpp
+++ b/src/displayapp/screens/InfiniPaint.cpp
@@ -4,7 +4,10 @@
 
 using namespace Pinetime::Applications::Screens;
 
-InfiniPaint::InfiniPaint(Pinetime::Applications::DisplayApp* app, Pinetime::Components::LittleVgl& lvgl, Pinetime::Controllers::MotorController& motor) : Screen(app), lvgl {lvgl}, motor{motor} {
+InfiniPaint::InfiniPaint(Pinetime::Applications::DisplayApp* app,
+                         Pinetime::Components::LittleVgl& lvgl,
+                         Pinetime::Controllers::MotorController& motor)
+  : Screen(app), lvgl {lvgl}, motor {motor} {
   std::fill(b, b + bufferSize, selectColor);
 }
 
@@ -15,7 +18,11 @@ InfiniPaint::~InfiniPaint() {
 bool InfiniPaint::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
   switch (event) {
     case Pinetime::Applications::TouchEvents::LongTap:
+      color = (color + 1) % 8;
       switch (color) {
+        case 0:
+          selectColor = LV_COLOR_MAGENTA;
+          break;
         case 1:
           selectColor = LV_COLOR_GREEN;
           break;
@@ -40,12 +47,10 @@ bool InfiniPaint::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
 
         default:
           color = 0;
-          selectColor = LV_COLOR_MAGENTA;
           break;
       }
 
       std::fill(b, b + bufferSize, selectColor);
-      color++;
       motor.RunForDuration(50);
       return true;
     default:

--- a/src/displayapp/screens/InfiniPaint.h
+++ b/src/displayapp/screens/InfiniPaint.h
@@ -3,6 +3,7 @@
 #include <lvgl/lvgl.h>
 #include <cstdint>
 #include "Screen.h"
+#include "components/motor/MotorController.h"
 
 namespace Pinetime {
   namespace Components {
@@ -13,7 +14,7 @@ namespace Pinetime {
 
       class InfiniPaint : public Screen {
       public:
-        InfiniPaint(DisplayApp* app, Pinetime::Components::LittleVgl& lvgl);
+        InfiniPaint(DisplayApp* app, Pinetime::Components::LittleVgl& lvgl, Controllers::MotorController& motor);
 
         ~InfiniPaint() override;
 
@@ -23,12 +24,13 @@ namespace Pinetime {
 
       private:
         Pinetime::Components::LittleVgl& lvgl;
+        Controllers::MotorController& motor;
         static constexpr uint16_t width = 10;
         static constexpr uint16_t height = 10;
         static constexpr uint16_t bufferSize = width * height;
         lv_color_t b[bufferSize];
         lv_color_t selectColor = LV_COLOR_WHITE;
-        uint8_t color = 2;
+        uint8_t color = 3;
       };
     }
   }

--- a/src/displayapp/screens/InfiniPaint.h
+++ b/src/displayapp/screens/InfiniPaint.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <lvgl/lvgl.h>
-#include <cstdint>
 #include "Screen.h"
 #include "components/motor/MotorController.h"
+#include <cstdint>
+#include <lvgl/lvgl.h>
 
 namespace Pinetime {
   namespace Components {
@@ -30,7 +30,7 @@ namespace Pinetime {
         static constexpr uint16_t bufferSize = width * height;
         lv_color_t b[bufferSize];
         lv_color_t selectColor = LV_COLOR_WHITE;
-        uint8_t color = 3;
+        uint8_t color = 2;
       };
     }
   }


### PR DESCRIPTION
This is a very simple pull requests that changes the Paint app in order to vibrate on color change (because It's hard to know if the touch controller actually registered a long press or a small swipe). I also fixed the logic for the color rotation. Before, the color magenta was unreachable and instead black was chosen a second time. The `color`  variable was changed to initialize to 3 instead of 2, so you don't have to press twice on the first rotation.

- [x] the changes were successfully tested on hardware and showed no problems.