### PR TITLE
#992 Update docker/build.sh to use specific requirements.txt version from mcutools

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -43,8 +43,10 @@ GetGcc() {
 }
 
 GetMcuBoot() {
-  git clone https://github.com/mcu-tools/mcuboot.git "$TOOLS_DIR/mcuboot"
-  pip3 install -r "$TOOLS_DIR/mcuboot/scripts/requirements.txt"
+  mkdir -p "$TOOLS_DIR/mcuboot"
+  wget -q https://raw.githubusercontent.com/mcu-tools/mcuboot/71b8f981df4f4e65df1757c6ba14ce8d2b7e7696/scripts/requirements.txt \
+    -O "$TOOLS_DIR/mcuboot/requirements.txt"
+  pip3 install -r "$TOOLS_DIR/mcuboot/requirements.txt"
 }
 
 GetNrfSdk() {


### PR DESCRIPTION
# Ticket:
https://github.com/InfiniTimeOrg/InfiniTime/issues/992

# Description:
This PR should fix the error of building FW using docker:
```
Traceback (most recent call last):
  File "../../tools/mcuboot/imgtool.py", line 17, in <module>
    from imgtool import main
  File "/sources/tools/mcuboot/imgtool/main.py", line 23, in <module>
    from imgtool import image, imgtool_version
  File "/sources/tools/mcuboot/imgtool/image.py", line 22, in <module>
    from .boot_record import create_sw_component_data
  File "/sources/tools/mcuboot/imgtool/boot_record.py", line 17, in <module>
    import cbor
ModuleNotFoundError: No module named 'cbor'
```

# Other
This pull request was created instead [PR-944](https://github.com/InfiniTimeOrg/InfiniTime/pull/994). I used @stoehraj the idea of the fix (See [link](https://github.com/InfiniTimeOrg/InfiniTime/issues/992#issuecomment-1038378230)), since I could not find his PR.
I can't push docker image to dockerhub so @JF002 could you do it to get docker image be fixed.
I have tested the result docker image locally.