### PR TITLE
Fix alarm on time change

### DIFF
--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -36,6 +36,8 @@ void DateTime::SetTime(
   UpdateTime(systickCounter);
   NRF_LOG_INFO("* %d %d %d ", this->hour, this->minute, this->second);
   NRF_LOG_INFO("* %d %d %d ", this->day, this->month, this->year);
+
+  systemTask->PushMessage(System::Messages::OnNewTime);
 }
 
 void DateTime::UpdateTime(uint32_t systickCounter) {

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -295,6 +295,9 @@ void SystemTask::Work() {
         case Messages::OnNewTime:
           ReloadIdleTimer();
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::UpdateDateTime);
+          if (alarmController.State() == Controllers::AlarmController::AlarmState::Set) {
+            alarmController.ScheduleAlarm();
+          }
           break;
         case Messages::OnNewNotification:
           if (settingsController.GetNotificationStatus() == Pinetime::Controllers::Settings::Notification::ON) {


### PR DESCRIPTION
The alarm needs to be rescheduled when the time has been changed.
Also the SystemTask message `OnNewTime` was never sent, so now it is sent when the time is set.

Fixes #774