### PR TITLE
#992 Added installing cbor packet into the Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update -qq \
 
 RUN pip3 install adafruit-nrfutil
 RUN pip3 install -Iv cryptography==3.3
+RUN pip3 install cbor
 
 # build.sh knows how to compile
 COPY build.sh /opt/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,9 @@ RUN apt-get update -qq \
 
 RUN pip3 install adafruit-nrfutil
 RUN pip3 install -Iv cryptography==3.3
-RUN pip3 install cbor
+
+# Install dependences of mcuboot/imgtool.py
+RUN pip3 install intelhex click cbor>=1.0.0
 
 # build.sh knows how to compile
 COPY build.sh /opt/
@@ -36,8 +38,6 @@ COPY build.sh /opt/
 RUN bash -c "source /opt/build.sh; GetGcc;"
 # NrfSdk
 RUN bash -c "source /opt/build.sh; GetNrfSdk;"
-# McuBoot
-RUN bash -c "source /opt/build.sh; GetMcuBoot;"
 
 ARG PUID=1000
 ARG PGID=1000

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -25,7 +25,6 @@ main() {
   
   [[ ! -d "$TOOLS_DIR/$GCC_ARM_VER" ]] && GetGcc
   [[ ! -d "$TOOLS_DIR/$NRF_SDK_VER" ]] && GetNrfSdk
-  [[ ! -d "$TOOLS_DIR/mcuboot" ]] && GetMcuBoot
 
   mkdir -p "$BUILD_DIR"
 
@@ -40,11 +39,6 @@ main() {
 GetGcc() {
   GCC_SRC="$GCC_ARM_VER-$MACHINE-linux.tar.bz"
   wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/$GCC_SRC -O - | tar -xj -C $TOOLS_DIR/
-}
-
-GetMcuBoot() {
-  git clone https://github.com/mcu-tools/mcuboot.git "$TOOLS_DIR/mcuboot"
-  pip3 install -r "$TOOLS_DIR/mcuboot/scripts/requirements.txt"
 }
 
 GetNrfSdk() {


### PR DESCRIPTION
# Ticket:
https://github.com/InfiniTimeOrg/InfiniTime/issues/992

# Description:
This PR should fix the error of building FW using docker:
```
Traceback (most recent call last):
  File "../../tools/mcuboot/imgtool.py", line 17, in <module>
    from imgtool import main
  File "/sources/tools/mcuboot/imgtool/main.py", line 23, in <module>
    from imgtool import image, imgtool_version
  File "/sources/tools/mcuboot/imgtool/image.py", line 22, in <module>
    from .boot_record import create_sw_component_data
  File "/sources/tools/mcuboot/imgtool/boot_record.py", line 17, in <module>
    import cbor
ModuleNotFoundError: No module named 'cbor'
```

# Other
I can't push docker image to dockerhub so @JF002 could you do it to get docker image be fixed.
I have tested the result docker image locally, but it would be good if it will be tested by someone else :-)