### PR TITLE
Remove unused bits in Hrs3300::ReadAls, ReadHrs

### DIFF
--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -65,7 +65,7 @@ uint16_t Hrs3300::ReadAls() {
   auto m = ReadRegister(static_cast<uint8_t>(Registers::C1dataM));
   auto h = ReadRegister(static_cast<uint8_t>(Registers::C1dataH));
   auto l = ReadRegister(static_cast<uint8_t>(Registers::C1dataL));
-  return (m << 3) | (h << 11) | (l & 0x07);
+  return (h << 11) | (m << 3) | (l & 0x07);
 }
 
 void Hrs3300::SetGain(uint8_t gain) {

--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -58,14 +58,14 @@ uint16_t Hrs3300::ReadHrs() {
   auto m = ReadRegister(static_cast<uint8_t>(Registers::C0DataM));
   auto h = ReadRegister(static_cast<uint8_t>(Registers::C0DataH));
   auto l = ReadRegister(static_cast<uint8_t>(Registers::C0dataL));
-  return (m << 8) | ((h & 0x0f) << 4) | (l & 0x0f) | ((l & 0x30) << 12);
+  return (m << 8) | ((h & 0x0f) << 4) | (l & 0x0f);
 }
 
 uint16_t Hrs3300::ReadAls() {
   auto m = ReadRegister(static_cast<uint8_t>(Registers::C1dataM));
   auto h = ReadRegister(static_cast<uint8_t>(Registers::C1dataH));
   auto l = ReadRegister(static_cast<uint8_t>(Registers::C1dataL));
-  return (m << 3) | ((h & 0x3f) << 11) | (l & 0x07);
+  return (m << 3) | (h << 11) | (l & 0x07);
 }
 
 void Hrs3300::SetGain(uint8_t gain) {


### PR DESCRIPTION
First, thanks a lot! great work making this and continuing to make it.

(commit message:)
Since both functions `Hrs3300::ReadHrs`, `Hrs3300::ReadAls` return
`uint16_t`:
* removed extra 2 bits (at position 16,17) in HRS, which will be thrown
  out
* removed unneeded checks of garbage bits in ALS, since they too will be
  thrown out.

I have a bit more doubts about the second change (not doing ` & 0x3f `), since while it still does happen, it does not clearly say that the MSB of the H register is trash. (since for the uint16_t all the 3 MSB are trash)