### PR TITLE
New checkable button design

### DIFF
--- a/doc/ui_guidelines.md
+++ b/doc/ui_guidelines.md
@@ -9,5 +9,6 @@
 - Top bar takes at least 20px + padding
 	- Top bar right icons move 8px to the left when using a page indicator
 - A black background helps to hide the screen border, allowing the UI to look less cramped when utilizing the entire display area.
+- A checkable button should have a 3px wide border, and the border color should be about twice as bright as the button. Play/pause or start/stop buttons are not considered checkable, as they are considered two different buttons.
 
 ![example layouts](./ui/example.png)

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -77,6 +77,7 @@ Alarm::Alarm(DisplayApp* app, Controllers::AlarmController& alarmController)
   lv_obj_set_event_cb(btnEnable, btnEventHandler);
   lv_obj_set_size(btnEnable, 115, 50);
   lv_obj_align(btnEnable, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
+  lv_obj_set_style_local_border_width(btnEnable, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 3);
   txtEnable = lv_label_create(btnEnable, nullptr);
   SetEnableButtonState();
 
@@ -193,14 +194,17 @@ void Alarm::SetEnableButtonState() {
     case AlarmController::AlarmState::Set:
       lv_label_set_text(txtEnable, "ON");
       lv_obj_set_style_local_bg_color(btnEnable, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GREEN);
+      lv_obj_set_style_local_border_color(btnEnable, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_LIME);
       break;
     case AlarmController::AlarmState::Not_Set:
       lv_label_set_text(txtEnable, "OFF");
-      lv_obj_set_style_local_bg_color(btnEnable, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
+      lv_obj_set_style_local_bg_color(btnEnable, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0x2f, 0x35, 0x40));
+      lv_obj_set_style_local_border_color(btnEnable, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
       break;
     case AlarmController::AlarmState::Alerting:
       lv_label_set_text(txtEnable, Symbols::stop);
       lv_obj_set_style_local_bg_color(btnEnable, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_RED);
+      lv_obj_set_style_local_border_color(btnEnable, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_RED);
   }
 }
 


### PR DESCRIPTION
Alarm is the first app to get a checkable button, the on/off button. A switch probably wouldn't work in this app, so the button needs to be made distinguishable somehow. This is what I came up with. What do you think?

![off](https://user-images.githubusercontent.com/37774658/151672215-8c513518-11a8-4201-8890-83e5d1f375d1.jpg)
 
![on](https://user-images.githubusercontent.com/37774658/151672216-c0c1acd5-23d9-4457-b49e-32ca2348a465.jpg)
