### PR TITLE
SystemTask: add missing queue.h include for QueueHandle_t

### DIFF
--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include <FreeRTOS.h>
+#include <queue.h>
 #include <task.h>
 #include <timers.h>
 #include <heartratetask/HeartRateTask.h>


### PR DESCRIPTION
`QueueHandle_t` is used in header, but there is no forward declaration, so including the right `queue.h` header