### PR TITLE
Twos: fix warning about extra paranthesis

### DIFF
--- a/src/displayapp/screens/Twos.cpp
+++ b/src/displayapp/screens/Twos.cpp
@@ -130,7 +130,7 @@ bool Twos::placeNewTile() {
 }
 
 bool Twos::tryMerge(TwosTile grid[][4], int& newRow, int& newCol, int oldRow, int oldCol) {
-  if ((grid[newRow][newCol].value == grid[oldRow][oldCol].value)) {
+  if (grid[newRow][newCol].value == grid[oldRow][oldCol].value) {
     if ((newCol != oldCol) || (newRow != oldRow)) {
       if (!grid[newRow][newCol].merged) {
         unsigned int newVal = grid[oldRow][oldCol].value *= 2;


### PR DESCRIPTION
We have a comparison like `if (( a == b ))`, which is a parenthesis too
much, which generates the following warning

```
InfiniTime/src/displayapp/screens/Twos.cpp:133:35: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
  if ((grid[newRow][newCol].value == grid[oldRow][oldCol].value)) {
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
InfiniTime/src/displayapp/screens/Twos.cpp:133:35: note: remove extraneous parentheses around the comparison to silence this warning
  if ((grid[newRow][newCol].value == grid[oldRow][oldCol].value)) {
      ~                           ^                            ~
```