### PR TITLE
Clock: add missing Settings include

### DIFF
--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -6,6 +6,7 @@
 #include "components/motion/MotionController.h"
 #include "components/ble/BleController.h"
 #include "components/ble/NotificationManager.h"
+#include "components/settings/Settings.h"
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/WatchFaceDigital.h"
 #include "displayapp/screens/WatchFaceAnalog.h"


### PR DESCRIPTION
Add missing include in `Clock.cpp` for `Settings.h`. The Settings class
is forward declared in the header file, but it needs to be included in
the cpp file.