### PR TITLE
Reduce RAM overhead and free ~9kB of memory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -809,7 +809,7 @@ add_definitions(-DOS_CPUTIME_FREQ)
 add_definitions(-DNRF52 -DNRF52832 -DNRF52832_XXAA -DNRF52_PAN_74 -DNRF52_PAN_64 -DNRF52_PAN_12 -DNRF52_PAN_58 -DNRF52_PAN_54 -DNRF52_PAN_31 -DNRF52_PAN_51 -DNRF52_PAN_36 -DNRF52_PAN_15 -DNRF52_PAN_20 -DNRF52_PAN_55 -DBOARD_PCA10040)
 add_definitions(-DFREERTOS)
 add_definitions(-D__STACK_SIZE=1024)
-add_definitions(-D__HEAP_SIZE=4096)
+add_definitions(-D__HEAP_SIZE=3072)
 
 # NOTE : Add the following defines to enable debug mode of the NRF SDK:
 #add_definitions(-DDEBUG)

--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -62,7 +62,7 @@
 #define configTICK_RATE_HZ                      1024
 #define configMAX_PRIORITIES                    (3)
 #define configMINIMAL_STACK_SIZE                (120)
-#define configTOTAL_HEAP_SIZE                   (1024 * 17)
+#define configTOTAL_HEAP_SIZE                   (1024 * 14)
 #define configMAX_TASK_NAME_LEN                 (4)
 #define configUSE_16_BIT_TICKS                  0
 #define configIDLE_SHOULD_YIELD                 1
@@ -95,7 +95,7 @@
 #define configUSE_TIMERS             1
 #define configTIMER_TASK_PRIORITY    (0)
 #define configTIMER_QUEUE_LENGTH     32
-#define configTIMER_TASK_STACK_DEPTH (300)
+#define configTIMER_TASK_STACK_DEPTH (250)
 
 /* Tickless Idle configuration. */
 #define configEXPECTED_IDLE_TIME_BEFORE_SLEEP 2

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -124,7 +124,7 @@ void DisplayApp::Start(System::BootErrors error) {
     LoadApp(Apps::Clock, DisplayApp::FullRefreshDirections::None);
   }
 
-  if (pdPASS != xTaskCreate(DisplayApp::Process, "displayapp", 800, this, 0, &taskHandle)) {
+  if (pdPASS != xTaskCreate(DisplayApp::Process, "displayapp", 600, this, 0, &taskHandle)) {
     APP_ERROR_HANDLER(NRF_ERROR_NO_MEM);
   }
 }

--- a/src/libs/lv_conf.h
+++ b/src/libs/lv_conf.h
@@ -74,7 +74,7 @@ typedef int16_t lv_coord_t;
 #define LV_MEM_CUSTOM      0
 #if LV_MEM_CUSTOM == 0
 /* Size of the memory used by `lv_mem_alloc` in bytes (>= 2kB)*/
-#define LV_MEM_SIZE    (14U * 1024U)
+#define LV_MEM_SIZE    (8U * 1024U)
 
 /* Complier prefix for a big array declaration */
 #define LV_MEM_ATTR

--- a/src/libs/mynewt-nimble/porting/npl/freertos/src/nimble_port_freertos.c
+++ b/src/libs/mynewt-nimble/porting/npl/freertos/src/nimble_port_freertos.c
@@ -37,7 +37,7 @@ nimble_port_freertos_init(TaskFunction_t host_task_fn)
      * provided by NimBLE and in case of FreeRTOS it does not need to be wrapped
      * since it has compatible prototype.
      */
-    xTaskCreate(nimble_port_ll_task_func, "ll", configMINIMAL_STACK_SIZE + 200,
+    xTaskCreate(nimble_port_ll_task_func, "ll", configMINIMAL_STACK_SIZE + 20,
                 NULL, configMAX_PRIORITIES - 1, &ll_task_h);
 #endif
 
@@ -46,6 +46,6 @@ nimble_port_freertos_init(TaskFunction_t host_task_fn)
      * have separate task for NimBLE host, but since something needs to handle
      * default queue it is just easier to make separate task which does this.
      */
-    xTaskCreate(host_task_fn, "ble", configMINIMAL_STACK_SIZE + 600,
+    xTaskCreate(host_task_fn, "ble", configMINIMAL_STACK_SIZE + 210,
                 NULL, tskIDLE_PRIORITY + 1, &host_task_h);
 }

--- a/src/systemtask/SystemMonitor.h
+++ b/src/systemtask/SystemMonitor.h
@@ -2,6 +2,8 @@
 #include <FreeRTOS.h>
 #include <task.h>
 #include <nrf_log.h>
+#include <lvgl/lvgl.h>
+#include <malloc.h>
 
 namespace Pinetime {
   namespace System {
@@ -32,6 +34,24 @@ namespace Pinetime {
                            tasksStatus[i].pcTaskName,
                            tasksStatus[i].usStackHighWaterMark * 4);
           }
+
+          lv_mem_monitor_t mon;
+          lv_mem_monitor(&mon);
+          NRF_LOG_INFO("#LVGL Memory#\n"
+                       " used# %d (%d%%) / free %d\n"
+                       " max used# %lu\n"
+                       " frag# %d%%\n"
+                       " free# %d",
+                       static_cast<int>(mon.total_size - mon.free_size),
+                       mon.used_pct,
+                       mon.free_size,
+                       mon.max_used,
+                       mon.frag_pct,
+                       static_cast<int>(mon.free_biggest_size));
+
+          auto m = mallinfo();
+          NRF_LOG_INFO("heap : %d", m.uordblks);
+
           lastTick = xTaskGetTickCount();
         }
       }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -115,7 +115,7 @@ SystemTask::SystemTask(Drivers::SpiMaster& spi,
 
 void SystemTask::Start() {
   systemTasksMsgQueue = xQueueCreate(10, 1);
-  if (pdPASS != xTaskCreate(SystemTask::Process, "MAIN", 350, this, 0, &taskHandle)) {
+  if (pdPASS != xTaskCreate(SystemTask::Process, "MAIN", 300, this, 0, &taskHandle)) {
     APP_ERROR_HANDLER(NRF_ERROR_NO_MEM);
   }
 }


### PR DESCRIPTION
Using `SystemMonitor`, I checked the memory usage of the global heap, the FreeRTOS heap, the LVGL heap and the stack of the task.

Here are the results on develop (e0013e7):
```
Memory region         Used Size  Region Size  %age Used
           FLASH:      412136 B       480 KB     83.85%
             RAM:       57520 B        64 KB     87.77%
```

```
Free heap : 624
<info> app: Task [IDL] - 43
<info> app: Task [MAI] - 94
<info> app: Task [dis] - 308
<info> app: Task [LOG] - 71
<info> app: Task [Tmr] - 209
<info> app: Task [Hea] - 411
<info> app: Task [ble] - 491
<info> app: Task [ll] - 246
<info> app: #LVGL Memory#
 used# 6504 (46%) / free 7832
 max used# 6820
 frag# 1%
 free# 7820
<info> app: heap : 2740
```

 * **Free heap** (first line) is the memory available on the FreeRTOS heap
 * **Task[xxx]** shows the minimum space available in the stack of the task (watermacked value).
 * **LVGL max used** is also a watermacked value of the maximum memory used by LVGL
 * **heap** (last line) is the space available in the global heap (malloc).

This PR reduces the following buffers:
 * Global heap : from 4kB to 3kB (-1024B)
 * FreeRTOS heap : from 17kB to 14kB (-3072B)
 * LVGL heap : from 14kB to 8kB (-6144B)

And the following stacks:
 * Timer task stack : from 1200B to 1000B (200B)
 * Display task stack : from 3200B to 2400B (-800B)
 * BLE ll task stack : from 1280B to 560B (-720B)
 * BLE host task stack : from 2880B to 1320B (-1560B)
 * System task stack : from 1400B to 1200B (-200B)
 
In total, this PR frees 10507B of RAM memory, which is quite nice! This memory has always been available, but it was over-allocated in those buffers. Reducing the size of the buffers according to the needs of the current code allows us to have a better overview of the memory currently available.

```
Memory region         Used Size  Region Size  %age Used
           FLASH:      412056 B       480 KB     83.83%
             RAM:       48304 B        64 KB     73.71%
```

```
Free heap : 1032
<info> app: Task [MAI] - 44
<info> app: Task [IDL] - 43
<info> app: Task [Hea] - 425
<info> app: Task [LOG] - 71
<info> app: Task [Tmr] - 159
<info> app: Task [dis] - 111
<info> app: Task [ll] - 69
<info> app: Task [ble] - 103
<info> app: #LVGL Memory#
 used# 6484 (80%) / free 1708
 max used# 6800
 frag# 1%
 free# 1696
<info> app: heap : 2740
```

## How to test this PR ?
You can build this branch with RTT logging enabled to check the logs from the `System Monitor`.

Most of those info are also available in the SystemMonitor app in InfiniTime.
What should you check?
 - Free heap should not decrease under 0
 - Task stack should not decrease under 0
 - LVGL max used should no overflow 8192
 - Global heap should not overflow 3072

Example on my sealed PineTime running for ~10hours:
![1](https://user-images.githubusercontent.com/2261652/148040857-062d6768-0efd-4d7f-97b6-9749e8d10f87.jpg)
![2](https://user-images.githubusercontent.com/2261652/148040871-e598a38c-31a5-48bd-b525-6b0a584a52b9.jpg)

