### PR TITLE
Fix animation when long pressing on screens adjacent to watch face

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -262,7 +262,13 @@ void DisplayApp::Refresh() {
         break;
       case Messages::ButtonLongPressed:
         if (currentApp != Apps::Clock) {
-          LoadApp(Apps::Clock, DisplayApp::FullRefreshDirections::Down);
+          if (currentApp == Apps::Notifications) {
+            LoadApp(Apps::Clock, DisplayApp::FullRefreshDirections::Up);
+          } else if (currentApp == Apps::QuickSettings) {
+            LoadApp(Apps::Clock, DisplayApp::FullRefreshDirections::LeftAnim);
+          } else {
+            LoadApp(Apps::Clock, DisplayApp::FullRefreshDirections::Down);
+          }
         }
         break;
       case Messages::ButtonLongerPressed:


### PR DESCRIPTION
Add extra handling when in adjacent screens to use the most fitting animation.

Fixes #817