### PR TITLE
SystemMonitor: implement FreeRtosMonitor only if trace facility is set

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -516,6 +516,7 @@ list(APPEND SOURCE_FILES
         displayapp/lv_pinetime_theme.c
 
         systemtask/SystemTask.cpp
+        systemtask/SystemMonitor.cpp
         drivers/TwiMaster.cpp
 
         heartratetask/HeartRateTask.cpp
@@ -577,6 +578,7 @@ list(APPEND RECOVERY_SOURCE_FILES
         FreeRTOS/port_cmsis.c
 
         systemtask/SystemTask.cpp
+        systemtask/SystemMonitor.cpp
         drivers/TwiMaster.cpp
         components/gfx/Gfx.cpp
         components/rle/RleDecoder.cpp

--- a/src/components/ble/AlertNotificationClient.cpp
+++ b/src/components/ble/AlertNotificationClient.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include "components/ble/NotificationManager.h"
 #include "systemtask/SystemTask.h"
+#include <nrf_log.h>
 
 using namespace Pinetime::Controllers;
 constexpr ble_uuid16_t AlertNotificationClient::ansServiceUuid;

--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -3,6 +3,7 @@
 #include "components/ble/BleController.h"
 #include "drivers/SpiNorFlash.h"
 #include "systemtask/SystemTask.h"
+#include <nrf_log.h>
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/ble/HeartRateService.cpp
+++ b/src/components/ble/HeartRateService.cpp
@@ -1,6 +1,7 @@
 #include "components/ble/HeartRateService.h"
 #include "components/heartrate/HeartRateController.h"
 #include "systemtask/SystemTask.h"
+#include <nrf_log.h>
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/ble/MotionService.cpp
+++ b/src/components/ble/MotionService.cpp
@@ -1,6 +1,7 @@
 #include "components/ble/MotionService.h"
 #include "components/motion/MotionController.h"
 #include "systemtask/SystemTask.h"
+#include <nrf_log.h>
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 
 #include <hal/nrf_rtc.h>
+#include <nrf_log.h>
 #define min // workaround: nimble's min/max macros conflict with libstdc++
 #define max
 #include <host/ble_gap.h>

--- a/src/systemtask/SystemMonitor.cpp
+++ b/src/systemtask/SystemMonitor.cpp
@@ -1,0 +1,26 @@
+#include "systemtask/SystemTask.h"
+#if configUSE_TRACE_FACILITY == 1
+// FreeRtosMonitor
+#include <FreeRTOS.h>
+#include <task.h>
+#include <nrf_log.h>
+
+void Pinetime::System::SystemMonitor::Process() {
+  if (xTaskGetTickCount() - lastTick > 10000) {
+    NRF_LOG_INFO("---------------------------------------\nFree heap : %d", xPortGetFreeHeapSize());
+    TaskStatus_t tasksStatus[10];
+    auto nb = uxTaskGetSystemState(tasksStatus, 10, nullptr);
+    for (uint32_t i = 0; i < nb; i++) {
+      NRF_LOG_INFO("Task [%s] - %d", tasksStatus[i].pcTaskName, tasksStatus[i].usStackHighWaterMark);
+      if (tasksStatus[i].usStackHighWaterMark < 20)
+        NRF_LOG_INFO("WARNING!!! Task %s task is nearly full, only %dB available",
+                      tasksStatus[i].pcTaskName,
+                      tasksStatus[i].usStackHighWaterMark * 4);
+    }
+    lastTick = xTaskGetTickCount();
+  }
+}
+#else
+// DummyMonitor
+void Pinetime::System::SystemMonitor::Process() {}
+#endif

--- a/src/systemtask/SystemMonitor.h
+++ b/src/systemtask/SystemMonitor.h
@@ -1,44 +1,16 @@
 #pragma once
-#include <FreeRTOS.h>
+#include <FreeRTOS.h> // declares configUSE_TRACE_FACILITY
 #include <task.h>
-#include <nrf_log.h>
 
 namespace Pinetime {
   namespace System {
-    struct DummyMonitor {};
-    struct FreeRtosMonitor {};
-
-    template <class T> class SystemMonitor {
+    class SystemMonitor {
     public:
-      SystemMonitor() = delete;
-    };
-
-    template <> class SystemMonitor<DummyMonitor> {
-    public:
-      void Process() const {
-      }
-    };
-
-    template <> class SystemMonitor<FreeRtosMonitor> {
-    public:
-      void Process() const {
-        if (xTaskGetTickCount() - lastTick > 10000) {
-          NRF_LOG_INFO("---------------------------------------\nFree heap : %d", xPortGetFreeHeapSize());
-          auto nb = uxTaskGetSystemState(tasksStatus, 10, nullptr);
-          for (uint32_t i = 0; i < nb; i++) {
-            NRF_LOG_INFO("Task [%s] - %d", tasksStatus[i].pcTaskName, tasksStatus[i].usStackHighWaterMark);
-            if (tasksStatus[i].usStackHighWaterMark < 20)
-              NRF_LOG_INFO("WARNING!!! Task %s task is nearly full, only %dB available",
-                           tasksStatus[i].pcTaskName,
-                           tasksStatus[i].usStackHighWaterMark * 4);
-          }
-          lastTick = xTaskGetTickCount();
-        }
-      }
-
+      void Process();
+#if configUSE_TRACE_FACILITY == 1
     private:
       mutable TickType_t lastTick = 0;
-      mutable TaskStatus_t tasksStatus[10];
+#endif
     };
   }
 }

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -148,11 +148,7 @@ namespace Pinetime {
       bool stepCounterMustBeReset = false;
       static constexpr TickType_t batteryMeasurementPeriod = pdMS_TO_TICKS(10 * 60 * 1000);
 
-#if configUSE_TRACE_FACILITY == 1
-      SystemMonitor<FreeRtosMonitor> monitor;
-#else
-      SystemMonitor<DummyMonitor> monitor;
-#endif
+      SystemMonitor monitor;
     };
   }
 }


### PR DESCRIPTION
No need to implement `SystemMonitor<FreeRtosMonitor>` if the variable
`configUSE_TRACE_FACILITY` is set to `1`. Otherwise implement the
`DummyMonitor` class.