### PR TITLE
bug: turn screen on in recovery

### DIFF
--- a/src/displayapp/DisplayAppRecovery.cpp
+++ b/src/displayapp/DisplayAppRecovery.cpp
@@ -48,6 +48,8 @@ void DisplayApp::Process(void* instance) {
 }
 
 void DisplayApp::InitHw() {
+  brightnessController.Init();
+  brightnessController.Set(Controllers::BrightnessController::Levels::High); // Controllers::BrightnessController::Levels.
   DisplayLogo(colorWhite);
 }
 

--- a/src/displayapp/DisplayAppRecovery.h
+++ b/src/displayapp/DisplayAppRecovery.h
@@ -10,6 +10,7 @@
 #include <date/date.h>
 #include <drivers/Watchdog.h>
 #include <components/motor/MotorController.h>
+#include "components/brightness/BrightnessController.h"
 #include "BootErrors.h"
 #include "displayapp/TouchEvents.h"
 #include "displayapp/Apps.h"
@@ -72,6 +73,7 @@ namespace Pinetime {
       void Refresh();
       Pinetime::Drivers::St7789& lcd;
       Controllers::Ble& bleController;
+      Controllers::BrightnessController brightnessController;
 
       static constexpr uint8_t queueSize = 10;
       static constexpr uint8_t itemSize = 1;


### PR DESCRIPTION
# symptom

When I run the pinetime-recovery image I can't see anything on the
screen, although the device appears to be operating otherwise (shows up
in nRF Connect, transmits RTT logs)

# hypothesis

Brightness is set to  Off

# resolution

Set it to something else