### PR TITLE
Remove unused includes in HearRate and Motion.h

### DIFF
--- a/src/displayapp/screens/HeartRate.h
+++ b/src/displayapp/screens/HeartRate.h
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <chrono>
 #include "displayapp/screens/Screen.h"
-#include <bits/unique_ptr.h>
 #include "systemtask/SystemTask.h"
 #include <lvgl/src/lv_core/lv_style.h>
 #include <lvgl/src/lv_core/lv_obj.h>

--- a/src/displayapp/screens/Motion.h
+++ b/src/displayapp/screens/Motion.h
@@ -3,7 +3,6 @@
 #include <cstdint>
 #include <chrono>
 #include "displayapp/screens/Screen.h"
-#include <bits/unique_ptr.h>
 #include <lvgl/src/lv_core/lv_style.h>
 #include <lvgl/src/lv_core/lv_obj.h>
 #include <components/motion/MotionController.h>


### PR DESCRIPTION
The include `bits/unique_ptr.h` isn't used, so remove it.