### PR TITLE
PineTimeStyle: move down notification icon away from bluetooth icon

### DIFF
--- a/src/displayapp/screens/PineTimeStyle.cpp
+++ b/src/displayapp/screens/PineTimeStyle.cpp
@@ -108,7 +108,7 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
 
   notificationIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
-  lv_obj_align(notificationIcon, sidebar, LV_ALIGN_IN_TOP_MID, 0, 40);
+  lv_obj_align(notificationIcon, sidebar, LV_ALIGN_IN_TOP_MID, 0, 51);
 
   // Calendar icon
   calendarOuter = lv_obj_create(lv_scr_act(), nullptr);


### PR DESCRIPTION
The notification icon and the bluetooth icon overlapped. Move the Notification icon down a bit for better alignment.

up until now the PineTimeStyle looks like this:

![20211202_PineTimeStyle](https://user-images.githubusercontent.com/9076163/144509701-dbdb5ded-2fc3-4301-9464-aab87b1f38cc.png)

With the new notification placement it looks as follows (edit: now pixel perfect)
- Battery - 7px - bluetooth - 7px - notification - 8px - FRI
- Charger - 4px - bluetooth - 7px - notification - 8px - FRI

![2021-12-03 battery 7px 7px 8px](https://user-images.githubusercontent.com/9076163/144640144-2fe3c6cb-797e-4525-abf0-ab55f347f4df.png) ![2021-12-03 charge 4px 7px 8px](https://user-images.githubusercontent.com/9076163/144640264-0e80dc2b-cfd8-4337-a993-d18b5f6e6dad.png)


edit old pictures of first try:

![20211202_PineTimeStyle with fixed notification charging](https://user-images.githubusercontent.com/9076163/144511933-731d4fcb-d06f-4315-955c-11ad64aaa51d.png) ![20211202_PineTimeStyle with fixed notification on battery](https://user-images.githubusercontent.com/9076163/144511712-2dd0e538-4335-429d-a1bb-ed4692f5829d.png)

