### PR TITLE
Alarm: Change checkable button for a switch

### DIFF
--- a/doc/ui_guidelines.md
+++ b/doc/ui_guidelines.md
@@ -9,5 +9,6 @@
 - Top bar takes at least 20px + padding
 	- Top bar right icons move 8px to the left when using a page indicator
 - A black background helps to hide the screen border, allowing the UI to look less cramped when utilizing the entire display area.
+- A switch should be twice as wide as it is tall.
 
 ![example layouts](./ui/example.png)

--- a/src/displayapp/lv_pinetime_theme.c
+++ b/src/displayapp/lv_pinetime_theme.c
@@ -199,17 +199,16 @@ static void basic_init(void) {
 
   style_init_reset(&style_sw_bg);
   lv_style_set_bg_opa(&style_sw_bg, LV_STATE_DEFAULT, LV_OPA_COVER);
-  lv_style_set_bg_color(&style_sw_bg, LV_STATE_DEFAULT, LV_PINETIME_LIGHT_GRAY);
+  lv_style_set_bg_color(&style_sw_bg, LV_STATE_DEFAULT, LV_PINETIME_BLUE);
   lv_style_set_radius(&style_sw_bg, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
-  lv_style_set_value_color(&style_sw_bg, LV_STATE_DEFAULT, LV_PINETIME_BLUE);
 
   style_init_reset(&style_sw_indic);
   lv_style_set_bg_opa(&style_sw_indic, LV_STATE_DEFAULT, LV_OPA_COVER);
-  lv_style_set_bg_color(&style_sw_indic, LV_STATE_DEFAULT, LV_PINETIME_GREEN);
+  lv_style_set_bg_color(&style_sw_indic, LV_STATE_DEFAULT, LV_COLOR_GREEN);
 
   style_init_reset(&style_sw_knob);
   lv_style_set_bg_opa(&style_sw_knob, LV_STATE_DEFAULT, LV_OPA_COVER);
-  lv_style_set_bg_color(&style_sw_knob, LV_STATE_DEFAULT, LV_PINETIME_WHITE);
+  lv_style_set_bg_color(&style_sw_knob, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_style_set_radius(&style_sw_knob, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
   lv_style_set_pad_top(&style_sw_knob, LV_STATE_DEFAULT, -4);
   lv_style_set_pad_bottom(&style_sw_knob, LV_STATE_DEFAULT, -4);

--- a/src/displayapp/lv_pinetime_theme.c
+++ b/src/displayapp/lv_pinetime_theme.c
@@ -208,7 +208,8 @@ static void basic_init(void) {
 
   style_init_reset(&style_sw_knob);
   lv_style_set_bg_opa(&style_sw_knob, LV_STATE_DEFAULT, LV_OPA_COVER);
-  lv_style_set_bg_color(&style_sw_knob, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_style_set_bg_color(&style_sw_knob, LV_STATE_DEFAULT, LV_COLOR_SILVER);
+  lv_style_set_bg_color(&style_sw_knob, LV_STATE_CHECKED, LV_COLOR_WHITE);
   lv_style_set_radius(&style_sw_knob, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
   lv_style_set_pad_top(&style_sw_knob, LV_STATE_DEFAULT, -4);
   lv_style_set_pad_bottom(&style_sw_knob, LV_STATE_DEFAULT, -4);

--- a/src/displayapp/lv_pinetime_theme.h
+++ b/src/displayapp/lv_pinetime_theme.h
@@ -23,7 +23,7 @@ extern "C" {
 #define LV_PINETIME_LIGHT      lv_color_hex(0xf3f8fe)
 #define LV_PINETIME_GRAY       lv_color_hex(0x8a8a8a)
 #define LV_PINETIME_LIGHT_GRAY lv_color_hex(0xc4c4c4)
-#define LV_PINETIME_BLUE       lv_color_hex(0x2f3243) // 006fb6
+#define LV_PINETIME_BLUE       lv_color_hex(0x2f3540)
 #define LV_PINETIME_GREEN      lv_color_hex(0x4cb242)
 #define LV_PINETIME_RED        lv_color_hex(0xd51732)
 

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -82,8 +82,8 @@ Alarm::Alarm(DisplayApp* app, Controllers::AlarmController& alarmController, Pin
   btnStop = lv_btn_create(lv_scr_act(), nullptr);
   btnStop->user_data = this;
   lv_obj_set_event_cb(btnStop, btnEventHandler);
-  lv_obj_set_size(btnStop, 120, 50);
-  lv_obj_align(btnStop, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
+  lv_obj_set_size(btnStop, 115, 50);
+  lv_obj_align(btnStop, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
   lv_obj_set_style_local_bg_color(btnStop, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_RED);
   txtStop = lv_label_create(btnStop, nullptr);
   lv_label_set_text_static(txtStop, Symbols::stop);
@@ -113,6 +113,10 @@ Alarm::Alarm(DisplayApp* app, Controllers::AlarmController& alarmController, Pin
   lv_obj_align(enableSwitch, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 7, 0);
 
   UpdateAlarmTime();
+
+  if (alarmController.State() == Controllers::AlarmController::AlarmState::Alerting) {
+    SetAlerting();
+  }
 }
 
 Alarm::~Alarm() {
@@ -230,13 +234,11 @@ void Alarm::UpdateAlarmTime() {
 
 void Alarm::SetAlerting() {
   lv_obj_set_hidden(enableSwitch, true);
-  lv_obj_set_hidden(btnRecur, true);
   lv_obj_set_hidden(btnStop, false);
 }
 
 void Alarm::StopAlerting() {
   lv_obj_set_hidden(enableSwitch, false);
-  lv_obj_set_hidden(btnRecur, false);
   lv_obj_set_hidden(btnStop, true);
 }
 

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -116,6 +116,8 @@ Alarm::Alarm(DisplayApp* app, Controllers::AlarmController& alarmController, Pin
 
   if (alarmController.State() == Controllers::AlarmController::AlarmState::Alerting) {
     SetAlerting();
+  } else {
+    SetSwitchState(LV_ANIM_OFF);
   }
 }
 

--- a/src/displayapp/screens/Alarm.h
+++ b/src/displayapp/screens/Alarm.h
@@ -34,21 +34,21 @@ namespace Pinetime {
         bool OnButtonPushed() override;
 
       private:
-        bool running;
         uint8_t alarmHours;
         uint8_t alarmMinutes;
         Controllers::AlarmController& alarmController;
         Controllers::Settings& settingsController;
 
-        lv_obj_t *time, *lblampm, *btnEnable, *txtEnable, *btnMinutesUp, *btnMinutesDown, *btnHoursUp, *btnHoursDown, *txtMinUp,
-          *txtMinDown, *txtHrUp, *txtHrDown, *btnRecur, *txtRecur, *btnInfo, *txtInfo;
+        lv_obj_t *time, *lblampm, *btnStop, *txtStop, *btnMinutesUp, *btnMinutesDown, *btnHoursUp, *btnHoursDown, *txtMinUp,
+          *txtMinDown, *txtHrUp, *txtHrDown, *btnRecur, *txtRecur, *btnInfo, *txtInfo, *enableSwitch;
         lv_obj_t* txtMessage = nullptr;
         lv_obj_t* btnMessage = nullptr;
 
         enum class EnableButtonState { On, Off, Alerting };
-        void SetEnableButtonState();
         void SetRecurButtonState();
+        void SetSwitchState(lv_anim_enable_t anim);
         void SetAlarm();
+        void StopAlerting();
         void ShowInfo();
         void HideInfo();
         void ToggleRecurrence();


### PR DESCRIPTION
I tried to create a checkable button design in #973, but wasn't totally happy with it, so I changed it to a switch here anyway. This is better, because it uses a design people are already familiar with instead of creating something new.

![alarm](https://user-images.githubusercontent.com/37774658/152150594-40bfd591-6436-4ec0-ac0c-4840161cfb17.jpg)

EDIT: The alert layout doesn't need to be changed, so I reverted that change. The adjustment buttons don't need to be visible during alerting, but that's for another PR.