### PR TITLE
Fix unresponsive touch panel after update to 1.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(pinetime VERSION 1.7.0 LANGUAGES C CXX ASM)
+project(pinetime VERSION 1.7.1 LANGUAGES C CXX ASM)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 14)

--- a/src/drivers/Cst816s.cpp
+++ b/src/drivers/Cst816s.cpp
@@ -32,17 +32,11 @@ bool Cst816S::Init() {
   twiMaster.Read(twiAddress, 0xa7, &dummy, 1);
   vTaskDelay(5);
 
-  static constexpr uint8_t maxRetries = 3;
-  bool isDeviceOk;
-  uint8_t retries = 0;
-  do {
-    isDeviceOk = CheckDeviceIds();
-    retries++;
-  } while (!isDeviceOk && retries < maxRetries);
-
-  if (!isDeviceOk) {
-    return false;
-  }
+  // TODO This function check that the device IDs from the controller are equal to the ones
+  // we expect. However, it seems to return false positive (probably in case of communication issue).
+  // Also, it seems that some users have pinetimes that works correctly but that report different device IDs
+  // Until we know more about this, we'll just read the IDs but not take any action in case they are not 'valid'
+  CheckDeviceIds();
 
   /*
   [2] EnConLR - Continuous operation can slide around


### PR DESCRIPTION
This issue was reported [on twitter](https://twitter.com/meanmicio/status/1459558057655029761?s=20) just after the release of 1.7  the touch panel is completely unresponsive after the update of 1.7. It works fine when reverting to 1.6.
I built a [quick'n'dirty fix for Luis to test](https://github.com/InfiniTimeOrg/InfiniTime/tree/debug-touch-luis). This fix disables all the new checks we added in 1.7 to make the touch driver more reliable : it works!
The chip IDs reported by the chip are `b4.69.2` instead of the expected `b4.0.1`

So, we'll have to investigate why the IDs are different, but, as the touch panel is working fine, I assume this is "normal".

In the meantime, we can release a fix for this issue : when working on 1.7, we added a warning message that would be displayed when unexpected chip IDs were detected for the touchpanel. Before the release, we decided to remove this check as it seemed to yield false positives.
But this last minute change is not complete : the init() function of the driver would return too soon in case of invalid IDs and would not initialize the controller correctly : https://github.com/InfiniTimeOrg/InfiniTime/commit/e9c7ab4cfc82172a07c19a0c4877b4afd11412f8#diff-9d9d5389cf4cc0c3064d0778c604a6c4f06329d64e4c18a54464a7cbba9682d2R43

This PR remove the additional check for the device ID and takes no action in case those IDs are not the one we expected.