### PR TITLE
Let TouchHandler return TouchEvents instead of driver specific enum

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -60,28 +60,6 @@ namespace {
   static inline bool in_isr(void) {
     return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
   }
-
-  TouchEvents ConvertGesture(Pinetime::Drivers::Cst816S::Gestures gesture) {
-    switch (gesture) {
-      case Pinetime::Drivers::Cst816S::Gestures::SingleTap:
-        return TouchEvents::Tap;
-      case Pinetime::Drivers::Cst816S::Gestures::LongPress:
-        return TouchEvents::LongTap;
-      case Pinetime::Drivers::Cst816S::Gestures::DoubleTap:
-        return TouchEvents::DoubleTap;
-      case Pinetime::Drivers::Cst816S::Gestures::SlideRight:
-        return TouchEvents::SwipeRight;
-      case Pinetime::Drivers::Cst816S::Gestures::SlideLeft:
-        return TouchEvents::SwipeLeft;
-      case Pinetime::Drivers::Cst816S::Gestures::SlideDown:
-        return TouchEvents::SwipeDown;
-      case Pinetime::Drivers::Cst816S::Gestures::SlideUp:
-        return TouchEvents::SwipeUp;
-      case Pinetime::Drivers::Cst816S::Gestures::None:
-      default:
-        return TouchEvents::None;
-    }
-  }
 }
 
 DisplayApp::DisplayApp(Drivers::St7789& lcd,
@@ -227,7 +205,7 @@ void DisplayApp::Refresh() {
         if (state != States::Running) {
           break;
         }
-        auto gesture = ConvertGesture(touchHandler.GestureGet());
+        auto gesture = touchHandler.GestureGet();
         if (gesture == TouchEvents::None) {
           break;
         }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -6,6 +6,7 @@
 #include "BootloaderVersion.h"
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
+#include "displayapp/TouchEvents.h"
 #include "drivers/Cst816s.h"
 #include "drivers/St7789.h"
 #include "drivers/InternalFlash.h"
@@ -265,10 +266,10 @@ void SystemTask::Work() {
         case Messages::TouchWakeUp: {
           if (touchHandler.GetNewTouchInfo()) {
             auto gesture = touchHandler.GestureGet();
-            if (gesture != Pinetime::Drivers::Cst816S::Gestures::None and
-                ((gesture == Pinetime::Drivers::Cst816S::Gestures::DoubleTap and
+            if (gesture != Pinetime::Applications::TouchEvents::None and
+                ((gesture == Pinetime::Applications::TouchEvents::DoubleTap and
                   settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::DoubleTap)) or
-                 (gesture == Pinetime::Drivers::Cst816S::Gestures::SingleTap and
+                 (gesture == Pinetime::Applications::TouchEvents::Tap and
                   settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::SingleTap)))) {
               GoToRunning();
             }

--- a/src/touchhandler/TouchHandler.cpp
+++ b/src/touchhandler/TouchHandler.cpp
@@ -1,6 +1,36 @@
 #include "touchhandler/TouchHandler.h"
+#ifdef PINETIME_IS_RECOVERY
+  #include "displayapp/DummyLittleVgl.h"
+#else
+  #include "displayapp/LittleVgl.h"
+#endif
 
 using namespace Pinetime::Controllers;
+using namespace Pinetime::Applications;
+
+namespace {
+  TouchEvents ConvertGesture(Pinetime::Drivers::Cst816S::Gestures gesture) {
+    switch (gesture) {
+      case Pinetime::Drivers::Cst816S::Gestures::SingleTap:
+        return TouchEvents::Tap;
+      case Pinetime::Drivers::Cst816S::Gestures::LongPress:
+        return TouchEvents::LongTap;
+      case Pinetime::Drivers::Cst816S::Gestures::DoubleTap:
+        return TouchEvents::DoubleTap;
+      case Pinetime::Drivers::Cst816S::Gestures::SlideRight:
+        return TouchEvents::SwipeRight;
+      case Pinetime::Drivers::Cst816S::Gestures::SlideLeft:
+        return TouchEvents::SwipeLeft;
+      case Pinetime::Drivers::Cst816S::Gestures::SlideDown:
+        return TouchEvents::SwipeDown;
+      case Pinetime::Drivers::Cst816S::Gestures::SlideUp:
+        return TouchEvents::SwipeUp;
+      case Pinetime::Drivers::Cst816S::Gestures::None:
+      default:
+        return TouchEvents::None;
+    }
+  }
+}
 
 TouchHandler::TouchHandler(Drivers::Cst816S& touchPanel, Components::LittleVgl& lvgl) : touchPanel {touchPanel}, lvgl {lvgl} {
 }
@@ -12,9 +42,9 @@ void TouchHandler::CancelTap() {
   }
 }
 
-Pinetime::Drivers::Cst816S::Gestures TouchHandler::GestureGet() {
+Pinetime::Applications::TouchEvents TouchHandler::GestureGet() {
   auto returnGesture = gesture;
-  gesture = Drivers::Cst816S::Gestures::None;
+  gesture = Pinetime::Applications::TouchEvents::None;
   return returnGesture;
 }
 
@@ -33,11 +63,11 @@ bool TouchHandler::GetNewTouchInfo() {
           info.gesture == Pinetime::Drivers::Cst816S::Gestures::SlideRight ||
           info.gesture == Pinetime::Drivers::Cst816S::Gestures::LongPress) {
         if (info.touching) {
-          gesture = info.gesture;
+          gesture = ConvertGesture(info.gesture);
           gestureReleased = false;
         }
       } else {
-        gesture = info.gesture;
+        gesture = ConvertGesture(info.gesture);
       }
     }
   }

--- a/src/touchhandler/TouchHandler.h
+++ b/src/touchhandler/TouchHandler.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "drivers/Cst816s.h"
-#include "systemtask/SystemTask.h"
+#include "displayapp/TouchEvents.h"
 
 namespace Pinetime {
   namespace Components {
@@ -26,13 +26,13 @@ namespace Pinetime {
         uint8_t GetY() const {
           return info.y;
         }
-        Drivers::Cst816S::Gestures GestureGet();
+        Pinetime::Applications::TouchEvents GestureGet();
       private:
 
         Pinetime::Drivers::Cst816S::TouchInfos info;
         Pinetime::Drivers::Cst816S& touchPanel;
         Pinetime::Components::LittleVgl& lvgl;
-        Pinetime::Drivers::Cst816S::Gestures gesture;
+        Pinetime::Applications::TouchEvents gesture;
         bool isCancelled = false;
         bool gestureReleased = true;
     };


### PR DESCRIPTION
Let the TouchHandler::GestureGet() function return a TouchEvent instead
of the touchpanel-driver specific enum.

This helps to move the driver specific helper function `ConvertGesture`
from `DisplayApp` into `TouchHandler`.