### PR TITLE
Notifications: use motorController object instead of class function

### DIFF
--- a/src/components/motor/MotorController.h
+++ b/src/components/motor/MotorController.h
@@ -12,7 +12,7 @@ namespace Pinetime {
       void Init();
       void RunForDuration(uint8_t motorDuration);
       void StartRinging();
-      static void StopRinging();
+      void StopRinging();
 
     private:
       static void Ring(void* p_context);

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -39,7 +39,8 @@ namespace Pinetime {
                            Controllers::NotificationManager::Categories,
                            uint8_t notifNb,
                            Modes mode,
-                           Pinetime::Controllers::AlertNotificationService& alertNotificationService);
+                           Pinetime::Controllers::AlertNotificationService& alertNotificationService,
+                           Pinetime::Controllers::MotorController& motorController);
           ~NotificationItem();
           bool IsRunning() const {
             return running;
@@ -56,6 +57,7 @@ namespace Pinetime {
           lv_obj_t* label_reject;
           Modes mode;
           Pinetime::Controllers::AlertNotificationService& alertNotificationService;
+          Pinetime::Controllers::MotorController& motorController;
           bool running = true;
         };
 
@@ -66,6 +68,7 @@ namespace Pinetime {
         };
         Pinetime::Controllers::NotificationManager& notificationManager;
         Pinetime::Controllers::AlertNotificationService& alertNotificationService;
+        Pinetime::Controllers::MotorController& motorController;
         System::SystemTask& systemTask;
         Modes mode = Modes::Normal;
         std::unique_ptr<NotificationItem> currentItem;


### PR DESCRIPTION
We get the motorController object, so store and use it.

It's the only usage of the class function `StopRinging()` instead of using on the member function