### PR TITLE
Improved notification timeout

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -362,12 +362,12 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
 
     case Apps::Notifications:
       currentScreen = std::make_unique<Screens::Notifications>(
-        this, notificationManager, systemTask->nimble().alertService(), motorController, Screens::Notifications::Modes::Normal);
+        this, notificationManager, systemTask->nimble().alertService(), motorController, *systemTask, Screens::Notifications::Modes::Normal);
       ReturnApp(Apps::Clock, FullRefreshDirections::Up, TouchEvents::SwipeUp);
       break;
     case Apps::NotificationsPreview:
       currentScreen = std::make_unique<Screens::Notifications>(
-        this, notificationManager, systemTask->nimble().alertService(), motorController, Screens::Notifications::Modes::Preview);
+        this, notificationManager, systemTask->nimble().alertService(), motorController, *systemTask, Screens::Notifications::Modes::Preview);
       ReturnApp(Apps::Clock, FullRefreshDirections::Up, TouchEvents::SwipeUp);
       break;
     case Apps::Timer:

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <lvgl/lvgl.h>
+#include <FreeRTOS.h>
 #include <cstdint>
 #include <memory>
 #include "displayapp/screens/Screen.h"
 #include "components/ble/NotificationManager.h"
 #include "components/motor/MotorController.h"
+#include "systemtask/SystemTask.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -21,11 +23,13 @@ namespace Pinetime {
                                Pinetime::Controllers::NotificationManager& notificationManager,
                                Pinetime::Controllers::AlertNotificationService& alertNotificationService,
                                Pinetime::Controllers::MotorController& motorController,
+                               System::SystemTask& systemTask,
                                Modes mode);
         ~Notifications() override;
 
         void Refresh() override;
         bool OnTouchEvent(Pinetime::Applications::TouchEvents event) override;
+        void OnPreviewInteraction();
 
         class NotificationItem {
         public:
@@ -62,6 +66,7 @@ namespace Pinetime {
         };
         Pinetime::Controllers::NotificationManager& notificationManager;
         Pinetime::Controllers::AlertNotificationService& alertNotificationService;
+        System::SystemTask& systemTask;
         Modes mode = Modes::Normal;
         std::unique_ptr<NotificationItem> currentItem;
         Controllers::NotificationManager::Notification::Id currentId;
@@ -69,8 +74,9 @@ namespace Pinetime {
 
         lv_point_t timeoutLinePoints[2] {{0, 1}, {239, 1}};
         lv_obj_t* timeoutLine = nullptr;
-        uint32_t timeoutTickCountStart;
-        uint32_t timeoutTickCountEnd;
+        TickType_t timeoutTickCountStart;
+        static const TickType_t timeoutLength = pdMS_TO_TICKS(7000);
+        bool interacted = true;
 
         lv_task_t* taskRefresh;
       };

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -239,6 +239,7 @@ void SystemTask::Work() {
           if (!bleController.IsFirmwareUpdating()) {
             doNotGoToSleep = false;
           }
+          ReloadIdleTimer();
           break;
         case Messages::DisableSleeping:
           doNotGoToSleep = true;


### PR DESCRIPTION
Notification preview now disables sleep, so the preview can be longer than 5s without the display timing out first.
Notification timeout is now set to 7s
Call notification now also uses the preview timeout, so it will stop ringing after 7s.
The timeout can now be cancelled by tapping on the screen.
Added ReloadIdleTimer() to the SystemTask message EnableSleeping to restart the idle timer when there is no user interaction.
Made pressing the call buttons exit the notification screen, like they used to.