### PR TITLE
Update shakewake menu option

### DIFF
--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -59,7 +59,7 @@ std::unique_ptr<Screen> Settings::CreateScreen3() {
 
   std::array<Screens::List::Applications, 4> applications {{
     {Symbols::clock, "Chimes", Apps::SettingChimes},
-    {Symbols::none, "Wake Sense", Apps::SettingShakeThreshold},
+    {Symbols::tachometer, "Shake Calib.", Apps::SettingShakeThreshold},
     {Symbols::check, "Firmware", Apps::FirmwareValidation},
     {Symbols::list, "About", Apps::SysInfo}
   }};


### PR DESCRIPTION
Added an icon and renamed to Shake Calib., so that it's more clear this only affects shake wake.

![menu](https://user-images.githubusercontent.com/37774658/148392523-2c8561ec-b02c-40c8-a033-43541a86f405.jpg)
