### PR TITLE
Metronome: add missing include for Screen.h

### DIFF
--- a/src/displayapp/screens/Metronome.h
+++ b/src/displayapp/screens/Metronome.h
@@ -2,6 +2,7 @@
 
 #include "systemtask/SystemTask.h"
 #include "components/motor/MotorController.h"
+#include "displayapp/screens/Screen.h"
 
 namespace Pinetime {
   namespace Applications {


### PR DESCRIPTION
Metronome class inherits from Screen, but the `Screen.h` include is missing