### PR TITLE
Fix task priorities to ensure that button presses are correctly detected

### DIFF
--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -60,7 +60,7 @@
 #define configUSE_TICKLESS_IDLE_SIMPLE_DEBUG    0 /* See into vPortSuppressTicksAndSleep source code for explanation */
 #define configCPU_CLOCK_HZ                      (SystemCoreClock)
 #define configTICK_RATE_HZ                      1024
-#define configMAX_PRIORITIES                    (4)
+#define configMAX_PRIORITIES                    (3)
 #define configMINIMAL_STACK_SIZE                (120)
 #define configTOTAL_HEAP_SIZE                   (1024 * 17)
 #define configMAX_TASK_NAME_LEN                 (4)

--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -60,7 +60,7 @@
 #define configUSE_TICKLESS_IDLE_SIMPLE_DEBUG    0 /* See into vPortSuppressTicksAndSleep source code for explanation */
 #define configCPU_CLOCK_HZ                      (SystemCoreClock)
 #define configTICK_RATE_HZ                      1024
-#define configMAX_PRIORITIES                    (3)
+#define configMAX_PRIORITIES                    (4)
 #define configMINIMAL_STACK_SIZE                (120)
 #define configTOTAL_HEAP_SIZE                   (1024 * 17)
 #define configMAX_TASK_NAME_LEN                 (4)
@@ -93,7 +93,7 @@
 
 /* Software timer definitions. */
 #define configUSE_TIMERS             1
-#define configTIMER_TASK_PRIORITY    (0)
+#define configTIMER_TASK_PRIORITY    (1)
 #define configTIMER_QUEUE_LENGTH     32
 #define configTIMER_TASK_STACK_DEPTH (300)
 

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -77,6 +77,7 @@ int GAPEventCallback(struct ble_gap_event* event, void* arg) {
 
 void NimbleController::Init() {
   while (!ble_hs_synced()) {
+    vTaskDelay(10);
   }
 
   nptr = this;

--- a/src/libs/mynewt-nimble/porting/npl/freertos/src/nimble_port_freertos.c
+++ b/src/libs/mynewt-nimble/porting/npl/freertos/src/nimble_port_freertos.c
@@ -38,7 +38,7 @@ nimble_port_freertos_init(TaskFunction_t host_task_fn)
      * since it has compatible prototype.
      */
     xTaskCreate(nimble_port_ll_task_func, "ll", configMINIMAL_STACK_SIZE + 200,
-                NULL, 3, &ll_task_h);
+                NULL, 2, &ll_task_h);
 #endif
 
     /*
@@ -47,5 +47,5 @@ nimble_port_freertos_init(TaskFunction_t host_task_fn)
      * default queue it is just easier to make separate task which does this.
      */
     xTaskCreate(host_task_fn, "ble", configMINIMAL_STACK_SIZE + 600,
-                NULL, 2, &host_task_h);
+                NULL, 1, &host_task_h);
 }

--- a/src/libs/mynewt-nimble/porting/npl/freertos/src/nimble_port_freertos.c
+++ b/src/libs/mynewt-nimble/porting/npl/freertos/src/nimble_port_freertos.c
@@ -38,7 +38,7 @@ nimble_port_freertos_init(TaskFunction_t host_task_fn)
      * since it has compatible prototype.
      */
     xTaskCreate(nimble_port_ll_task_func, "ll", configMINIMAL_STACK_SIZE + 200,
-                NULL, configMAX_PRIORITIES - 1, &ll_task_h);
+                NULL, 3, &ll_task_h);
 #endif
 
     /*
@@ -47,5 +47,5 @@ nimble_port_freertos_init(TaskFunction_t host_task_fn)
      * default queue it is just easier to make separate task which does this.
      */
     xTaskCreate(host_task_fn, "ble", configMINIMAL_STACK_SIZE + 600,
-                NULL, tskIDLE_PRIORITY + 1, &host_task_h);
+                NULL, 2, &host_task_h);
 }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -107,7 +107,7 @@ SystemTask::SystemTask(Drivers::SpiMaster& spi,
 
 void SystemTask::Start() {
   systemTasksMsgQueue = xQueueCreate(10, 1);
-  if (pdPASS != xTaskCreate(SystemTask::Process, "MAIN", 350, this, 0, &taskHandle)) {
+  if (pdPASS != xTaskCreate(SystemTask::Process, "MAIN", 350, this, 1, &taskHandle)) {
     APP_ERROR_HANDLER(NRF_ERROR_NO_MEM);
   }
 }


### PR DESCRIPTION
In current configuration, the timer task (the one from FreeRTOS) has the lowest priority (0). Both display and system tasks are also set on priority 0.

In cases where any other task takes too much time to execute (it can happen in Display Task, see https://github.com/InfiniTimeOrg/InfiniTime/issues/825), the timer task does not have the opportunity to run fast enough to detect and debounce presses on the button.

This commit sets the following priorities:
 - [0] : Display  Task
 - [1] : Timer and System tasks
 - [2] : BLE Host
 - [3] : BLE LL

This way, we ensure that button presses will always be detected, even if the rendering of the display takes a huge amount of time.