### PR TITLE
Fix assertion failure in ButtonHandler

### DIFF
--- a/src/buttonhandler/ButtonHandler.cpp
+++ b/src/buttonhandler/ButtonHandler.cpp
@@ -8,7 +8,7 @@ void ButtonTimerCallback(TimerHandle_t xTimer) {
 }
 
 void ButtonHandler::Init(Pinetime::System::SystemTask* systemTask) {
-  buttonTimer = xTimerCreate("buttonTimer", 0, pdFALSE, systemTask, ButtonTimerCallback);
+  buttonTimer = xTimerCreate("buttonTimer", pdMS_TO_TICKS(200), pdFALSE, systemTask, ButtonTimerCallback);
 }
 
 ButtonActions ButtonHandler::HandleEvent(Events event) {


### PR DESCRIPTION
FreeRTOS says zero is not a valid value for xTimerPeriodInTicks.
Zero value fires an assertion on line 361 in timers.h