### PR TITLE
Add contact_links to issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: PineTime community chat (Matrix)
+    url: https://app.element.io/#/room/#pinetime:matrix.org
+    about: Please ask questions about PineTime here.
+  - name: PineTime developers chat (Matrix)
+    url: https://app.element.io/#/room/#pinetime-dev:matrix.org
+    about: Please ask questions about PineTime development here.


### PR DESCRIPTION
Add links to the PineTime community and PineTIme developer chatrooms to show up when trying to open a new issue. This will encourage users to first try and get help there.

We can also disable blank issues and force people to use the issue forms. People don't always use them and thus they may not provide all the necessary information. Should we disable them?

![Screenshot from 2022-01-26 15-21-42](https://user-images.githubusercontent.com/37774658/151172678-467cbaa8-6b82-46de-91cb-6347429fde12.png)