### PR TITLE
Status bar displays time in 12 or 24 hour format based on settings

### DIFF
--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -11,6 +11,9 @@ namespace {
   char const* MonthsStringLow[] = {"--", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 }
 
+DateTime::DateTime(Controllers::Settings& settingsController) : settingsController {settingsController} {
+}
+
 void DateTime::SetCurrentTime(std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> t) {
   this->currentDateTime = t;
   UpdateTime(previousSystickCounter); // Update internal state without updating the time
@@ -101,3 +104,23 @@ void DateTime::Register(Pinetime::System::SystemTask* systemTask) {
   this->systemTask = systemTask;
 }
 
+using ClockType = Pinetime::Controllers::Settings::ClockType;
+std::string DateTime::FormattedTime() {
+  // Return time as a string in 12- or 24-hour format
+  char buff[9];
+  if (settingsController.GetClockType() == ClockType::H12) {
+      uint8_t hour12;
+      const char* amPmStr;
+      if (hour < 12) {
+        hour12 = (hour == 0) ? 12 : hour;
+        amPmStr = "AM";
+      } else {
+        hour12 = (hour == 12) ? 12 : hour - 12;
+        amPmStr = "PM";
+      }
+      sprintf(buff, "%i:%02i %s", hour12, minute, amPmStr);
+  } else {
+    sprintf(buff, "%02i:%02i", hour, minute);
+  }
+  return std::string(buff);
+} 

--- a/src/components/datetime/DateTimeController.h
+++ b/src/components/datetime/DateTimeController.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 #include <chrono>
+#include <string>
+#include "components/settings/Settings.h"
 
 namespace Pinetime {
   namespace System {
@@ -10,6 +12,7 @@ namespace Pinetime {
   namespace Controllers {
     class DateTime {
     public:
+      DateTime(Controllers::Settings& settingsController);
       enum class Days : uint8_t { Unknown, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday };
       enum class Months : uint8_t {
         Unknown,
@@ -71,6 +74,7 @@ namespace Pinetime {
 
       void Register(System::SystemTask* systemTask);
       void SetCurrentTime(std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> t);
+      std::string FormattedTime();
 
     private:
       uint16_t year = 0;
@@ -87,6 +91,7 @@ namespace Pinetime {
 
       bool isMidnightAlreadyNotified = false;
       System::SystemTask* systemTask = nullptr;
+      Controllers::Settings& settingsController;
     };
   }
 }

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <cstdint>
 #include <bitset>
-#include "components/datetime/DateTimeController.h"
 #include "components/brightness/BrightnessController.h"
 #include "components/fs/FS.h"
 #include "drivers/Cst816s.h"

--- a/src/displayapp/screens/Tile.cpp
+++ b/src/displayapp/screens/Tile.cpp
@@ -33,7 +33,7 @@ Tile::Tile(uint8_t screenID,
 
   // Time
   label_time = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_fmt(label_time, "%02i:%02i", dateTimeController.Hours(), dateTimeController.Minutes());
+  lv_label_set_text(label_time, dateTimeController.FormattedTime().c_str());
   lv_label_set_align(label_time, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(label_time, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 0);
 
@@ -119,7 +119,7 @@ Tile::~Tile() {
 }
 
 void Tile::UpdateScreen() {
-  lv_label_set_text_fmt(label_time, "%02i:%02i", dateTimeController.Hours(), dateTimeController.Minutes());
+  lv_label_set_text(label_time, dateTimeController.FormattedTime().c_str());
   lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
 }
 

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -35,7 +35,7 @@ QuickSettings::QuickSettings(Pinetime::Applications::DisplayApp* app,
 
   // Time
   label_time = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_fmt(label_time, "%02i:%02i", dateTimeController.Hours(), dateTimeController.Minutes());
+  lv_label_set_text(label_time, dateTimeController.FormattedTime().c_str());
   lv_label_set_align(label_time, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 0, 0);
 
@@ -123,7 +123,7 @@ QuickSettings::~QuickSettings() {
 }
 
 void QuickSettings::UpdateScreen() {
-  lv_label_set_text_fmt(label_time, "%02i:%02i", dateTimeController.Hours(), dateTimeController.Minutes());
+  lv_label_set_text(label_time, dateTimeController.FormattedTime().c_str());
   lv_label_set_text(batteryIcon, BatteryIcon::GetBatteryIcon(batteryController.PercentRemaining()));
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -101,7 +101,11 @@ Pinetime::Controllers::Ble bleController;
 Pinetime::Controllers::HeartRateController heartRateController;
 Pinetime::Applications::HeartRateTask heartRateApp(heartRateSensor, heartRateController);
 
-Pinetime::Controllers::DateTime dateTimeController;
+Pinetime::Controllers::FS fs {spiNorFlash};
+Pinetime::Controllers::Settings settingsController {fs};
+Pinetime::Controllers::MotorController motorController {};
+
+Pinetime::Controllers::DateTime dateTimeController {settingsController};
 Pinetime::Drivers::Watchdog watchdog;
 Pinetime::Drivers::WatchdogView watchdogView(watchdog);
 Pinetime::Controllers::NotificationManager notificationManager;
@@ -110,10 +114,6 @@ Pinetime::Controllers::TimerController timerController;
 Pinetime::Controllers::AlarmController alarmController {dateTimeController};
 Pinetime::Controllers::TouchHandler touchHandler(touchPanel, lvgl);
 Pinetime::Controllers::ButtonHandler buttonHandler;
-
-Pinetime::Controllers::FS fs {spiNorFlash};
-Pinetime::Controllers::Settings settingsController {fs};
-Pinetime::Controllers::MotorController motorController {};
 
 Pinetime::Applications::DisplayApp displayApp(lcd,
                                               lvgl,


### PR DESCRIPTION
This makes the status bar display time in the correct format per the "Time format" setting.

New function is added to DateTime called FormattedTime returns a string with the correct time format, so the caller doesn't need to check the settings directly.

I had to remove one unused include from Settings.h to avoid circular include problems.

This is a scaled-back version of #786 (per @Riksu9000 's suggestion) to fix the time display while thinking about how to handle other changes to the status bar.