### PR TITLE
SystemTask: forward declare BatteryController to fix of cyclic dependency

### DIFF
--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -13,6 +13,7 @@
 #include <libraries/log/nrf_log.h>
 
 #include "BootloaderVersion.h"
+#include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
 #include "drivers/Cst816s.h"
 #include "drivers/St7789.h"

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -13,7 +13,6 @@
 #include <components/motion/MotionController.h>
 
 #include "systemtask/SystemMonitor.h"
-#include "components/battery/BatteryController.h"
 #include "components/ble/NimbleController.h"
 #include "components/ble/NotificationManager.h"
 #include "components/motor/MotorController.h"
@@ -47,6 +46,7 @@ namespace Pinetime {
     class Hrs3300;
   }
   namespace Controllers {
+    class Battery;
     class TouchHandler;
     class ButtonHandler;
   }


### PR DESCRIPTION
SystemTask.h included BatteryController.h, and BatteryController.h
included SystemTask.h. If unlucky the class SystemTask isn't created yet
when BatteryController wants to use it.

Fix that cyclic dependency by forward declaring the BatteryController
class and including it in the SystemTask.cpp file, where it is needed.