### PR TITLE
Settings: more specific read and write mode

### DIFF
--- a/src/components/settings/Settings.cpp
+++ b/src/components/settings/Settings.cpp
@@ -26,7 +26,7 @@ void Settings::LoadSettingsFromFile() {
   SettingsData bufferSettings;
   lfs_file_t settingsFile;
 
-  if ( fs.FileOpen(&settingsFile, "/settings.dat", LFS_O_RDWR | LFS_O_CREAT) != LFS_ERR_OK) {
+  if ( fs.FileOpen(&settingsFile, "/settings.dat", LFS_O_RDONLY) != LFS_ERR_OK) {
     return;
   }
   fs.FileRead(&settingsFile, reinterpret_cast<uint8_t*>(&bufferSettings), sizeof(settings));
@@ -39,7 +39,7 @@ void Settings::LoadSettingsFromFile() {
 void Settings::SaveSettingsToFile() {
   lfs_file_t settingsFile;
 
-  if ( fs.FileOpen(&settingsFile, "/settings.dat", LFS_O_RDWR | LFS_O_CREAT) != LFS_ERR_OK) {
+  if ( fs.FileOpen(&settingsFile, "/settings.dat", LFS_O_WRONLY | LFS_O_CREAT) != LFS_ERR_OK) {
     return;
   }
   fs.FileWrite(&settingsFile, reinterpret_cast<uint8_t*>(&settings), sizeof(settings));


### PR DESCRIPTION
For each filesystem interaction be more specific if we want to read from
the file or write to it.

Doing a non-creating read on the loading of the settings file, otherwise
an empty file could be created, and when reading that empty file for the
initial settings I would expect an error (or random data) when reading.

I found this, trying to create a simulator for the file-access. Maybe I'm not understanding how `littlefs` works, but for me it seems like this should be an issue for the first read of the `settings.dat` file

---

Not tested on an actual device