### PR TITLE
Fix SettingChimes cbOption array size

### DIFF
--- a/src/displayapp/screens/settings/SettingChimes.h
+++ b/src/displayapp/screens/settings/SettingChimes.h
@@ -20,7 +20,7 @@ namespace Pinetime {
       private:
         Controllers::Settings& settingsController;
         uint8_t optionsTotal;
-        lv_obj_t* cbOption[2];
+        lv_obj_t* cbOption[3];
       };
     }
   }


### PR DESCRIPTION
There are 3 options, but the array-size is set to 2. This leads to
memory corruption in the initialization of the SettingChimes screen when
assigning the third option object pointer.

Found in https://github.com/InfiniTimeOrg/InfiniSim/issues/11 by @edo0