### PR TITLE
[WIP] Add configuration files for Sphinx/ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats: all
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/build-flash-and-debug/index.md
+++ b/docs/build-flash-and-debug/index.md
@@ -1,0 +1,33 @@
+# Build, flash and debug
+## Project branches
+## Versioning
+## Files included in the release notes
+## Build the project
+## Build the documentation
+### Setup
+The documentation is written in Makrdown (.md) files and generated using the Sphinx documentation generator.
+
+First, we need to install Sphinx and its dependencies:
+ - `myst-parser` : add support for markdown files
+ - `sphinx_rtd_theme` : theme from ReadTheDocs
+```
+pip install sphinx
+pip install myst-parser
+pip install sphinx_rtd_theme
+```
+
+### Build the doc
+Run the following command in the folder `docs`
+```
+sphinx-build -b html ./ ./generated
+```
+
+Then display the doc by browsing to `generated/index.html` using your favorite web browser.
+
+## Flash the firmware using OpenOCD and STLinkV2
+## Build the project with Docker
+## Build the project with VSCode
+## Bootloader, OTA and DFU
+## Stub using NRF52-DK
+## Logging with JLink RTT
+## Using files from the releases

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,39 @@
+# Configuration file for the Sphinx documentation builder.
+
+# -- Project information
+
+project = 'InfiniTime'
+copyright = '2021, InfiniTime'
+author = 'InfiniTime'
+
+release = '1.7'
+version = '1.7.1'
+
+# -- General configuration
+
+extensions = [
+    'sphinx.ext.duration',
+    'sphinx.ext.doctest',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.intersphinx',
+    'myst_parser',
+]
+
+source_suffix = ['.md']
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
+}
+intersphinx_disabled_domains = ['std']
+
+templates_path = ['_templates']
+
+# -- Options for HTML output
+
+html_theme = 'sphinx_rtd_theme'
+
+# -- Options for EPUB output
+epub_show_urls = 'footnote'
+

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -1,0 +1,1 @@
+# Credits

--- a/docs/developer-documentation/index.md
+++ b/docs/developer-documentation/index.md
@@ -1,0 +1,6 @@
+# Developer documentation
+## Rough structure of the code
+## How to implement an app
+## Generating the fonts and symbols
+## Creating a stopwatch in PineTime (article)
+## BLE implementation and API

--- a/docs/going-further.md
+++ b/docs/going-further.md
@@ -1,0 +1,5 @@
+# Going further
+* The [PineTime wiki](https://wiki.pine64.org/wiki/PineTime)
+* InfiniTime resources from other people
+  * Videos
+  * Articles

--- a/docs/how-to-contribute.md
+++ b/docs/how-to-contribute.md
@@ -1,0 +1,1 @@
+# How to contribute

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,12 @@
+# InfiniTime
+
+```{toctree}
+what-is-infinitime/index.md
+user-documentation/index.md
+developer-documentation/index.md
+build-flash-and-debug/index.md
+how-to-contribute.md
+going-further.md
+licences.md
+credits.md
+```

--- a/docs/licences.md
+++ b/docs/licences.md
@@ -1,0 +1,1 @@
+# Licences

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+myst-parser

--- a/docs/setup.cfg
+++ b/docs/setup.cfg
@@ -1,0 +1,4 @@
+[options.extras_require]
+docs =
+    sphinx
+    myst-parser

--- a/docs/user-documentation/index.md
+++ b/docs/user-documentation/index.md
@@ -1,0 +1,20 @@
+# User documentation
+## Getting started with InfiniTime
+### Unboxing your PineTime
+### Boot/Reboot/Switch off InfiniTime
+### Setting up date and time
+#### Manually
+#### Using companion apps
+#### Using any Chromium-based web-browser
+#### Using NRFConnectr
+### Companion apps
+### The InfiniTime UI
+## Flash And Upgrade
+### Firmware, bootloader, recovery firmware
+### Upgrading your PineTime
+#### Over-The-Air (OTA)
+#### Using Gadgetbridge
+#### Using Amazfish
+#### Using NRFConnect
+### Using the SWD interface
+## Firmware validation

--- a/docs/what-is-infinitime/index.md
+++ b/docs/what-is-infinitime/index.md
@@ -1,0 +1,7 @@
+# What is InfiniTime
+## Generalities about PineTime
+## InfiniTime goals
+## InfiniTime features - high level
+## InfiniTime history
+### Project history
+### Firmwares history and changelog


### PR DESCRIPTION
Following our discussion in #748, I open this PR to start working on the re-working of the documentation of the project:
 - The documentation (user documentation, developers documentation,...) is stored in this repo
 - It's processed by the documentation generator [Sphinx](https://www.sphinx-doc.org/en/master/) and hosted on [ReadTheDocs](https://readthedocs.org/).
 - The URL https://doc.infinitime.io will point to the documentation on RTD.

I created a [new team *doc-writer*](https://github.com/orgs/InfiniTimeOrg/teams) for contributors that focus on writing and maintaining the documentation of the project. I also invited @ncartron to join the project as the first member of this team