### PR TITLE
FIX: AlarmTriggered fall through to ShowPairingKey

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -215,6 +215,7 @@ void DisplayApp::Refresh() {
         } else {
           LoadApp(Apps::Alarm, DisplayApp::FullRefreshDirections::None);
         }
+        break;
       case Messages::ShowPairingKey:
         LoadApp(Apps::PassKey, DisplayApp::FullRefreshDirections::Up);
         break;


### PR DESCRIPTION
Add missing break statement - AlarmTriggered case falls through to ShowPairingKey case