### PR TITLE
AlarmController: allow loss of precision for alarmTime cast

### DIFF
--- a/src/components/alarm/AlarmController.cpp
+++ b/src/components/alarm/AlarmController.cpp
@@ -54,7 +54,8 @@ void AlarmController::ScheduleAlarm() {
 
   auto now = dateTimeController.CurrentDateTime();
   alarmTime = now;
-  time_t ttAlarmTime = std::chrono::system_clock::to_time_t(alarmTime);
+  time_t ttAlarmTime = std::chrono::system_clock::to_time_t(
+    std::chrono::time_point_cast<std::chrono::system_clock::duration>(alarmTime));
   tm* tmAlarmTime = std::localtime(&ttAlarmTime);
 
   // If the time being set has already passed today,the alarm should be set for tomorrow


### PR DESCRIPTION
Allow a loss of precision if the system clock has a lower resolution
than nanoseconds. This is the case for webassembly.