### PR TITLE
SettingChimes: replace raw array with std::array

### DIFF
--- a/src/displayapp/screens/settings/SettingChimes.cpp
+++ b/src/displayapp/screens/settings/SettingChimes.cpp
@@ -14,6 +14,8 @@ namespace {
   }
 }
 
+constexpr std::array<SettingChimes::Option, 3> SettingChimes::options;
+
 SettingChimes::SettingChimes(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
   : Screen(app), settingsController {settingsController} {
 
@@ -40,37 +42,16 @@ SettingChimes::SettingChimes(Pinetime::Applications::DisplayApp* app, Pinetime::
   lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
-  optionsTotal = 0;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " Off");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  SetRadioButtonStyle(cbOption[optionsTotal]);
-  if (settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::None) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
+  for (unsigned int i = 0; i < options.size(); i++) {
+    cbOption[i] = lv_checkbox_create(container1, nullptr);
+    lv_checkbox_set_text(cbOption[i], options[i].name);
+    if (settingsController.GetChimeOption() == options[i].chimesOption) {
+      lv_checkbox_set_checked(cbOption[i], true);
+    }
+    cbOption[i]->user_data = this;
+    lv_obj_set_event_cb(cbOption[i], event_handler);
+    SetRadioButtonStyle(cbOption[i]);
   }
-
-  optionsTotal++;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " Every hour");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  SetRadioButtonStyle(cbOption[optionsTotal]);
-  if (settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::Hours) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  }
-
-  optionsTotal++;
-  cbOption[optionsTotal] = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text_static(cbOption[optionsTotal], " Every 30 mins");
-  cbOption[optionsTotal]->user_data = this;
-  lv_obj_set_event_cb(cbOption[optionsTotal], event_handler);
-  SetRadioButtonStyle(cbOption[optionsTotal]);
-  if (settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::HalfHours) {
-    lv_checkbox_set_checked(cbOption[optionsTotal], true);
-  }
-
-  optionsTotal++;
 }
 
 SettingChimes::~SettingChimes() {
@@ -80,18 +61,10 @@ SettingChimes::~SettingChimes() {
 
 void SettingChimes::UpdateSelected(lv_obj_t* object, lv_event_t event) {
   if (event == LV_EVENT_VALUE_CHANGED) {
-    for (uint8_t i = 0; i < optionsTotal; i++) {
+    for (uint8_t i = 0; i < options.size(); i++) {
       if (object == cbOption[i]) {
         lv_checkbox_set_checked(cbOption[i], true);
-        if (i == 0) {
-          settingsController.SetChimeOption(Controllers::Settings::ChimesOption::None);
-        }
-        if (i == 1) {
-          settingsController.SetChimeOption(Controllers::Settings::ChimesOption::Hours);
-        }
-        if (i == 2) {
-          settingsController.SetChimeOption(Controllers::Settings::ChimesOption::HalfHours);
-        }
+        settingsController.SetChimeOption(options[i].chimesOption);
       } else {
         lv_checkbox_set_checked(cbOption[i], false);
       }

--- a/src/displayapp/screens/settings/SettingChimes.h
+++ b/src/displayapp/screens/settings/SettingChimes.h
@@ -4,6 +4,7 @@
 #include <lvgl/lvgl.h>
 #include "components/settings/Settings.h"
 #include "displayapp/screens/Screen.h"
+#include <array>
 
 namespace Pinetime {
 
@@ -12,15 +13,26 @@ namespace Pinetime {
 
       class SettingChimes : public Screen {
       public:
+        struct Option {
+          Controllers::Settings::ChimesOption chimesOption;
+          const char* name;
+        };
+
         SettingChimes(DisplayApp* app, Pinetime::Controllers::Settings& settingsController);
         ~SettingChimes() override;
 
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
+        static constexpr std::array<Option, 3> options = {{
+          {Controllers::Settings::ChimesOption::None, " Off"},
+          {Controllers::Settings::ChimesOption::Hours, " Every hour"},
+          {Controllers::Settings::ChimesOption::HalfHours, " Every 30 mins"}
+        }};
+
+        lv_obj_t* cbOption[options.size()];
+
         Controllers::Settings& settingsController;
-        uint8_t optionsTotal;
-        lv_obj_t* cbOption[3];
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingChimes.h
+++ b/src/displayapp/screens/settings/SettingChimes.h
@@ -13,24 +13,23 @@ namespace Pinetime {
 
       class SettingChimes : public Screen {
       public:
-        struct Option {
-          Controllers::Settings::ChimesOption chimesOption;
-          const char* name;
-        };
-
         SettingChimes(DisplayApp* app, Pinetime::Controllers::Settings& settingsController);
         ~SettingChimes() override;
 
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
+        struct Option {
+          Controllers::Settings::ChimesOption chimesOption;
+          const char* name;
+        };
         static constexpr std::array<Option, 3> options = {{
           {Controllers::Settings::ChimesOption::None, " Off"},
           {Controllers::Settings::ChimesOption::Hours, " Every hour"},
           {Controllers::Settings::ChimesOption::HalfHours, " Every 30 mins"}
         }};
 
-        lv_obj_t* cbOption[options.size()];
+        std::array<lv_obj_t*, options.size()> cbOption;
 
         Controllers::Settings& settingsController;
       };


### PR DESCRIPTION
~~As suggested in https://github.com/InfiniTimeOrg/InfiniTime/pull/1026#issuecomment-1063394505
replace the C-sytle array with a `std::array` and use constexpr variables to access the array to clarify the accessed combobox.~~

ping @JF002 

---

Use a custom `Option` class containing the chimesOption the the corresponding name to render on the display. Create a `std::array` for the possible chimes options and iterate over that to simplify the code (simple loop instead of hard coding all three possibilities)
