### PR TITLE
Notifications: replace newlines in label-copy instead of const char* title directly

### DIFF
--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -198,15 +198,18 @@ Notifications::NotificationItem::NotificationItem(const char* title,
 
   lv_obj_t* alert_type = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(alert_type, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x888888));
-  if (title == nullptr)
-    title = "Notification";
-  char* pchar;
-  pchar = strchr(title, '\n');
-  while (pchar != nullptr) {
-    *pchar = ' ';
-    pchar = strchr(pchar + 1, '\n');
+  if(title == nullptr) {
+    lv_label_set_text_static(alert_type, "Notification");
+  } else {
+    // copy title to label and replace newlines with spaces
+    lv_label_set_text(alert_type, title);
+    char *pchar = strchr(lv_label_get_text(alert_type), '\n');
+    while (pchar != nullptr) {
+      *pchar = ' ';
+      pchar = strchr(pchar + 1, '\n');
+    }
+    lv_label_refr_text(alert_type);
   }
-  lv_label_set_text(alert_type, title);
   lv_label_set_long_mode(alert_type, LV_LABEL_LONG_SROLL_CIRC);
   lv_obj_set_width(alert_type, 180);
   lv_obj_align(alert_type, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 16);

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -62,10 +62,6 @@ namespace Pinetime {
         };
 
       private:
-        struct NotificationData {
-          const char* title;
-          const char* text;
-        };
         Pinetime::Controllers::NotificationManager& notificationManager;
         Pinetime::Controllers::AlertNotificationService& alertNotificationService;
         Pinetime::Controllers::MotorController& motorController;


### PR DESCRIPTION
The variable `title` is defined as `const char*`, which means, that
`strchr()` returns a `const char*` as well according to
https://www.cplusplus.com/reference/cstring/strchr/

But in the same line the return value is assigned to a non-const
`char*`, which shouldn't be allowed (error with `-pedantic`).

To prevent manual memory management just use `std::string` to copy the
provided title and replace newlines in the copied string.