### PR TITLE
Music: initialize totalLength to have non-random data from the start

### DIFF
--- a/src/displayapp/screens/Music.h
+++ b/src/displayapp/screens/Music.h
@@ -69,7 +69,7 @@ namespace Pinetime {
         std::string track;
 
         /** Total length in seconds */
-        int totalLength;
+        int totalLength = 0;
         /** Current length in seconds */
         int currentLength;
         /** Last length */


### PR DESCRIPTION
In the first `Music::Refresh` call the lastLength and totalLength are
not initialized. The `lastLength` value is read first from the
musicService. Naturally in the first itereation that is changed and
`UpdateLength()` is called. There the variable `totalLength` is used as
well, but that variable isn't initialed to a sensible value yet. This
leads to sometimes the `Music.h` screen segfaulting (depending on the
random uninitialized data in the `lastLength` variable)