### PR TITLE
Settings: remove unused driver include

### DIFF
--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -4,7 +4,6 @@
 #include "components/datetime/DateTimeController.h"
 #include "components/brightness/BrightnessController.h"
 #include "components/fs/FS.h"
-#include "drivers/Cst816s.h"
 
 namespace Pinetime {
   namespace Controllers {


### PR DESCRIPTION
The include for `drivers/Cst816s.h` isn't used in `Settings.h` and `Settings.cpp`

Tested only compiling, not on actual device