### PR TITLE
Fix build with gcc 10.1 toolchain

### DIFF
--- a/src/components/heartrate/Ppg.h
+++ b/src/components/heartrate/Ppg.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include "components/heartrate/Biquad.h"
 #include "components/heartrate/Ptagc.h"
 


### PR DESCRIPTION
I tried to build InfiniTime with the GCC cross compiler provided by Arch Linux. However the build failed due to [a change in newer versions of libstdc++](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=beb0086f592563ddd2b14444d4e2495b17b1d4bf). The `<array>` header does no longer include the `<cstdint>` and `<cstddef>` headers via the `<stdexcept>` header.

I have not yet tested this change on my hardware as it should be trivial.