### PR TITLE
SettingShakeThreshold: add missing SystemTask.h, relative include

### DIFF
--- a/src/displayapp/screens/settings/SettingShakeThreshold.cpp
+++ b/src/displayapp/screens/settings/SettingShakeThreshold.cpp
@@ -1,4 +1,4 @@
-#include "SettingShakeThreshold.h"
+#include "displayapp/screens/settings/SettingShakeThreshold.h"
 #include <lvgl/lvgl.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Screen.h"

--- a/src/displayapp/screens/settings/SettingShakeThreshold.h
+++ b/src/displayapp/screens/settings/SettingShakeThreshold.h
@@ -5,6 +5,7 @@
 #include "components/settings/Settings.h"
 #include "displayapp/screens/Screen.h"
 #include <components/motion/MotionController.h>
+#include "systemtask/SystemTask.h"
 namespace Pinetime {
 
   namespace Applications {


### PR DESCRIPTION
SettingShakeThreshold.h uses SystemTask, but doesn't include the header.
Fixing that for the simulator.

For consistency make the header include a relative to src include.