### PR TITLE
Watchface digital include cleanups

### DIFF
--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -12,6 +12,7 @@
 #include "components/ble/NotificationManager.h"
 #include "components/heartrate/HeartRateController.h"
 #include "components/motion/MotionController.h"
+#include "components/settings/Settings.h"
 using namespace Pinetime::Applications::Screens;
 
 WatchFaceDigital::WatchFaceDigital(DisplayApp* app,

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <memory>
 #include "displayapp/screens/Screen.h"
-#include "displayapp/screens/ScreenList.h"
 #include "components/datetime/DateTimeController.h"
 
 namespace Pinetime {


### PR DESCRIPTION
The header has an extra unused `ScreenList.h` include.

And the `cpp` file needs a `Settings.h` include. The header uses a forward declaration for it, but the `cpp` file needs the real include.