### PR TITLE
Datetime const and analog const ref

### DIFF
--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -108,11 +108,11 @@ void DateTime::UpdateTime(uint32_t systickCounter) {
   }
 }
 
-const char* DateTime::MonthShortToString() {
+const char* DateTime::MonthShortToString() const {
   return MonthsString[static_cast<uint8_t>(month)];
 }
 
-const char* DateTime::DayOfWeekShortToString() {
+const char* DateTime::DayOfWeekShortToString() const {
   return DaysStringShort[static_cast<uint8_t>(dayOfWeek)];
 }
 

--- a/src/components/datetime/DateTimeController.h
+++ b/src/components/datetime/DateTimeController.h
@@ -61,8 +61,8 @@ namespace Pinetime {
         return second;
       }
 
-      const char* MonthShortToString();
-      const char* DayOfWeekShortToString();
+      const char* MonthShortToString() const;
+      const char* DayOfWeekShortToString() const;
       static const char* MonthShortToStringLow(Months month);
 
       std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> CurrentDateTime() const {

--- a/src/displayapp/screens/WatchFaceAnalog.h
+++ b/src/displayapp/screens/WatchFaceAnalog.h
@@ -74,7 +74,7 @@ namespace Pinetime {
         lv_obj_t* batteryIcon;
         lv_obj_t* notificationIcon;
 
-        Controllers::DateTime& dateTimeController;
+        const Controllers::DateTime& dateTimeController;
         Controllers::Battery& batteryController;
         Controllers::Ble& bleController;
         Controllers::NotificationManager& notificationManager;


### PR DESCRIPTION
`MonthShortToString` and `DayOfWeekShortToString` don't change theunderlying object. Those are just getters and can be declared `const`.

With the getters const we can store a const reference in `WatchFaceAnalog`