### PR TITLE
Optional secure pairing with a passkey

### DIFF
--- a/src/components/ble/BatteryInformationService.cpp
+++ b/src/components/ble/BatteryInformationService.cpp
@@ -17,7 +17,7 @@ BatteryInformationService::BatteryInformationService(Controllers::Battery& batte
     characteristicDefinition {{.uuid = &batteryLevelUuid.u,
                                .access_cb = BatteryInformationServiceCallback,
                                .arg = this,
-                               .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_READ_ENC | BLE_GATT_CHR_F_READ_AUTHEN | BLE_GATT_CHR_F_NOTIFY,
+                               .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
                                .val_handle = &batteryLevelHandle},
                               {0}},
     serviceDefinition {

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -134,9 +134,7 @@ void NimbleController::Init() {
 
   RestoreBond();
 
-  if (!ble_gap_adv_active() && !bleController.IsConnected()) {
-    StartAdvertising();
-  }
+  StartAdvertising();
 }
 
 void NimbleController::StartAdvertising() {
@@ -274,7 +272,7 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
        * display capability only so we only handle the "display" action here.
        *
        * Standards insist that the rand() PRNG be deterministic.
-       * Use the nimble TRNG here since rand() is predictable.
+       * Use the tinycrypt prng here since rand() is predictable.
        */
       NRF_LOG_INFO("Security event : BLE_GAP_EVENT_PASSKEY_ACTION");
       if (event->passkey.params.action == BLE_SM_IOACT_DISP) {

--- a/src/components/ble/NimbleController.h
+++ b/src/components/ble/NimbleController.h
@@ -110,8 +110,8 @@ namespace Pinetime {
       ImmediateAlertService immediateAlertService;
       HeartRateService heartRateService;
       MotionService motionService;
-      ServiceDiscovery serviceDiscovery;
       FSService fsService;
+      ServiceDiscovery serviceDiscovery;
 
       uint8_t addrType;
       uint16_t connectionHandle = BLE_HS_CONN_HANDLE_NONE;


### PR DESCRIPTION
Support passkey pairing when requested by the central.
Also, fixes a comment and a reorder warning introduced by a faulty conflict resolution.