### PR TITLE
Limit the size of the track and album name received by MusicService.

### DIFF
--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -47,6 +47,8 @@ namespace {
   constexpr ble_uuid128_t msRepeatCharUuid {CharUuid(0x0b, 0x00)};
   constexpr ble_uuid128_t msShuffleCharUuid {CharUuid(0x0c, 0x00)};
 
+  constexpr uint8_t MaxStringSize {40};
+
   int MusicCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
     return static_cast<Pinetime::Controllers::MusicService*>(arg)->OnCommand(conn_handle, attr_handle, ctxt);
   }
@@ -125,6 +127,11 @@ void Pinetime::Controllers::MusicService::Init() {
 int Pinetime::Controllers::MusicService::OnCommand(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
   if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
     size_t notifSize = OS_MBUF_PKTLEN(ctxt->om);
+
+    if(notifSize > MaxStringSize) {
+      notifSize = MaxStringSize;
+    }
+
     char data[notifSize + 1];
     data[notifSize] = '\0';
     os_mbuf_copydata(ctxt->om, 0, notifSize, data);

--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -128,7 +128,7 @@ int Pinetime::Controllers::MusicService::OnCommand(uint16_t conn_handle, uint16_
   if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
     size_t notifSize = OS_MBUF_PKTLEN(ctxt->om);
 
-    if(notifSize > MaxStringSize) {
+    if (notifSize > MaxStringSize) {
       notifSize = MaxStringSize;
     }
 


### PR DESCRIPTION
This should work around this bug : https://github.com/InfiniTimeOrg/InfiniTime/issues/825 and prevent heap over-allocation.