### PR TITLE
StopWatch: cleanup unused includes and use relative to src includes

### DIFF
--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -1,13 +1,10 @@
-#include "StopWatch.h"
+#include "displayapp/screens/StopWatch.h"
 
 #include "displayapp/screens/Screen.h"
 #include "displayapp/screens/Symbols.h"
 #include <lvgl/lvgl.h>
-#include "projdefs.h"
-#include "FreeRTOSConfig.h"
-#include "task.h"
-
-#include <tuple>
+#include <FreeRTOS.h>
+#include <task.h>
 
 using namespace Pinetime::Applications::Screens;
 

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -4,7 +4,7 @@
 #include "components/datetime/DateTimeController.h"
 #include "displayapp/LittleVgl.h"
 
-#include "FreeRTOS.h"
+#include <FreeRTOS.h>
 #include "portmacro_cmsis.h"
 
 #include <array>


### PR DESCRIPTION
use relative include and remove replace `FreeRTOSConfig.h` include with the `FreeRTOS.h` include as used everywhere else

The tuple include is unused and was removed as well