### PR TITLE
Hrs driver changes

### DIFF
--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -58,14 +58,14 @@ uint16_t Hrs3300::ReadHrs() {
   auto m = ReadRegister(static_cast<uint8_t>(Registers::C0DataM));
   auto h = ReadRegister(static_cast<uint8_t>(Registers::C0DataH));
   auto l = ReadRegister(static_cast<uint8_t>(Registers::C0dataL));
-  return (m << 8) | ((h & 0x0f) << 4) | (l & 0x0f) | ((l & 0x30) << 12);
+  return ((l & 0x30) << 12) | (m << 8) | ((h & 0x0f) << 4) | (l & 0x0f);
 }
 
 uint16_t Hrs3300::ReadAls() {
   auto m = ReadRegister(static_cast<uint8_t>(Registers::C1dataM));
   auto h = ReadRegister(static_cast<uint8_t>(Registers::C1dataH));
   auto l = ReadRegister(static_cast<uint8_t>(Registers::C1dataL));
-  return (m << 3) | ((h & 0x3f) << 11) | (l & 0x07);
+  return ((h & 0x3f) << 11) | (m << 3) | (l & 0x07);
 }
 
 void Hrs3300::SetGain(uint8_t gain) {

--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -54,14 +54,14 @@ void Hrs3300::Disable() {
   WriteRegister(static_cast<uint8_t>(Registers::Enable), value);
 }
 
-uint16_t Hrs3300::ReadHrs() {
+uint32_t Hrs3300::ReadHrs() {
   auto m = ReadRegister(static_cast<uint8_t>(Registers::C0DataM));
   auto h = ReadRegister(static_cast<uint8_t>(Registers::C0DataH));
   auto l = ReadRegister(static_cast<uint8_t>(Registers::C0dataL));
   return ((l & 0x30) << 12) | (m << 8) | ((h & 0x0f) << 4) | (l & 0x0f);
 }
 
-uint16_t Hrs3300::ReadAls() {
+uint32_t Hrs3300::ReadAls() {
   auto m = ReadRegister(static_cast<uint8_t>(Registers::C1dataM));
   auto h = ReadRegister(static_cast<uint8_t>(Registers::C1dataH));
   auto l = ReadRegister(static_cast<uint8_t>(Registers::C1dataL));

--- a/src/drivers/Hrs3300.h
+++ b/src/drivers/Hrs3300.h
@@ -30,8 +30,8 @@ namespace Pinetime {
       void Init();
       void Enable();
       void Disable();
-      uint16_t ReadHrs();
-      uint16_t ReadAls();
+      uint32_t ReadHrs();
+      uint32_t ReadAls();
       void SetGain(uint8_t gain);
       void SetDrive(uint8_t drive);
 

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -65,8 +65,7 @@ void HeartRateTask::Work() {
     }
 
     if (measurementStarted) {
-      auto hrs = heartRateSensor.ReadHrs();
-      ppg.Preprocess(hrs);
+      ppg.Preprocess(static_cast<float>(heartRateSensor.ReadHrs()));
       auto bpm = ppg.HeartRate();
 
       if (lastBpm == 0 && bpm == 0)


### PR DESCRIPTION
changed low level driver for HRS3300 to return uint32_t values (since it gives 18 bit values) 
and changed hidden uint16_t to float convert, to a static_cast.

supersedes #875

thanks for all the great work!