### PR TITLE
TouchHandler: remove unused FreeRTOS.h and task.h includes from header

### DIFF
--- a/src/touchhandler/TouchHandler.h
+++ b/src/touchhandler/TouchHandler.h
@@ -1,8 +1,6 @@
 #pragma once
 #include "drivers/Cst816s.h"
 #include "systemtask/SystemTask.h"
-#include <FreeRTOS.h>
-#include <task.h>
 
 namespace Pinetime {
   namespace Components {
@@ -10,9 +8,6 @@ namespace Pinetime {
   }
   namespace Drivers {
     class Cst816S;
-  }
-  namespace System {
-    class SystemTask;
   }
   namespace Controllers {
     class TouchHandler {


### PR DESCRIPTION
FreeRTOS and task.h aren't used in the Header file. Furthermore the
SystemTask forward declaration isn't needed as it isn't used in the
header.