### PR TITLE
WatchFaceAnalog: local date/time variables

### DIFF
--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -137,9 +137,9 @@ WatchFaceAnalog::~WatchFaceAnalog() {
 }
 
 void WatchFaceAnalog::UpdateClock() {
-  hour = dateTimeController.Hours();
-  minute = dateTimeController.Minutes();
-  second = dateTimeController.Seconds();
+  uint8_t hour = dateTimeController.Hours();
+  uint8_t minute = dateTimeController.Minutes();
+  uint8_t second = dateTimeController.Seconds();
 
   if (sMinute != minute) {
     auto const angle = minute * 6;
@@ -214,9 +214,9 @@ void WatchFaceAnalog::Refresh() {
   currentDateTime = dateTimeController.CurrentDateTime();
 
   if (currentDateTime.IsUpdated()) {
-    month = dateTimeController.Month();
-    day = dateTimeController.Day();
-    dayOfWeek = dateTimeController.DayOfWeek();
+    Pinetime::Controllers::DateTime::Months month = dateTimeController.Month();
+    uint8_t day = dateTimeController.Day();
+    Pinetime::Controllers::DateTime::Days dayOfWeek = dateTimeController.DayOfWeek();
 
     UpdateClock();
 

--- a/src/displayapp/screens/WatchFaceAnalog.h
+++ b/src/displayapp/screens/WatchFaceAnalog.h
@@ -35,13 +35,6 @@ namespace Pinetime {
 
       private:
         uint8_t sHour, sMinute, sSecond;
-        uint8_t hour;
-        uint8_t minute;
-        uint8_t second;
-
-        Pinetime::Controllers::DateTime::Months month;
-        uint8_t day;
-        Pinetime::Controllers::DateTime::Days dayOfWeek;
 
         Pinetime::Controllers::DateTime::Months currentMonth = Pinetime::Controllers::DateTime::Months::Unknown;
         Pinetime::Controllers::DateTime::Days currentDayOfWeek = Pinetime::Controllers::DateTime::Days::Unknown;


### PR DESCRIPTION
Use local date and time variables. No need to store them in the object.