### PR TITLE
BatteryInfo: remove unused FreeRTOS.h and timer.h includes

### DIFF
--- a/src/displayapp/screens/BatteryInfo.h
+++ b/src/displayapp/screens/BatteryInfo.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <FreeRTOS.h>
-#include <timers.h>
 #include "Screen.h"
 #include <lvgl/lvgl.h>
 


### PR DESCRIPTION
Those two includes are not used. The project still compiles without them.

Not tested on PineTime, just compiled