### PR TITLE
DateTimeControler: remove unused include

### DIFF
--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -1,6 +1,5 @@
 #include "DateTimeController.h"
 #include <date/date.h>
-#include <libraries/log/nrf_log.h>
 #include <systemtask/SystemTask.h>
 
 using namespace Pinetime::Controllers;


### PR DESCRIPTION
Compiles fine without it. Not tested on PineTime, just compiled