### PR TITLE
Music: fix warning about overridden function

### DIFF
--- a/src/displayapp/screens/Music.h
+++ b/src/displayapp/screens/Music.h
@@ -40,7 +40,7 @@ namespace Pinetime {
         void OnObjectEvent(lv_obj_t* obj, lv_event_t event);
 
       private:
-        bool OnTouchEvent(TouchEvents event);
+        bool OnTouchEvent(TouchEvents event) override;
 
         void UpdateLength();
 


### PR DESCRIPTION
Clang warns on `OnTouchEvent()` function, which is overridden, but is
missing the `override` keyword

```
In file included from InfiniTime/src/displayapp/screens/Music.cpp:18:
InfiniTime/src/displayapp/screens/Music.h:43:14: warning: 'OnTouchEvent' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        bool OnTouchEvent(TouchEvents event);
             ^
```