### PR TITLE
PTS: add seconds display

### DIFF
--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -192,7 +192,7 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
 
   // Display seconds
   timeDD3 = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(timeDD3, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
+  lv_obj_set_style_local_text_color(timeDD3, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_label_set_text_static(timeDD3, ":00");
   lv_obj_align(timeDD3, sidebar, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
 
@@ -423,7 +423,6 @@ void WatchFacePineTimeStyle::Refresh() {
 
     if (displayedSecond != second) {
       displayedSecond = second;
-
       lv_label_set_text_fmt(timeDD3, ":%02d", second);
     }
 

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -172,11 +172,10 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   }
   stepGauge = lv_gauge_create(lv_scr_act(), nullptr);
   lv_gauge_set_needle_count(stepGauge, 1, needle_colors);
-  lv_obj_set_size(stepGauge, 40, 40);
-  lv_obj_align(stepGauge, sidebar, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
-  lv_gauge_set_scale(stepGauge, 360, 11, 0);
-  lv_gauge_set_angle_offset(stepGauge, 180);
-  lv_gauge_set_critical_value(stepGauge, 100);
+  lv_obj_set_size(stepGauge, 37, 37);
+  lv_obj_align(stepGauge, sidebar, LV_ALIGN_IN_BOTTOM_MID, 0, -10);
+  lv_gauge_set_scale(stepGauge, 180, 5, 0);
+  lv_gauge_set_critical_value(stepGauge, 120);
   lv_gauge_set_range(stepGauge, 0, 100);
   lv_gauge_set_value(stepGauge, 0, 0);
 
@@ -190,6 +189,12 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_obj_set_style_local_line_opa(stepGauge, LV_GAUGE_PART_NEEDLE, LV_STATE_DEFAULT, LV_OPA_COVER);
   lv_obj_set_style_local_line_width(stepGauge, LV_GAUGE_PART_NEEDLE, LV_STATE_DEFAULT, 3);
   lv_obj_set_style_local_pad_inner(stepGauge, LV_GAUGE_PART_NEEDLE, LV_STATE_DEFAULT, 4);
+
+  // Display seconds
+  timeDD3 = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(timeDD3, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x000000));
+  lv_label_set_text_static(timeDD3, ":00");
+  lv_obj_align(timeDD3, sidebar, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
 
   btnNextTime = lv_btn_create(lv_scr_act(), nullptr);
   btnNextTime->user_data = this;
@@ -390,6 +395,7 @@ void WatchFacePineTimeStyle::Refresh() {
 
     uint8_t hour = time.hours().count();
     uint8_t minute = time.minutes().count();
+    uint8_t second = time.seconds().count();
 
     if (displayedHour != hour || displayedMinute != minute) {
       displayedHour = hour;
@@ -413,6 +419,12 @@ void WatchFacePineTimeStyle::Refresh() {
         lv_label_set_text_fmt(timeDD1, "%02d", hour);
         lv_label_set_text_fmt(timeDD2, "%02d", minute);
       }
+    }
+
+    if (displayedSecond != second) {
+      displayedSecond = second;
+
+      lv_label_set_text_fmt(timeDD3, ":%02d", second);
     }
 
     if ((year != currentYear) || (month != currentMonth) || (dayOfWeek != currentDayOfWeek) || (day != currentDay)) {

--- a/src/displayapp/screens/WatchFacePineTimeStyle.h
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.h
@@ -43,6 +43,7 @@ namespace Pinetime {
       private:
         uint8_t displayedHour = -1;
         uint8_t displayedMinute = -1;
+        uint8_t displayedSecond = -1;
 
         uint16_t currentYear = 1970;
         Controllers::DateTime::Months currentMonth = Pinetime::Controllers::DateTime::Months::Unknown;
@@ -75,6 +76,7 @@ namespace Pinetime {
         lv_obj_t* sidebar;
         lv_obj_t* timeDD1;
         lv_obj_t* timeDD2;
+        lv_obj_t* timeDD3;
         lv_obj_t* timeAMPM;
         lv_obj_t* dateDayOfWeek;
         lv_obj_t* dateDay;


### PR DESCRIPTION
After receiving a PineTime for Christmas, I started trying to code a bit for it. The first thing I noticed was that the very nice PineTimeStyle watch face does not show the seconds, so I changed that. The design is adapted from the [original Pebble TimeStyle](https://apps.rebble.io/en_US/application/55a5c024f4510f794c000071), where the seconds are also displayed in the bottom right corner. I therefore had to move the step counter up and to avoid coming to near to the calendar, I also changed the step counter to be a half circle instead of a full circle.

I am using the very same changes (but applied to master) since more than a week now on my PineTime and it works perfectly fine, but since I only have a sealed version, I didn't dare to flash the develop branch with the changes. However, I now also simulated it using the awesome work of @NeroBurner in https://github.com/NeroBurner/InfiniTime/tree/lv_simulation_lvgl7 on the current develop branch and everything seems to work here as well.

This is how it looks like:

https://user-images.githubusercontent.com/18088991/148376673-56090395-fa88-4022-b68f-e6dc4a500719.mp4

Also mentioning @kieranc since he is the original author of the PineTimeStyle watchface. Would be really nice to have this included in the official InfiniTime builds!
