### PR TITLE
PineTimeStyle: SetClockFace(2)

### DIFF
--- a/src/displayapp/screens/PineTimeStyle.cpp
+++ b/src/displayapp/screens/PineTimeStyle.cpp
@@ -59,6 +59,7 @@ PineTimeStyle::PineTimeStyle(DisplayApp* app,
     notificatioManager {notificatioManager},
     settingsController {settingsController},
     motionController {motionController} {
+  settingsController.SetClockFace(2);
 
   // Create a 200px wide background rectangle
   timebar = lv_obj_create(lv_scr_act(), nullptr);


### PR DESCRIPTION
I notices all the other watch faces do this (for the relevant number),
and PineTimeStyle does not - so here's a tiny change to make it call
`SetClockFace` too.

(alternatively, maybe all the watchfaces should _not_ do this.)
