### PR TITLE
Extract thread safe functions from the DisplayApp task

### DIFF
--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -72,6 +72,12 @@ namespace Pinetime {
 
       void Register(Pinetime::System::SystemTask* systemTask);
 
+      void ReturnToWatchface();
+      void OpenNotifications();
+      void OnButtonPushed();
+      void OnTimeOutUpdated();
+      void OnBleRadioEnableToggle();
+
     private:
       Pinetime::Drivers::St7789& lcd;
       Pinetime::Components::LittleVgl& lvgl;

--- a/src/displayapp/Messages.h
+++ b/src/displayapp/Messages.h
@@ -6,23 +6,12 @@ namespace Pinetime {
       enum class Messages : uint8_t {
         GoToSleep,
         GoToRunning,
-        UpdateDateTime,
-        UpdateBleConnection,
         TouchEvent,
         ButtonPushed,
-        ButtonLongPressed,
-        ButtonLongerPressed,
-        ButtonDoubleClicked,
-        NewNotification,
         TimerDone,
-        BleFirmwareUpdateStarted,
-        UpdateTimeOut,
         DimScreen,
         RestoreBrightness,
-        ShowPairingKey,
         AlarmTriggered,
-        Clock,
-        BleRadioEnableToggle
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingAirplaneMode.cpp
+++ b/src/displayapp/screens/settings/SettingAirplaneMode.cpp
@@ -71,7 +71,7 @@ SettingAirplaneMode::~SettingAirplaneMode() {
   lv_obj_clean(lv_scr_act());
   // Do not call SaveSettings - see src/components/settings/Settings.h
   if (priorMode != settingsController.GetBleRadioEnabled()) {
-    app->PushMessage(Pinetime::Applications::Display::Messages::BleRadioEnableToggle);
+    app->OnBleRadioEnableToggle();
   }
 }
 

--- a/src/displayapp/screens/settings/SettingDisplay.cpp
+++ b/src/displayapp/screens/settings/SettingDisplay.cpp
@@ -69,7 +69,7 @@ void SettingDisplay::UpdateSelected(lv_obj_t* object, lv_event_t event) {
       if (object == cbOption[i]) {
         lv_checkbox_set_checked(cbOption[i], true);
         settingsController.SetScreenTimeOut(options[i]);
-        app->PushMessage(Applications::Display::Messages::UpdateTimeOut);
+        app->OnTimeOutUpdated();
       } else {
         lv_checkbox_set_checked(cbOption[i], false);
       }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -287,7 +287,6 @@ void SystemTask::Work() {
           break;
         case Messages::OnNewTime:
           ReloadIdleTimer();
-          displayApp.PushMessage(Pinetime::Applications::Display::Messages::UpdateDateTime);
           if (alarmController.State() == Controllers::AlarmController::AlarmState::Set) {
             alarmController.ScheduleAlarm();
           }
@@ -299,7 +298,7 @@ void SystemTask::Work() {
             } else {
               ReloadIdleTimer();
             }
-            displayApp.PushMessage(Pinetime::Applications::Display::Messages::NewNotification);
+            displayApp.StartApp(Applications::Apps::NotificationsPreview, Applications::DisplayApp::FullRefreshDirections::Down);
           }
           break;
         case Messages::OnTimerDone:
@@ -329,7 +328,7 @@ void SystemTask::Work() {
           if (isSleeping && !isWakingUp) {
             GoToRunning();
           }
-          displayApp.PushMessage(Pinetime::Applications::Display::Messages::BleFirmwareUpdateStarted);
+          displayApp.StartApp(Applications::Apps::FirmwareUpdate, Applications::DisplayApp::FullRefreshDirections::Down);
           break;
         case Messages::BleFirmwareUpdateFinished:
           if (bleController.State() == Pinetime::Controllers::Ble::FirmwareUpdateStates::Validated) {
@@ -401,20 +400,22 @@ void SystemTask::Work() {
           break;
         case Messages::OnNewHour:
           using Pinetime::Controllers::AlarmController;
-          if (settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::Hours && alarmController.State() != AlarmController::AlarmState::Alerting) {
+          if (settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::Hours &&
+              alarmController.State() != AlarmController::AlarmState::Alerting) {
             if (isSleeping && !isWakingUp) {
               GoToRunning();
-              displayApp.PushMessage(Pinetime::Applications::Display::Messages::Clock);
+              displayApp.ReturnToWatchface();
             }
             motorController.RunForDuration(35);
           }
           break;
         case Messages::OnNewHalfHour:
           using Pinetime::Controllers::AlarmController;
-          if (settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::HalfHours && alarmController.State() != AlarmController::AlarmState::Alerting) {
+          if (settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::HalfHours &&
+              alarmController.State() != AlarmController::AlarmState::Alerting) {
             if (isSleeping && !isWakingUp) {
               GoToRunning();
-              displayApp.PushMessage(Pinetime::Applications::Display::Messages::Clock);
+              displayApp.ReturnToWatchface();
             }
             motorController.RunForDuration(35);
           }
@@ -438,10 +439,10 @@ void SystemTask::Work() {
             GoToRunning();
           }
           motorController.RunForDuration(35);
-          displayApp.PushMessage(Pinetime::Applications::Display::Messages::ShowPairingKey);
+          displayApp.StartApp(Applications::Apps::PassKey, Applications::DisplayApp::FullRefreshDirections::Up);
           break;
         case Messages::BleRadioEnableToggle:
-          if(settingsController.GetBleRadioEnabled()) {
+          if (settingsController.GetBleRadioEnabled()) {
             nimbleController.EnableRadio();
           } else {
             nimbleController.DisableRadio();
@@ -520,13 +521,13 @@ void SystemTask::HandleButtonAction(Controllers::ButtonActions action) {
       }
       break;
     case Actions::DoubleClick:
-      displayApp.PushMessage(Applications::Display::Messages::ButtonDoubleClicked);
+      displayApp.OpenNotifications();
       break;
     case Actions::LongPress:
-      displayApp.PushMessage(Applications::Display::Messages::ButtonLongPressed);
+      displayApp.ReturnToWatchface();
       break;
     case Actions::LongerPress:
-      displayApp.PushMessage(Applications::Display::Messages::ButtonLongerPressed);
+      displayApp.StartApp(Applications::Apps::SysInfo, Applications::DisplayApp::FullRefreshDirections::Up);
       break;
     default:
       return;


### PR DESCRIPTION
These functions can be executed directly, instead of queueing them up for the DisplayApp task to execute.
Simplifies the DisplayApp task by removing unnecessary messages from it.