### PR TITLE
Adjust systemtask to respect doNotGoToSleep.

### DIFF
--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -279,7 +279,7 @@ void SystemTask::Work() {
         } break;
         case Messages::GoToSleep:
           if (doNotGoToSleep) {
-            return;
+            break;
           }
           isGoingToSleep = true;
           NRF_LOG_INFO("[systemtask] Going to sleep");

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -278,6 +278,9 @@ void SystemTask::Work() {
           }
         } break;
         case Messages::GoToSleep:
+          if (doNotGoToSleep) {
+            return;
+          }
           isGoingToSleep = true;
           NRF_LOG_INFO("[systemtask] Going to sleep");
           xTimerStop(idleTimer, 0);
@@ -497,7 +500,7 @@ void SystemTask::OnTouchEvent() {
 }
 
 void SystemTask::PushMessage(System::Messages msg) {
-  if (msg == Messages::GoToSleep) {
+  if (msg == Messages::GoToSleep && !doNotGoToSleep) {
     isGoingToSleep = true;
   }
 


### PR DESCRIPTION
System task getting a GoToSleep event will not respect doNotGoToSleep and attempt to sleep anyway. 