### PR TITLE
Added repeat option to timer

### DIFF
--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -81,7 +81,7 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_obj_set_height(btnRepeat, 40);
   txtRepeat = lv_label_create(btnRepeat, nullptr);
   lv_label_set_text(txtRepeat, "Repeat");
-  // Always starts off not repeating so color is already what it should be.
+  lv_btn_set_checkable(btnRepeat, true);
 
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
 }
@@ -122,13 +122,6 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
         lv_obj_del(btnMinutesUp);
         btnMinutesUp = nullptr;
       }
-    } else if (obj == btnRepeat) {
-        repeating = !repeating;
-        if (repeating) {
-          lv_obj_set_style_local_bg_color(btnRepeat, LV_BTNMATRIX_PART_BG, LV_STATE_DEFAULT, LV_COLOR_GREEN);
-        } else {
-          lv_theme_apply(btnRepeat, LV_THEME_BTN);
-        }
     } else {
       if (!timerController.IsRunning()) {
         if (obj == btnMinutesUp) {
@@ -169,7 +162,7 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
 }
 
 void Timer::setDone() {
-  if (repeating) {
+  if (lv_obj_get_state(btnRepeat, LV_BTN_PART_MAIN) & LV_STATE_CHECKED) {
     timerController.StartTimer((secondsToSet + minutesToSet * 60) * 1000);
   } else {
     lv_label_set_text(time, "00:00");

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -64,7 +64,7 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
   btnPlayPause->user_data = this;
   lv_obj_set_event_cb(btnPlayPause, btnEventHandler);
-  lv_obj_align(btnPlayPause, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, -10);
+  lv_obj_align(btnPlayPause, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 0, -10);
   lv_obj_set_height(btnPlayPause, 40);
   txtPlayPause = lv_label_create(btnPlayPause, nullptr);
   if (timerController.IsRunning()) {
@@ -73,6 +73,15 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
     lv_label_set_text(txtPlayPause, Symbols::play);
     createButtons();
   }
+
+  btnRepeat = lv_btn_create(lv_scr_act(), nullptr);
+  btnRepeat->user_data = this;
+  lv_obj_set_event_cb(btnRepeat, btnEventHandler);
+  lv_obj_align(btnRepeat, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, -10);
+  lv_obj_set_height(btnRepeat, 40);
+  txtRepeat = lv_label_create(btnRepeat, nullptr);
+  lv_label_set_text(txtRepeat, "Repeat");
+  // Always starts off not repeating so color is already what it should be.
 
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
 }
@@ -113,6 +122,13 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
         lv_obj_del(btnMinutesUp);
         btnMinutesUp = nullptr;
       }
+    } else if (obj == btnRepeat) {
+        repeating = !repeating;
+        if (repeating) {
+          lv_obj_set_style_local_bg_color(btnRepeat, LV_BTNMATRIX_PART_BG, LV_STATE_DEFAULT, LV_COLOR_GREEN);
+        } else {
+          lv_theme_apply(btnRepeat, LV_THEME_BTN);
+        }
     } else {
       if (!timerController.IsRunning()) {
         if (obj == btnMinutesUp) {
@@ -153,9 +169,13 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
 }
 
 void Timer::setDone() {
-  lv_label_set_text(time, "00:00");
-  lv_label_set_text(txtPlayPause, Symbols::play);
-  secondsToSet = 0;
-  minutesToSet = 0;
-  createButtons();
+  if (repeating) {
+    timerController.StartTimer((secondsToSet + minutesToSet * 60) * 1000);
+  } else {
+    lv_label_set_text(time, "00:00");
+    lv_label_set_text(txtPlayPause, Symbols::play);
+    secondsToSet = 0;
+    minutesToSet = 0;
+    createButtons();
+  }
 }

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -25,6 +25,7 @@ namespace Pinetime::Applications::Screens {
 
   private:
     bool running;
+    bool repeating = false;
     uint8_t secondsToSet = 0;
     uint8_t minutesToSet = 0;
     Controllers::TimerController& timerController;
@@ -32,7 +33,7 @@ namespace Pinetime::Applications::Screens {
     void createButtons();
 
     lv_obj_t *time, *msecTime, *btnPlayPause, *txtPlayPause, *btnMinutesUp, *btnMinutesDown, *btnSecondsUp, *btnSecondsDown, *txtMUp,
-      *txtMDown, *txtSUp, *txtSDown;
+      *txtMDown, *txtSUp, *txtSDown, *btnRepeat, *txtRepeat;
 
     lv_task_t* taskRefresh;
   };

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -25,7 +25,6 @@ namespace Pinetime::Applications::Screens {
 
   private:
     bool running;
-    bool repeating = false;
     uint8_t secondsToSet = 0;
     uint8_t minutesToSet = 0;
     Controllers::TimerController& timerController;


### PR DESCRIPTION
Closes #918 
I moved the play/pause button to the left and put a "Repeat" button next to it which just toggles `repeating` when it's pressed. When repeating is disabled, it follows the default theme for buttons and the timer behaves exactly as it did before but when repeating is enabled, it turns green and when the timer ends, the timer is started again at whatever duration it was started at last. I thought about modifying the TimerController to get repeating working by changing the timer mode to `APP_TIMER_MODE_REPEATED` but I has trouble getting it working. So currently, the timer app itself restarts the timer when `repeating` is enabled. I made it so that repeating can be toggled even when the timer is enabled since having the button not work but still visible as if it did when the timer was running seemed weird to me. I also didn't want to make it not visible because then it would seem the play/pause button was off to the side for no reason when the timer was running and I didn't want the play/pause button to move when the timer started. I also didn't have another good place to put the repeat button.

I tested this on a sealed device so I don't have any debugging info for it and I haven't done C++ in years but as far as I can tell, everything is well so this can be merged once reviewed.

https://user-images.githubusercontent.com/16981283/148719309-8b7bca0b-d34f-4b71-9bec-4ade939901fc.mp4