### PR TITLE
Replace Airplane mode icon

### DIFF
--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<Screen> Settings::CreateScreen3() {
     {Symbols::clock, "Chimes", Apps::SettingChimes},
     {Symbols::tachometer, "Shake Calib.", Apps::SettingShakeThreshold},
     {Symbols::check, "Firmware", Apps::FirmwareValidation},
-    {Symbols::list, "Airplane mode", Apps::SettingAirplaneMode}
+    {Symbols::airplane, "Airplane mode", Apps::SettingAirplaneMode}
   }};
 
   return std::make_unique<Screens::List>(2, 4, app, settingsController, applications);


### PR DESCRIPTION
This PR replaces the generic list icon in the Airplane Mode settings entry with a more fitting one
![airplane](https://user-images.githubusercontent.com/27302194/155182230-355258b7-491d-4daa-8954-848720230c07.jpg)

