### PR TITLE
SystemTask: fix static cast missing brackets syntax

### DIFF
--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -197,13 +197,13 @@ void SystemTask::Work() {
   // Touchscreen
   nrf_gpio_cfg_sense_input(PinMap::Cst816sIrq,
                            static_cast<nrf_gpio_pin_pull_t>(GPIO_PIN_CNF_PULL_Pullup),
-                           static_cast<nrf_gpio_pin_sense_t> GPIO_PIN_CNF_SENSE_Low);
+                           static_cast<nrf_gpio_pin_sense_t>(GPIO_PIN_CNF_SENSE_Low));
 
   pinConfig.skip_gpio_setup = true;
   pinConfig.hi_accuracy = false;
   pinConfig.is_watcher = false;
   pinConfig.sense = static_cast<nrf_gpiote_polarity_t>(NRF_GPIOTE_POLARITY_HITOLO);
-  pinConfig.pull = static_cast<nrf_gpio_pin_pull_t> GPIO_PIN_CNF_PULL_Pullup;
+  pinConfig.pull = static_cast<nrf_gpio_pin_pull_t>(GPIO_PIN_CNF_PULL_Pullup);
 
   nrfx_gpiote_in_init(PinMap::Cst816sIrq, &pinConfig, nrfx_gpiote_evt_handler);
 


### PR DESCRIPTION
The static_cast syntax requires brackets around the input variable. The
implementation worked because the used input are defines, which add the
missing brackets like the following:
```cpp
  #define GPIO_PIN_CNF_SENSE_Low (3UL)
```