### PR TITLE
removed SetClockFace from watchface Constructors

### DIFF
--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -57,7 +57,6 @@ WatchFaceAnalog::WatchFaceAnalog(Pinetime::Applications::DisplayApp* app,
     bleController {bleController},
     notificationManager {notificationManager},
     settingsController {settingsController} {
-  settingsController.SetClockFace(1);
 
   sHour = 99;
   sMinute = 99;

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -32,7 +32,6 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
     settingsController {settingsController},
     heartRateController {heartRateController},
     motionController {motionController} {
-  settingsController.SetClockFace(0);
 
   batteryIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_static(batteryIcon, Symbols::batteryFull);


### PR DESCRIPTION
closes #966 

as discussed there, (and as seen in a quick test) the `SetClockFace` is not needed.