### PR TITLE
Fix indev_drv and fs_drv going out of scope, store as member variable

### DIFF
--- a/src/components/fs/FS.cpp
+++ b/src/components/fs/FS.cpp
@@ -181,8 +181,6 @@ namespace {
 }
 
 void FS::LVGLFileSystemInit() {
-
-  lv_fs_drv_t fs_drv;
   lv_fs_drv_init(&fs_drv);
 
   fs_drv.file_size = sizeof(lfs_file_t);

--- a/src/components/fs/FS.h
+++ b/src/components/fs/FS.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include "drivers/SpiNorFlash.h"
 #include <littlefs/lfs.h>
+#include <lvgl/lvgl.h>
 
 namespace Pinetime {
   namespace Controllers {
@@ -67,6 +68,8 @@ namespace Pinetime {
       static constexpr size_t startAddress = 0x0B4000;
       static constexpr size_t size = 0x34C000;
       static constexpr size_t blockSize = 4096;
+
+      lv_fs_drv_t fs_drv;
 
       bool resourcesValid = false;
       const struct lfs_config lfsConfig;

--- a/src/displayapp/LittleVgl.cpp
+++ b/src/displayapp/LittleVgl.cpp
@@ -54,8 +54,6 @@ void LittleVgl::InitDisplay() {
 }
 
 void LittleVgl::InitTouchpad() {
-  lv_indev_drv_t indev_drv;
-
   lv_indev_drv_init(&indev_drv);
   indev_drv.type = LV_INDEV_TYPE_POINTER;
   indev_drv.read_cb = touchpad_read;

--- a/src/displayapp/LittleVgl.h
+++ b/src/displayapp/LittleVgl.h
@@ -38,6 +38,7 @@ namespace Pinetime {
       lv_color_t buf2_1[LV_HOR_RES_MAX * 4];
       lv_color_t buf2_2[LV_HOR_RES_MAX * 4];
 
+      lv_indev_drv_t indev_drv;
       lv_disp_drv_t disp_drv;
       lv_point_t previousClick;
 


### PR DESCRIPTION
The variables fs_drv (FS.h) and indev_drv (LittleVgl.h) are going out of
scope after the init.

Store them as member variables to keep them alive.

Originally found by @Quantum-cross in lvgl8 porting branch. Cleaned up and extracted by me to make the lvgl8 branch smaller. I don't know how critical this change is, but fs and input device driver objects running out of scope seems non-intentional to me.

Tested on pintime:
- connects to gadgetbridge
- apps like twos and others start
- switching Watchfaces works