### PR TITLE
Non-relative includes, restructure, add missing includes

### DIFF
--- a/doc/contribute.md
+++ b/doc/contribute.md
@@ -94,6 +94,7 @@ If there are no preconfigured rules for your IDE, you can use one of the existin
  - **Includes** :
     - files from the project : `#include "relative/path/to/the/file.h"`
     - external files and std : `#include <file.h>`
+    - use includes relative to included directories like `src`, not relative to the current file. Don't do: `#include "../file.h"`
  - Only use [primary spellings for operators and tokens](https://en.cppreference.com/w/cpp/language/operator_alternative)
  - Use auto sparingly. Don't use auto for [fundamental/built-in types](https://en.cppreference.com/w/cpp/language/types) and [fixed width integer types](https://en.cppreference.com/w/cpp/types/integer), except when initializing with a cast to avoid duplicating the type name.
  - Examples:

--- a/src/BootloaderVersion.h
+++ b/src/BootloaderVersion.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <cstddef>
+
 namespace Pinetime {
   class BootloaderVersion {
   public:

--- a/src/Version.h.in
+++ b/src/Version.h.in
@@ -2,6 +2,8 @@
 
 @VERSION_EDIT_WARNING@
 
+#include <cstdint>
+
 namespace Pinetime {
   class Version {
     public:

--- a/src/components/alarm/AlarmController.cpp
+++ b/src/components/alarm/AlarmController.cpp
@@ -15,7 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include "AlarmController.h"
+#include "components/alarm/AlarmController.h"
 #include "systemtask/SystemTask.h"
 #include "app_timer.h"
 #include "task.h"

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -1,4 +1,4 @@
-#include "BatteryController.h"
+#include "components/battery/BatteryController.h"
 #include "drivers/PinMap.h"
 #include <hal/nrf_gpio.h>
 #include <nrfx_saadc.h>

--- a/src/components/ble/AlertNotificationClient.cpp
+++ b/src/components/ble/AlertNotificationClient.cpp
@@ -1,6 +1,6 @@
-#include "AlertNotificationClient.h"
+#include "components/ble/AlertNotificationClient.h"
 #include <algorithm>
-#include "NotificationManager.h"
+#include "components/ble/NotificationManager.h"
 #include "systemtask/SystemTask.h"
 
 using namespace Pinetime::Controllers;

--- a/src/components/ble/AlertNotificationClient.h
+++ b/src/components/ble/AlertNotificationClient.h
@@ -7,7 +7,7 @@
 #include <host/ble_gap.h>
 #undef max
 #undef min
-#include "BleClient.h"
+#include "components/ble/BleClient.h"
 
 namespace Pinetime {
 

--- a/src/components/ble/AlertNotificationService.cpp
+++ b/src/components/ble/AlertNotificationService.cpp
@@ -1,8 +1,8 @@
-#include "AlertNotificationService.h"
+#include "components/ble/AlertNotificationService.h"
 #include <hal/nrf_rtc.h>
 #include <cstring>
 #include <algorithm>
-#include "NotificationManager.h"
+#include "components/ble/NotificationManager.h"
 #include "systemtask/SystemTask.h"
 
 using namespace Pinetime::Controllers;

--- a/src/components/ble/BatteryInformationService.cpp
+++ b/src/components/ble/BatteryInformationService.cpp
@@ -1,5 +1,5 @@
-#include <nrf_log.h>
 #include "components/ble/BatteryInformationService.h"
+#include <nrf_log.h>
 #include "components/battery/BatteryController.h"
 
 using namespace Pinetime::Controllers;

--- a/src/components/ble/BatteryInformationService.cpp
+++ b/src/components/ble/BatteryInformationService.cpp
@@ -1,5 +1,5 @@
 #include <nrf_log.h>
-#include "BatteryInformationService.h"
+#include "components/ble/BatteryInformationService.h"
 #include "components/battery/BatteryController.h"
 
 using namespace Pinetime::Controllers;

--- a/src/components/ble/BleController.cpp
+++ b/src/components/ble/BleController.cpp
@@ -1,4 +1,4 @@
-#include "BleController.h"
+#include "components/ble/BleController.h"
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/ble/CurrentTimeClient.cpp
+++ b/src/components/ble/CurrentTimeClient.cpp
@@ -1,4 +1,4 @@
-#include "CurrentTimeClient.h"
+#include "components/ble/CurrentTimeClient.h"
 #include <hal/nrf_rtc.h>
 #include <nrf_log.h>
 #include "components/datetime/DateTimeController.h"

--- a/src/components/ble/CurrentTimeClient.h
+++ b/src/components/ble/CurrentTimeClient.h
@@ -5,7 +5,7 @@
 #undef max
 #undef min
 #include <cstdint>
-#include "BleClient.h"
+#include "components/ble/BleClient.h"
 
 namespace Pinetime {
   namespace Controllers {

--- a/src/components/ble/CurrentTimeService.cpp
+++ b/src/components/ble/CurrentTimeService.cpp
@@ -1,4 +1,4 @@
-#include "CurrentTimeService.h"
+#include "components/ble/CurrentTimeService.h"
 #include <hal/nrf_rtc.h>
 #include <nrf_log.h>
 

--- a/src/components/ble/DeviceInformationService.cpp
+++ b/src/components/ble/DeviceInformationService.cpp
@@ -1,4 +1,4 @@
-#include "DeviceInformationService.h"
+#include "components/ble/DeviceInformationService.h"
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/ble/DeviceInformationService.h
+++ b/src/components/ble/DeviceInformationService.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #define min // workaround: nimble's min/max macros conflict with libstdc++
 #define max
 #include <host/ble_gap.h>

--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -1,4 +1,4 @@
-#include "DfuService.h"
+#include "components/ble/DfuService.h"
 #include <cstring>
 #include "components/ble/BleController.h"
 #include "drivers/SpiNorFlash.h"

--- a/src/components/ble/HeartRateService.cpp
+++ b/src/components/ble/HeartRateService.cpp
@@ -1,4 +1,4 @@
-#include "HeartRateService.h"
+#include "components/ble/HeartRateService.h"
 #include "components/heartrate/HeartRateController.h"
 #include "systemtask/SystemTask.h"
 

--- a/src/components/ble/ImmediateAlertService.cpp
+++ b/src/components/ble/ImmediateAlertService.cpp
@@ -1,6 +1,6 @@
-#include "ImmediateAlertService.h"
+#include "components/ble/ImmediateAlertService.h"
 #include <cstring>
-#include "NotificationManager.h"
+#include "components/ble/NotificationManager.h"
 #include "systemtask/SystemTask.h"
 
 using namespace Pinetime::Controllers;

--- a/src/components/ble/MotionService.cpp
+++ b/src/components/ble/MotionService.cpp
@@ -1,4 +1,4 @@
-#include "MotionService.h"
+#include "components/ble/MotionService.h"
 #include "components/motion//MotionController.h"
 #include "systemtask/SystemTask.h"
 

--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -15,7 +15,7 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include "MusicService.h"
+#include "components/ble/MusicService.h"
 #include "systemtask/SystemTask.h"
 
 namespace {

--- a/src/components/ble/NavigationService.cpp
+++ b/src/components/ble/NavigationService.cpp
@@ -16,7 +16,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "NavigationService.h"
+#include "components/ble/NavigationService.h"
 
 #include "systemtask/SystemTask.h"
 

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -1,4 +1,4 @@
-#include "NimbleController.h"
+#include "components/ble/NimbleController.h"
 #include <hal/nrf_rtc.h>
 #define min // workaround: nimble's min/max macros conflict with libstdc++
 #define max

--- a/src/components/ble/NimbleController.h
+++ b/src/components/ble/NimbleController.h
@@ -7,19 +7,19 @@
 #include <host/ble_gap.h>
 #undef max
 #undef min
-#include "AlertNotificationClient.h"
-#include "AlertNotificationService.h"
-#include "BatteryInformationService.h"
-#include "CurrentTimeClient.h"
-#include "CurrentTimeService.h"
-#include "DeviceInformationService.h"
-#include "DfuService.h"
-#include "ImmediateAlertService.h"
-#include "MusicService.h"
-#include "NavigationService.h"
-#include "ServiceDiscovery.h"
-#include "HeartRateService.h"
-#include "MotionService.h"
+#include "components/ble/AlertNotificationClient.h"
+#include "components/ble/AlertNotificationService.h"
+#include "components/ble/BatteryInformationService.h"
+#include "components/ble/CurrentTimeClient.h"
+#include "components/ble/CurrentTimeService.h"
+#include "components/ble/DeviceInformationService.h"
+#include "components/ble/DfuService.h"
+#include "components/ble/ImmediateAlertService.h"
+#include "components/ble/MusicService.h"
+#include "components/ble/NavigationService.h"
+#include "components/ble/ServiceDiscovery.h"
+#include "components/ble/HeartRateService.h"
+#include "components/ble/MotionService.h"
 
 namespace Pinetime {
   namespace Drivers {

--- a/src/components/ble/NotificationManager.cpp
+++ b/src/components/ble/NotificationManager.cpp
@@ -1,4 +1,4 @@
-#include "NotificationManager.h"
+#include "components/ble/NotificationManager.h"
 #include <cstring>
 #include <algorithm>
 

--- a/src/components/ble/ServiceDiscovery.cpp
+++ b/src/components/ble/ServiceDiscovery.cpp
@@ -1,6 +1,6 @@
-#include "ServiceDiscovery.h"
+#include "components/ble/ServiceDiscovery.h"
 #include <libraries/log/nrf_log.h>
-#include "BleClient.h"
+#include "components/ble/BleClient.h"
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/brightness/BrightnessController.cpp
+++ b/src/components/brightness/BrightnessController.cpp
@@ -1,4 +1,4 @@
-#include "BrightnessController.h"
+#include "components/brightness/BrightnessController.h"
 #include <hal/nrf_gpio.h>
 #include "displayapp/screens/Symbols.h"
 #include "drivers/PinMap.h"

--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -1,4 +1,4 @@
-#include "DateTimeController.h"
+#include "components/datetime/DateTimeController.h"
 #include <date/date.h>
 #include <libraries/log/nrf_log.h>
 #include <systemtask/SystemTask.h>

--- a/src/components/firmwarevalidator/FirmwareValidator.cpp
+++ b/src/components/firmwarevalidator/FirmwareValidator.cpp
@@ -1,4 +1,4 @@
-#include "FirmwareValidator.h"
+#include "components/firmwarevalidator/FirmwareValidator.h"
 
 #include <hal/nrf_rtc.h>
 #include "drivers/InternalFlash.h"

--- a/src/components/fs/FS.cpp
+++ b/src/components/fs/FS.cpp
@@ -1,4 +1,4 @@
-#include "FS.h"
+#include "components/fs/FS.h"
 #include <cstring>
 #include <littlefs/lfs.h>
 #include <lvgl/lvgl.h>

--- a/src/components/gfx/Gfx.cpp
+++ b/src/components/gfx/Gfx.cpp
@@ -1,4 +1,4 @@
-#include "Gfx.h"
+#include "components/gfx/Gfx.h"
 #include "drivers/St7789.h"
 using namespace Pinetime::Components;
 

--- a/src/components/heartrate/Biquad.cpp
+++ b/src/components/heartrate/Biquad.cpp
@@ -4,7 +4,7 @@
   C++ port Copyright (C) 2021 Jean-François Milants
 */
 
-#include "Biquad.h"
+#include "components/heartrate/Biquad.h"
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/heartrate/HeartRateController.cpp
+++ b/src/components/heartrate/HeartRateController.cpp
@@ -1,4 +1,4 @@
-#include "HeartRateController.h"
+#include "components/heartrate/HeartRateController.h"
 #include <heartratetask/HeartRateTask.h>
 #include <systemtask/SystemTask.h>
 

--- a/src/components/heartrate/Ppg.cpp
+++ b/src/components/heartrate/Ppg.cpp
@@ -6,7 +6,7 @@
 
 #include <vector>
 #include <nrf_log.h>
-#include "Ppg.h"
+#include "components/heartrate/Ppg.h"
 using namespace Pinetime::Controllers;
 
 /** Original implementation from wasp-os : https://github.com/daniel-thompson/wasp-os/blob/master/wasp/ppg.py */

--- a/src/components/heartrate/Ppg.cpp
+++ b/src/components/heartrate/Ppg.cpp
@@ -4,9 +4,9 @@
   C++ port Copyright (C) 2021 Jean-François Milants
 */
 
+#include "components/heartrate/Ppg.h"
 #include <vector>
 #include <nrf_log.h>
-#include "components/heartrate/Ppg.h"
 using namespace Pinetime::Controllers;
 
 /** Original implementation from wasp-os : https://github.com/daniel-thompson/wasp-os/blob/master/wasp/ppg.py */

--- a/src/components/heartrate/Ppg.h
+++ b/src/components/heartrate/Ppg.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <array>
-#include "Biquad.h"
-#include "Ptagc.h"
+#include "components/heartrate/Biquad.h"
+#include "components/heartrate/Ptagc.h"
 
 namespace Pinetime {
   namespace Controllers {

--- a/src/components/heartrate/Ptagc.cpp
+++ b/src/components/heartrate/Ptagc.cpp
@@ -5,7 +5,7 @@
 */
 
 #include <cmath>
-#include "Ptagc.h"
+#include "components/heartrate/Ptagc.h"
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/heartrate/Ptagc.cpp
+++ b/src/components/heartrate/Ptagc.cpp
@@ -4,8 +4,8 @@
   C++ port Copyright (C) 2021 Jean-François Milants
 */
 
-#include <cmath>
 #include "components/heartrate/Ptagc.h"
+#include <cmath>
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/motion/MotionController.cpp
+++ b/src/components/motion/MotionController.cpp
@@ -1,4 +1,4 @@
-#include "MotionController.h"
+#include "components/motion/MotionController.h"
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/motor/MotorController.cpp
+++ b/src/components/motor/MotorController.cpp
@@ -1,4 +1,4 @@
-#include "MotorController.h"
+#include "components/motor/MotorController.h"
 #include <hal/nrf_gpio.h>
 #include "systemtask/SystemTask.h"
 #include "app_timer.h"

--- a/src/components/rle/RleDecoder.cpp
+++ b/src/components/rle/RleDecoder.cpp
@@ -1,4 +1,4 @@
-#include "RleDecoder.h"
+#include "components/rle/RleDecoder.h"
 
 using namespace Pinetime::Tools;
 

--- a/src/components/settings/Settings.cpp
+++ b/src/components/settings/Settings.cpp
@@ -1,4 +1,4 @@
-#include "Settings.h"
+#include "components/settings/Settings.h"
 #include <cstdlib>
 #include <cstring>
 

--- a/src/components/timer/TimerController.cpp
+++ b/src/components/timer/TimerController.cpp
@@ -2,7 +2,7 @@
 // Created by florian on 16.05.21.
 //
 
-#include "TimerController.h"
+#include "components/timer/TimerController.h"
 #include "systemtask/SystemTask.h"
 #include "app_timer.h"
 #include "task.h"

--- a/src/displayapp/Colors.cpp
+++ b/src/displayapp/Colors.cpp
@@ -1,4 +1,4 @@
-#include "Colors.h"
+#include "displayapp/Colors.h"
 
 using namespace Pinetime::Applications;
 using namespace Pinetime::Controllers;

--- a/src/displayapp/Colors.h
+++ b/src/displayapp/Colors.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <lvgl/src/lv_misc/lv_color.h>
-#include <components/settings/Settings.h>
+#include "components/settings/Settings.h"
 
 namespace Pinetime {
   namespace Applications {

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -1,9 +1,9 @@
-#include "DisplayApp.h"
+#include "displayapp/DisplayApp.h"
 #include <libraries/log/nrf_log.h>
-#include <displayapp/screens/HeartRate.h>
-#include <displayapp/screens/Motion.h>
-#include <displayapp/screens/Timer.h>
-#include <displayapp/screens/Alarm.h>
+#include "displayapp/screens/HeartRate.h"
+#include "displayapp/screens/Motion.h"
+#include "displayapp/screens/Timer.h"
+#include "displayapp/screens/Alarm.h"
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
 #include "components/datetime/DateTimeController.h"

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -5,9 +5,9 @@
 #include <task.h>
 #include <memory>
 #include <systemtask/Messages.h>
-#include "Apps.h"
-#include "LittleVgl.h"
-#include "TouchEvents.h"
+#include "displayapp/Apps.h"
+#include "displayapp/LittleVgl.h"
+#include "displayapp/TouchEvents.h"
 #include "components/brightness/BrightnessController.h"
 #include "components/motor/MotorController.h"
 #include "components/firmwarevalidator/FirmwareValidator.h"
@@ -17,7 +17,7 @@
 #include "components/alarm/AlarmController.h"
 #include "touchhandler/TouchHandler.h"
 
-#include "Messages.h"
+#include "displayapp/Messages.h"
 #include "BootErrors.h"
 
 namespace Pinetime {

--- a/src/displayapp/DisplayAppRecovery.cpp
+++ b/src/displayapp/DisplayAppRecovery.cpp
@@ -1,9 +1,9 @@
-#include "DisplayAppRecovery.h"
+#include "displayapp/DisplayAppRecovery.h"
 #include <FreeRTOS.h>
 #include <task.h>
 #include <libraries/log/nrf_log.h>
-#include <components/rle/RleDecoder.h>
-#include <touchhandler/TouchHandler.h>
+#include "components/rle/RleDecoder.h"
+#include "touchhandler/TouchHandler.h"
 #include "displayapp/icons/infinitime/infinitime-nb.c"
 #include "components/ble/BleController.h"
 

--- a/src/displayapp/DisplayAppRecovery.h
+++ b/src/displayapp/DisplayAppRecovery.h
@@ -11,10 +11,10 @@
 #include <drivers/Watchdog.h>
 #include <components/motor/MotorController.h>
 #include "BootErrors.h"
-#include "TouchEvents.h"
-#include "Apps.h"
-#include "Messages.h"
-#include "DummyLittleVgl.h"
+#include "displayapp/TouchEvents.h"
+#include "displayapp/Apps.h"
+#include "displayapp/Messages.h"
+#include "displayapp/DummyLittleVgl.h"
 
 namespace Pinetime {
   namespace Drivers {

--- a/src/displayapp/DummyLittleVgl.h
+++ b/src/displayapp/DummyLittleVgl.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <libs/lvgl/src/lv_core/lv_style.h>
-#include <libs/lvgl/src/lv_themes/lv_theme.h>
-#include <libs/lvgl/src/lv_hal/lv_hal.h>
+#include <lvgl/src/lv_core/lv_style.h>
+#include <lvgl/src/lv_themes/lv_theme.h>
+#include <lvgl/src/lv_hal/lv_hal.h>
 #include <drivers/St7789.h>
 #include <drivers/Cst816s.h>
 

--- a/src/displayapp/LittleVgl.cpp
+++ b/src/displayapp/LittleVgl.cpp
@@ -1,5 +1,5 @@
-#include "LittleVgl.h"
-#include "lv_pinetime_theme.h"
+#include "displayapp/LittleVgl.h"
+#include "displayapp/lv_pinetime_theme.h"
 
 #include <FreeRTOS.h>
 #include <task.h>

--- a/src/displayapp/Messages.h
+++ b/src/displayapp/Messages.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 namespace Pinetime {
   namespace Applications {
     namespace Display {

--- a/src/displayapp/lv_pinetime_theme.c
+++ b/src/displayapp/lv_pinetime_theme.c
@@ -6,7 +6,7 @@
 /*********************
  *      INCLUDES
  *********************/
-#include "lv_pinetime_theme.h"
+#include "displayapp/lv_pinetime_theme.h"
 
 /*********************
  *      DEFINES

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -15,9 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include "Alarm.h"
-#include "Screen.h"
-#include "Symbols.h"
+#include "displayapp/screens/Alarm.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
 
 using namespace Pinetime::Applications::Screens;
 using Pinetime::Controllers::AlarmController;

--- a/src/displayapp/screens/Alarm.h
+++ b/src/displayapp/screens/Alarm.h
@@ -17,9 +17,9 @@
 */
 #pragma once
 
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include "systemtask/SystemTask.h"
-#include "../LittleVgl.h"
+#include "displayapp/LittleVgl.h"
 #include "components/alarm/AlarmController.h"
 
 namespace Pinetime {

--- a/src/displayapp/screens/ApplicationList.cpp
+++ b/src/displayapp/screens/ApplicationList.cpp
@@ -1,10 +1,10 @@
-#include "ApplicationList.h"
+#include "displayapp/screens/ApplicationList.h"
 #include <lvgl/lvgl.h>
 #include <array>
-#include "Symbols.h"
-#include "Tile.h"
+#include "displayapp/screens/Symbols.h"
+#include "displayapp/screens/Tile.h"
 #include "displayapp/Apps.h"
-#include "../DisplayApp.h"
+#include "displayapp/DisplayApp.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -2,8 +2,8 @@
 
 #include <memory>
 
-#include "Screen.h"
-#include "ScreenList.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/ScreenList.h"
 #include "components/datetime/DateTimeController.h"
 #include "components/settings/Settings.h"
 #include "components/battery/BatteryController.h"

--- a/src/displayapp/screens/BatteryIcon.cpp
+++ b/src/displayapp/screens/BatteryIcon.cpp
@@ -1,5 +1,5 @@
-#include <cstdint>
 #include "displayapp/screens/BatteryIcon.h"
+#include <cstdint>
 #include "displayapp/screens/Symbols.h"
 
 using namespace Pinetime::Applications::Screens;

--- a/src/displayapp/screens/BatteryIcon.cpp
+++ b/src/displayapp/screens/BatteryIcon.cpp
@@ -1,6 +1,6 @@
 #include <cstdint>
-#include "BatteryIcon.h"
-#include "Symbols.h"
+#include "displayapp/screens/BatteryIcon.h"
+#include "displayapp/screens/Symbols.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/BatteryIcon.h
+++ b/src/displayapp/screens/BatteryIcon.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 namespace Pinetime {
   namespace Applications {

--- a/src/displayapp/screens/BatteryInfo.cpp
+++ b/src/displayapp/screens/BatteryInfo.cpp
@@ -1,5 +1,5 @@
-#include "BatteryInfo.h"
-#include "../DisplayApp.h"
+#include "displayapp/screens/BatteryInfo.h"
+#include "displayapp/DisplayApp.h"
 #include "components/battery/BatteryController.h"
 
 using namespace Pinetime::Applications::Screens;

--- a/src/displayapp/screens/BatteryInfo.h
+++ b/src/displayapp/screens/BatteryInfo.h
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <FreeRTOS.h>
 #include <timers.h>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include <lvgl/lvgl.h>
 
 namespace Pinetime {

--- a/src/displayapp/screens/BleIcon.cpp
+++ b/src/displayapp/screens/BleIcon.cpp
@@ -1,5 +1,5 @@
-#include "BleIcon.h"
-#include "Symbols.h"
+#include "displayapp/screens/BleIcon.h"
+#include "displayapp/screens/Symbols.h"
 using namespace Pinetime::Applications::Screens;
 
 const char* BleIcon::GetIcon(bool isConnected) {

--- a/src/displayapp/screens/Brightness.cpp
+++ b/src/displayapp/screens/Brightness.cpp
@@ -1,4 +1,4 @@
-#include "Brightness.h"
+#include "displayapp/screens/Brightness.h"
 #include <lvgl/lvgl.h>
 
 using namespace Pinetime::Applications::Screens;

--- a/src/displayapp/screens/Brightness.h
+++ b/src/displayapp/screens/Brightness.h
@@ -2,7 +2,7 @@
 
 #include <lvgl/src/lv_core/lv_obj.h>
 #include <cstdint>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include "components/brightness/BrightnessController.h"
 
 namespace Pinetime {

--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -1,4 +1,4 @@
-#include "Clock.h"
+#include "displayapp/screens/Clock.h"
 
 #include <date/date.h>
 #include <lvgl/lvgl.h>
@@ -6,10 +6,10 @@
 #include "components/motion/MotionController.h"
 #include "components/ble/BleController.h"
 #include "components/ble/NotificationManager.h"
-#include "../DisplayApp.h"
-#include "WatchFaceDigital.h"
-#include "WatchFaceAnalog.h"
-#include "PineTimeStyle.h"
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/WatchFaceDigital.h"
+#include "displayapp/screens/WatchFaceAnalog.h"
+#include "displayapp/screens/PineTimeStyle.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <memory>
 #include <components/heartrate/HeartRateController.h>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include "components/datetime/DateTimeController.h"
 
 namespace Pinetime {

--- a/src/displayapp/screens/DropDownDemo.cpp
+++ b/src/displayapp/screens/DropDownDemo.cpp
@@ -1,7 +1,7 @@
-#include "DropDownDemo.h"
+#include "displayapp/screens/DropDownDemo.h"
 #include <lvgl/lvgl.h>
 #include <libraries/log/nrf_log.h>
-#include "../DisplayApp.h"
+#include "displayapp/DisplayApp.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/DropDownDemo.h
+++ b/src/displayapp/screens/DropDownDemo.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include <lvgl/src/lv_core/lv_obj.h>
 
 namespace Pinetime {

--- a/src/displayapp/screens/Error.cpp
+++ b/src/displayapp/screens/Error.cpp
@@ -1,4 +1,4 @@
-#include "Error.h"
+#include "displayapp/screens/Error.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/Error.h
+++ b/src/displayapp/screens/Error.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include "BootErrors.h"
 #include <lvgl/lvgl.h>
 

--- a/src/displayapp/screens/FirmwareUpdate.cpp
+++ b/src/displayapp/screens/FirmwareUpdate.cpp
@@ -1,7 +1,7 @@
-#include "FirmwareUpdate.h"
+#include "displayapp/screens/FirmwareUpdate.h"
 #include <lvgl/lvgl.h>
 #include "components/ble/BleController.h"
-#include "../DisplayApp.h"
+#include "displayapp/DisplayApp.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/FirmwareUpdate.h
+++ b/src/displayapp/screens/FirmwareUpdate.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include <lvgl/src/lv_core/lv_obj.h>
 #include "FreeRTOS.h"
 

--- a/src/displayapp/screens/FirmwareValidation.cpp
+++ b/src/displayapp/screens/FirmwareValidation.cpp
@@ -1,8 +1,8 @@
-#include "FirmwareValidation.h"
+#include "displayapp/screens/FirmwareValidation.h"
 #include <lvgl/lvgl.h>
 #include "Version.h"
 #include "components/firmwarevalidator/FirmwareValidator.h"
-#include "../DisplayApp.h"
+#include "displayapp/DisplayApp.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/FirmwareValidation.h
+++ b/src/displayapp/screens/FirmwareValidation.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include <lvgl/src/lv_core/lv_obj.h>
 
 namespace Pinetime {

--- a/src/displayapp/screens/FlashLight.cpp
+++ b/src/displayapp/screens/FlashLight.cpp
@@ -1,6 +1,6 @@
-#include "FlashLight.h"
-#include "../DisplayApp.h"
-#include "Symbols.h"
+#include "displayapp/screens/FlashLight.h"
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Symbols.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/FlashLight.h
+++ b/src/displayapp/screens/FlashLight.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include "components/brightness/BrightnessController.h"
 #include "systemtask/SystemTask.h"
 #include <cstdint>

--- a/src/displayapp/screens/HeartRate.cpp
+++ b/src/displayapp/screens/HeartRate.cpp
@@ -1,8 +1,8 @@
-#include <libs/lvgl/lvgl.h>
-#include "HeartRate.h"
+#include <lvgl/lvgl.h>
+#include "displayapp/screens/HeartRate.h"
 #include <components/heartrate/HeartRateController.h>
 
-#include "../DisplayApp.h"
+#include "displayapp/DisplayApp.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/HeartRate.cpp
+++ b/src/displayapp/screens/HeartRate.cpp
@@ -1,5 +1,5 @@
-#include <lvgl/lvgl.h>
 #include "displayapp/screens/HeartRate.h"
+#include <lvgl/lvgl.h>
 #include <components/heartrate/HeartRateController.h>
 
 #include "displayapp/DisplayApp.h"

--- a/src/displayapp/screens/HeartRate.h
+++ b/src/displayapp/screens/HeartRate.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <chrono>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include <bits/unique_ptr.h>
 #include "systemtask/SystemTask.h"
 #include <libs/lvgl/src/lv_core/lv_style.h>

--- a/src/displayapp/screens/HeartRate.h
+++ b/src/displayapp/screens/HeartRate.h
@@ -5,8 +5,8 @@
 #include "displayapp/screens/Screen.h"
 #include <bits/unique_ptr.h>
 #include "systemtask/SystemTask.h"
-#include <libs/lvgl/src/lv_core/lv_style.h>
-#include <libs/lvgl/src/lv_core/lv_obj.h>
+#include <lvgl/src/lv_core/lv_style.h>
+#include <lvgl/src/lv_core/lv_obj.h>
 
 namespace Pinetime {
   namespace Controllers {

--- a/src/displayapp/screens/InfiniPaint.cpp
+++ b/src/displayapp/screens/InfiniPaint.cpp
@@ -1,6 +1,6 @@
-#include "InfiniPaint.h"
-#include "../DisplayApp.h"
-#include "../LittleVgl.h"
+#include "displayapp/screens/InfiniPaint.h"
+#include "displayapp/DisplayApp.h"
+#include "displayapp/LittleVgl.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/InfiniPaint.h
+++ b/src/displayapp/screens/InfiniPaint.h
@@ -2,7 +2,7 @@
 
 #include <lvgl/lvgl.h>
 #include <cstdint>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 
 namespace Pinetime {
   namespace Components {

--- a/src/displayapp/screens/InfiniPaint.h
+++ b/src/displayapp/screens/InfiniPaint.h
@@ -2,6 +2,7 @@
 
 #include <lvgl/lvgl.h>
 #include <cstdint>
+#include <algorithm> // std::fill
 #include "displayapp/screens/Screen.h"
 
 namespace Pinetime {

--- a/src/displayapp/screens/Label.cpp
+++ b/src/displayapp/screens/Label.cpp
@@ -1,4 +1,4 @@
-#include "Label.h"
+#include "displayapp/screens/Label.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/Label.h
+++ b/src/displayapp/screens/Label.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include <lvgl/lvgl.h>
 
 namespace Pinetime {

--- a/src/displayapp/screens/List.cpp
+++ b/src/displayapp/screens/List.cpp
@@ -1,6 +1,6 @@
-#include "List.h"
-#include "../DisplayApp.h"
-#include "Symbols.h"
+#include "displayapp/screens/List.h"
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Symbols.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/List.h
+++ b/src/displayapp/screens/List.h
@@ -3,8 +3,8 @@
 #include <lvgl/lvgl.h>
 #include <cstdint>
 #include <memory>
-#include "Screen.h"
-#include "../Apps.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/Apps.h"
 #include "components/settings/Settings.h"
 
 #define MAXLISTITEMS 4

--- a/src/displayapp/screens/Meter.cpp
+++ b/src/displayapp/screens/Meter.cpp
@@ -1,6 +1,6 @@
-#include "Meter.h"
+#include "displayapp/screens/Meter.h"
 #include <lvgl/lvgl.h>
-#include "../DisplayApp.h"
+#include "displayapp/DisplayApp.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/Meter.h
+++ b/src/displayapp/screens/Meter.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include <lvgl/src/lv_core/lv_style.h>
 #include <lvgl/src/lv_core/lv_obj.h>
 

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -1,5 +1,5 @@
-#include "Metronome.h"
-#include "Symbols.h"
+#include "displayapp/screens/Metronome.h"
+#include "displayapp/screens/Symbols.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/Motion.cpp
+++ b/src/displayapp/screens/Motion.cpp
@@ -1,5 +1,5 @@
-#include <lvgl/lvgl.h>
 #include "displayapp/screens/Motion.h"
+#include <lvgl/lvgl.h>
 #include "displayapp/DisplayApp.h"
 
 using namespace Pinetime::Applications::Screens;

--- a/src/displayapp/screens/Motion.cpp
+++ b/src/displayapp/screens/Motion.cpp
@@ -1,6 +1,6 @@
 #include <libs/lvgl/lvgl.h>
-#include "Motion.h"
-#include "../DisplayApp.h"
+#include "displayapp/screens/Motion.h"
+#include "displayapp/DisplayApp.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/Motion.cpp
+++ b/src/displayapp/screens/Motion.cpp
@@ -1,4 +1,4 @@
-#include <libs/lvgl/lvgl.h>
+#include <lvgl/lvgl.h>
 #include "displayapp/screens/Motion.h"
 #include "displayapp/DisplayApp.h"
 

--- a/src/displayapp/screens/Motion.h
+++ b/src/displayapp/screens/Motion.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <chrono>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include <bits/unique_ptr.h>
 #include <libs/lvgl/src/lv_core/lv_style.h>
 #include <libs/lvgl/src/lv_core/lv_obj.h>

--- a/src/displayapp/screens/Motion.h
+++ b/src/displayapp/screens/Motion.h
@@ -4,8 +4,8 @@
 #include <chrono>
 #include "displayapp/screens/Screen.h"
 #include <bits/unique_ptr.h>
-#include <libs/lvgl/src/lv_core/lv_style.h>
-#include <libs/lvgl/src/lv_core/lv_obj.h>
+#include <lvgl/src/lv_core/lv_style.h>
+#include <lvgl/src/lv_core/lv_obj.h>
 #include <components/motion/MotionController.h>
 
 namespace Pinetime {

--- a/src/displayapp/screens/Music.cpp
+++ b/src/displayapp/screens/Music.cpp
@@ -15,10 +15,10 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include "Music.h"
-#include "Symbols.h"
+#include "displayapp/screens/Music.h"
+#include "displayapp/screens/Symbols.h"
 #include <cstdint>
-#include "../DisplayApp.h"
+#include "displayapp/DisplayApp.h"
 #include "components/ble/MusicService.h"
 #include "displayapp/icons/music/disc.cpp"
 #include "displayapp/icons/music/disc_f_1.cpp"

--- a/src/displayapp/screens/Music.h
+++ b/src/displayapp/screens/Music.h
@@ -20,7 +20,7 @@
 #include <FreeRTOS.h>
 #include <lvgl/src/lv_core/lv_obj.h>
 #include <string>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 
 namespace Pinetime {
   namespace Controllers {

--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -15,9 +15,9 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#include "Navigation.h"
+#include "displayapp/screens/Navigation.h"
 #include <cstdint>
-#include "../DisplayApp.h"
+#include "displayapp/DisplayApp.h"
 #include "components/ble/NavigationService.h"
 
 using namespace Pinetime::Applications::Screens;

--- a/src/displayapp/screens/Navigation.h
+++ b/src/displayapp/screens/Navigation.h
@@ -20,7 +20,7 @@
 #include <FreeRTOS.h>
 #include <lvgl/src/lv_core/lv_obj.h>
 #include <string>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include <array>
 
 namespace Pinetime {

--- a/src/displayapp/screens/NotificationIcon.cpp
+++ b/src/displayapp/screens/NotificationIcon.cpp
@@ -1,5 +1,5 @@
-#include "NotificationIcon.h"
-#include "Symbols.h"
+#include "displayapp/screens/NotificationIcon.h"
+#include "displayapp/screens/Symbols.h"
 using namespace Pinetime::Applications::Screens;
 
 const char* NotificationIcon::GetIcon(bool newNotificationAvailable) {

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -1,8 +1,8 @@
-#include "Notifications.h"
-#include <displayapp/DisplayApp.h>
+#include "displayapp/screens/Notifications.h"
+#include "displayapp/DisplayApp.h"
 #include "components/ble/MusicService.h"
 #include "components/ble/AlertNotificationService.h"
-#include "Symbols.h"
+#include "displayapp/screens/Symbols.h"
 
 using namespace Pinetime::Applications::Screens;
 extern lv_font_t jetbrains_mono_extrabold_compressed;

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -3,7 +3,7 @@
 #include <lvgl/lvgl.h>
 #include <cstdint>
 #include <memory>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include "components/ble/NotificationManager.h"
 #include "components/motor/MotorController.h"
 

--- a/src/displayapp/screens/Paddle.cpp
+++ b/src/displayapp/screens/Paddle.cpp
@@ -1,6 +1,6 @@
-#include "Paddle.h"
-#include "../DisplayApp.h"
-#include "../LittleVgl.h"
+#include "displayapp/screens/Paddle.h"
+#include "displayapp/DisplayApp.h"
+#include "displayapp/LittleVgl.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/Paddle.h
+++ b/src/displayapp/screens/Paddle.h
@@ -2,7 +2,7 @@
 
 #include <lvgl/lvgl.h>
 #include <cstdint>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 
 namespace Pinetime {
   namespace Components {

--- a/src/displayapp/screens/PineTimeStyle.cpp
+++ b/src/displayapp/screens/PineTimeStyle.cpp
@@ -19,21 +19,21 @@
  * Style/layout copied from TimeStyle for Pebble by Dan Tilden (github.com/tilden)
  */
 
-#include "PineTimeStyle.h"
+#include "displayapp/screens/PineTimeStyle.h"
 #include <date/date.h>
 #include <lvgl/lvgl.h>
 #include <cstdio>
 #include <displayapp/Colors.h>
-#include "BatteryIcon.h"
-#include "BleIcon.h"
-#include "NotificationIcon.h"
-#include "Symbols.h"
+#include "displayapp/screens/BatteryIcon.h"
+#include "displayapp/screens/BleIcon.h"
+#include "displayapp/screens/NotificationIcon.h"
+#include "displayapp/screens/Symbols.h"
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
 #include "components/ble/NotificationManager.h"
 #include "components/motion/MotionController.h"
 #include "components/settings/Settings.h"
-#include "../DisplayApp.h"
+#include "displayapp/DisplayApp.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/PineTimeStyle.h
+++ b/src/displayapp/screens/PineTimeStyle.h
@@ -4,8 +4,8 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
-#include "Screen.h"
-#include "ScreenList.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/ScreenList.h"
 #include "components/datetime/DateTimeController.h"
 
 namespace Pinetime {

--- a/src/displayapp/screens/Screen.cpp
+++ b/src/displayapp/screens/Screen.cpp
@@ -1,4 +1,4 @@
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 using namespace Pinetime::Applications::Screens;
 
 void Screen::RefreshTaskCallback(lv_task_t* task) {

--- a/src/displayapp/screens/Screen.h
+++ b/src/displayapp/screens/Screen.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include "../TouchEvents.h"
+#include "displayapp/TouchEvents.h"
 #include <lvgl/lvgl.h>
 
 namespace Pinetime {

--- a/src/displayapp/screens/ScreenList.h
+++ b/src/displayapp/screens/ScreenList.h
@@ -3,8 +3,8 @@
 #include <array>
 #include <functional>
 #include <memory>
-#include "Screen.h"
-#include "../DisplayApp.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/DisplayApp.h"
 
 namespace Pinetime {
   namespace Applications {

--- a/src/displayapp/screens/Steps.cpp
+++ b/src/displayapp/screens/Steps.cpp
@@ -1,7 +1,7 @@
-#include "Steps.h"
+#include "displayapp/screens/Steps.h"
 #include <lvgl/lvgl.h>
-#include "../DisplayApp.h"
-#include "Symbols.h"
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Symbols.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/Steps.h
+++ b/src/displayapp/screens/Steps.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <lvgl/lvgl.h>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include <components/motion/MotionController.h>
 
 namespace Pinetime {

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -1,8 +1,8 @@
 #include "StopWatch.h"
 
-#include "Screen.h"
-#include "Symbols.h"
-#include "lvgl/lvgl.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
+#include <lvgl/lvgl.h>
 #include "projdefs.h"
 #include "FreeRTOSConfig.h"
 #include "task.h"

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include "components/datetime/DateTimeController.h"
-#include "../LittleVgl.h"
+#include "displayapp/LittleVgl.h"
 
 #include "FreeRTOS.h"
 #include "portmacro_cmsis.h"

--- a/src/displayapp/screens/SystemInfo.cpp
+++ b/src/displayapp/screens/SystemInfo.cpp
@@ -1,7 +1,7 @@
-#include "SystemInfo.h"
+#include "displayapp/screens/SystemInfo.h"
 #include <lvgl/lvgl.h>
-#include "../DisplayApp.h"
-#include "Label.h"
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Label.h"
 #include "Version.h"
 #include "BootloaderVersion.h"
 #include "components/battery/BatteryController.h"

--- a/src/displayapp/screens/SystemInfo.h
+++ b/src/displayapp/screens/SystemInfo.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <memory>
-#include "Screen.h"
-#include "ScreenList.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/ScreenList.h"
 
 namespace Pinetime {
   namespace Controllers {

--- a/src/displayapp/screens/Tile.cpp
+++ b/src/displayapp/screens/Tile.cpp
@@ -1,6 +1,6 @@
-#include "Tile.h"
-#include "../DisplayApp.h"
-#include "BatteryIcon.h"
+#include "displayapp/screens/Tile.h"
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/BatteryIcon.h"
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/Tile.h
+++ b/src/displayapp/screens/Tile.h
@@ -3,8 +3,8 @@
 #include <lvgl/lvgl.h>
 #include <cstdint>
 #include <memory>
-#include "Screen.h"
-#include "../Apps.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/Apps.h"
 #include "components/datetime/DateTimeController.h"
 #include "components/settings/Settings.h"
 #include "components/datetime/DateTimeController.h"

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -1,8 +1,8 @@
-#include "Timer.h"
+#include "displayapp/screens/Timer.h"
 
-#include "Screen.h"
-#include "Symbols.h"
-#include "lvgl/lvgl.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
+#include <lvgl/lvgl.h>
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 #include "components/datetime/DateTimeController.h"
 #include "systemtask/SystemTask.h"
-#include "../LittleVgl.h"
+#include "displayapp/LittleVgl.h"
 
 #include "components/timer/TimerController.h"
 

--- a/src/displayapp/screens/Twos.cpp
+++ b/src/displayapp/screens/Twos.cpp
@@ -1,4 +1,4 @@
-#include "Twos.h"
+#include "displayapp/screens/Twos.h"
 #include <array>
 #include <cstdio>
 #include <cstdlib>

--- a/src/displayapp/screens/Twos.h
+++ b/src/displayapp/screens/Twos.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <lvgl/src/lv_core/lv_obj.h>
-#include "Screen.h"
+#include "displayapp/screens/Screen.h"
 
 namespace Pinetime {
   namespace Applications {

--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -1,5 +1,5 @@
-#include <lvgl/lvgl.h>
 #include "displayapp/screens/WatchFaceAnalog.h"
+#include <lvgl/lvgl.h>
 #include "displayapp/screens/BatteryIcon.h"
 #include "displayapp/screens/BleIcon.h"
 #include "displayapp/screens/Symbols.h"

--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -1,4 +1,4 @@
-#include <libs/lvgl/lvgl.h>
+#include <lvgl/lvgl.h>
 #include "displayapp/screens/WatchFaceAnalog.h"
 #include "displayapp/screens/BatteryIcon.h"
 #include "displayapp/screens/BleIcon.h"

--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -1,9 +1,9 @@
 #include <libs/lvgl/lvgl.h>
-#include "WatchFaceAnalog.h"
-#include "BatteryIcon.h"
-#include "BleIcon.h"
-#include "Symbols.h"
-#include "NotificationIcon.h"
+#include "displayapp/screens/WatchFaceAnalog.h"
+#include "displayapp/screens/BatteryIcon.h"
+#include "displayapp/screens/BleIcon.h"
+#include "displayapp/screens/Symbols.h"
+#include "displayapp/screens/NotificationIcon.h"
 
 LV_IMG_DECLARE(bg_clock);
 

--- a/src/displayapp/screens/WatchFaceAnalog.h
+++ b/src/displayapp/screens/WatchFaceAnalog.h
@@ -4,8 +4,8 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
-#include "Screen.h"
-#include "ScreenList.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/ScreenList.h"
 #include "components/datetime/DateTimeController.h"
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -1,12 +1,12 @@
-#include "WatchFaceDigital.h"
+#include "displayapp/screens/WatchFaceDigital.h"
 
 #include <date/date.h>
 #include <lvgl/lvgl.h>
 #include <cstdio>
-#include "BatteryIcon.h"
-#include "BleIcon.h"
-#include "NotificationIcon.h"
-#include "Symbols.h"
+#include "displayapp/screens/BatteryIcon.h"
+#include "displayapp/screens/BleIcon.h"
+#include "displayapp/screens/NotificationIcon.h"
+#include "displayapp/screens/Symbols.h"
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
 #include "components/ble/NotificationManager.h"

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -4,8 +4,8 @@
 #include <chrono>
 #include <cstdint>
 #include <memory>
-#include "Screen.h"
-#include "ScreenList.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/ScreenList.h"
 #include "components/datetime/DateTimeController.h"
 
 namespace Pinetime {

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -1,4 +1,4 @@
-#include "QuickSettings.h"
+#include "displayapp/screens/settings/QuickSettings.h"
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Symbols.h"
 #include "displayapp/screens/BatteryIcon.h"

--- a/src/displayapp/screens/settings/SettingDisplay.cpp
+++ b/src/displayapp/screens/settings/SettingDisplay.cpp
@@ -1,4 +1,4 @@
-#include "SettingDisplay.h"
+#include "displayapp/screens/settings/SettingDisplay.h"
 #include <lvgl/lvgl.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/Messages.h"

--- a/src/displayapp/screens/settings/SettingPineTimeStyle.cpp
+++ b/src/displayapp/screens/settings/SettingPineTimeStyle.cpp
@@ -1,4 +1,4 @@
-#include "SettingPineTimeStyle.h"
+#include "displayapp/screens/settings/SettingPineTimeStyle.h"
 #include <lvgl/lvgl.h>
 #include <displayapp/Colors.h>
 #include "displayapp/DisplayApp.h"

--- a/src/displayapp/screens/settings/SettingSetDate.cpp
+++ b/src/displayapp/screens/settings/SettingSetDate.cpp
@@ -1,4 +1,4 @@
-#include "SettingSetDate.h"
+#include "displayapp/screens/settings/SettingSetDate.h"
 #include <lvgl/lvgl.h>
 #include <hal/nrf_rtc.h>
 #include <nrf_log.h>

--- a/src/displayapp/screens/settings/SettingSetTime.cpp
+++ b/src/displayapp/screens/settings/SettingSetTime.cpp
@@ -1,4 +1,4 @@
-#include "SettingSetTime.h"
+#include "displayapp/screens/settings/SettingSetTime.h"
 #include <lvgl/lvgl.h>
 #include <hal/nrf_rtc.h>
 #include <nrf_log.h>

--- a/src/displayapp/screens/settings/SettingSteps.cpp
+++ b/src/displayapp/screens/settings/SettingSteps.cpp
@@ -1,4 +1,4 @@
-#include "SettingSteps.h"
+#include "displayapp/screens/settings/SettingSteps.h"
 #include <lvgl/lvgl.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Symbols.h"

--- a/src/displayapp/screens/settings/SettingTimeFormat.cpp
+++ b/src/displayapp/screens/settings/SettingTimeFormat.cpp
@@ -1,4 +1,4 @@
-#include "SettingTimeFormat.h"
+#include "displayapp/screens/settings/SettingTimeFormat.h"
 #include <lvgl/lvgl.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Screen.h"

--- a/src/displayapp/screens/settings/SettingWakeUp.cpp
+++ b/src/displayapp/screens/settings/SettingWakeUp.cpp
@@ -1,4 +1,4 @@
-#include "SettingWakeUp.h"
+#include "displayapp/screens/settings/SettingWakeUp.h"
 #include <lvgl/lvgl.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Screen.h"

--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -1,4 +1,4 @@
-#include "SettingWatchFace.h"
+#include "displayapp/screens/settings/SettingWatchFace.h"
 #include <lvgl/lvgl.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Screen.h"

--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -1,4 +1,4 @@
-#include "Settings.h"
+#include "displayapp/screens/settings/Settings.h"
 #include <lvgl/lvgl.h>
 #include <array>
 #include "displayapp/screens/List.h"

--- a/src/drivers/Bma421.cpp
+++ b/src/drivers/Bma421.cpp
@@ -1,6 +1,6 @@
+#include "drivers/Bma421.h"
 #include <libraries/delay/nrf_delay.h>
 #include <libraries/log/nrf_log.h>
-#include "drivers/Bma421.h"
 #include "drivers/TwiMaster.h"
 #include <drivers/Bma421_C/bma423.h>
 

--- a/src/drivers/Bma421.cpp
+++ b/src/drivers/Bma421.cpp
@@ -1,7 +1,7 @@
 #include <libraries/delay/nrf_delay.h>
 #include <libraries/log/nrf_log.h>
-#include "Bma421.h"
-#include "TwiMaster.h"
+#include "drivers/Bma421.h"
+#include "drivers/TwiMaster.h"
 #include <drivers/Bma421_C/bma423.h>
 
 using namespace Pinetime::Drivers;

--- a/src/drivers/Cst816s.cpp
+++ b/src/drivers/Cst816s.cpp
@@ -1,4 +1,4 @@
-#include "Cst816s.h"
+#include "drivers/Cst816s.h"
 #include <FreeRTOS.h>
 #include <legacy/nrf_drv_gpiote.h>
 #include <nrfx_log.h>

--- a/src/drivers/Cst816s.h
+++ b/src/drivers/Cst816s.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "TwiMaster.h"
+#include "drivers/TwiMaster.h"
 
 namespace Pinetime {
   namespace Drivers {

--- a/src/drivers/DebugPins.cpp
+++ b/src/drivers/DebugPins.cpp
@@ -1,4 +1,4 @@
-#include "DebugPins.h"
+#include "drivers/DebugPins.h"
 #include <hal/nrf_gpio.h>
 
 #ifdef USE_DEBUG_PINS

--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -4,9 +4,9 @@
   C++ port Copyright (C) 2021 Jean-François Milants
 */
 
+#include "drivers/Hrs3300.h"
 #include <algorithm>
 #include <nrf_gpio.h>
-#include "drivers/Hrs3300.h"
 
 #include <FreeRTOS.h>
 #include <task.h>

--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -6,7 +6,7 @@
 
 #include <algorithm>
 #include <nrf_gpio.h>
-#include "Hrs3300.h"
+#include "drivers/Hrs3300.h"
 
 #include <FreeRTOS.h>
 #include <task.h>

--- a/src/drivers/Hrs3300.h
+++ b/src/drivers/Hrs3300.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "TwiMaster.h"
+#include "drivers/TwiMaster.h"
 
 namespace Pinetime {
   namespace Drivers {

--- a/src/drivers/InternalFlash.cpp
+++ b/src/drivers/InternalFlash.cpp
@@ -1,4 +1,4 @@
-#include "InternalFlash.h"
+#include "drivers/InternalFlash.h"
 #include <mdk/nrf.h>
 using namespace Pinetime::Drivers;
 

--- a/src/drivers/PinMap.h
+++ b/src/drivers/PinMap.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 namespace Pinetime {
   namespace PinMap {

--- a/src/drivers/Spi.cpp
+++ b/src/drivers/Spi.cpp
@@ -1,4 +1,4 @@
-#include "Spi.h"
+#include "drivers/Spi.h"
 #include <hal/nrf_gpio.h>
 #include <nrfx_log.h>
 

--- a/src/drivers/Spi.h
+++ b/src/drivers/Spi.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <cstddef>
-#include "SpiMaster.h"
+#include "drivers/SpiMaster.h"
 
 namespace Pinetime {
   namespace Drivers {

--- a/src/drivers/SpiMaster.cpp
+++ b/src/drivers/SpiMaster.cpp
@@ -1,4 +1,4 @@
-#include "SpiMaster.h"
+#include "drivers/SpiMaster.h"
 #include <hal/nrf_gpio.h>
 #include <hal/nrf_spim.h>
 #include <nrfx_log.h>

--- a/src/drivers/SpiNorFlash.cpp
+++ b/src/drivers/SpiNorFlash.cpp
@@ -1,8 +1,8 @@
-#include "SpiNorFlash.h"
+#include "drivers/SpiNorFlash.h"
 #include <hal/nrf_gpio.h>
 #include <libraries/delay/nrf_delay.h>
 #include <libraries/log/nrf_log.h>
-#include "Spi.h"
+#include "drivers/Spi.h"
 
 using namespace Pinetime::Drivers;
 

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -1,8 +1,8 @@
-#include "St7789.h"
+#include "drivers/St7789.h"
 #include <hal/nrf_gpio.h>
 #include <libraries/delay/nrf_delay.h>
 #include <nrfx_log.h>
-#include "Spi.h"
+#include "drivers/Spi.h"
 
 using namespace Pinetime::Drivers;
 

--- a/src/drivers/TwiMaster.cpp
+++ b/src/drivers/TwiMaster.cpp
@@ -1,4 +1,4 @@
-#include "TwiMaster.h"
+#include "drivers/TwiMaster.h"
 #include <cstring>
 #include <hal/nrf_gpio.h>
 #include <nrfx_log.h>

--- a/src/drivers/Watchdog.cpp
+++ b/src/drivers/Watchdog.cpp
@@ -1,4 +1,4 @@
-#include "Watchdog.h"
+#include "drivers/Watchdog.h"
 #include <mdk/nrf.h>
 using namespace Pinetime::Drivers;
 

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -1,4 +1,4 @@
-#include "HeartRateTask.h"
+#include "heartratetask/HeartRateTask.h"
 #include <drivers/Hrs3300.h>
 #include <components/heartrate/HeartRateController.h>
 #include <nrf_log.h>

--- a/src/logging/DummyLogger.h
+++ b/src/logging/DummyLogger.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Logger.h"
+#include "logging/Logger.h"
 
 namespace Pinetime {
   namespace Logging {

--- a/src/logging/NrfLogger.cpp
+++ b/src/logging/NrfLogger.cpp
@@ -1,4 +1,4 @@
-#include "NrfLogger.h"
+#include "logging/NrfLogger.h"
 
 #include <libraries/log/nrf_log.h>
 #include <libraries/log/nrf_log_ctrl.h>

--- a/src/logging/NrfLogger.h
+++ b/src/logging/NrfLogger.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "Logger.h"
+#include "logging/Logger.h"
 
 #include <FreeRTOS.h>
 #include <task.h>

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -1,4 +1,4 @@
-#include "SystemTask.h"
+#include "systemtask/SystemTask.h"
 #define min // workaround: nimble's min/max macros conflict with libstdc++
 #define max
 #include <host/ble_gap.h>

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -11,7 +11,7 @@
 #include <drivers/PinMap.h>
 #include <components/motion/MotionController.h>
 
-#include "SystemMonitor.h"
+#include "systemtask/SystemMonitor.h"
 #include "components/battery/BatteryController.h"
 #include "components/ble/NimbleController.h"
 #include "components/ble/NotificationManager.h"
@@ -33,7 +33,7 @@
 #endif
 
 #include "drivers/Watchdog.h"
-#include "Messages.h"
+#include "systemtask/Messages.h"
 
 extern std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> NoInit_BackUpTime;
 namespace Pinetime {

--- a/src/touchhandler/TouchHandler.cpp
+++ b/src/touchhandler/TouchHandler.cpp
@@ -1,4 +1,4 @@
-#include "TouchHandler.h"
+#include "touchhandler/TouchHandler.h"
 
 using namespace Pinetime::Controllers;
 


### PR DESCRIPTION
This is a two-part PR, first use relative includes, and secondly restructure all includes.

The non-relative includes are needed for me in #743 to inject my header-stubs for the simulator and is a more robust coding style for header files

---

First commit message:

Don't use relative imports like `../foo.h` as those depend on the
relative position of both files. Rather than that use imports relative
to the `src` directory, which explicitly is part of the include
directories.

---

Second commit message:

Update the include structure:
- use `#include "foo.h"` for headers from the InfiniTime project (except
  bundled libraries)
- use `#include <foo.h>` for everything else (external libraries or standard
  library)

Change the include order from the most project specific down to the most
generic include. This helps to enforce, that our headers include what
they use. For example if `foo.h` uses `std::array` but forgets the
include. This won't be cought if `main.cpp` includes `<array>` before
`foo.h`.

For example `DeviceInformationService.h` did miss `<stdint>` include for
`uint16_t` and `BootloaderVersion.h` missed `<stddef>` for `size_t`.
As last example `InfiniPaint.cpp` missed include `<algorithm>` for `std::fill`.

The following include order is used:
- project headers
- nimble library
- littlefs library
- date library
- lvgl library
- FreeRTOS library
- nrf5 sdk
- standard libraries

