### PR TITLE
Global color picker

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -450,6 +450,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/settings/SettingChimes.cpp
         displayapp/screens/settings/SettingShakeThreshold.cpp
         displayapp/screens/settings/SettingAirplaneMode.cpp
+        displayapp/screens/settings/SettingColor.cpp
 
         ## Watch faces
         displayapp/icons/bg_clock.c

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -42,6 +42,11 @@ namespace Pinetime {
         Colors ColorBG = Colors::Black;
       };
 
+      struct GlobalColors {
+        Colors ColorList = Colors::Cyan;
+        Colors ColorTile = Colors::Cyan;
+      };
+
       Settings(Pinetime::Controllers::FS& fs);
 
       void Init();
@@ -92,6 +97,24 @@ namespace Pinetime {
       };
       Colors GetPTSColorBG() const {
         return settings.PTS.ColorBG;
+      };
+
+      void SetColorList(Colors colorList) {
+        if (colorList != settings.GC.ColorList)
+          settingsChanged = true;
+        settings.GC.ColorList = colorList;
+      };
+      Colors GetColorList() const {
+        return settings.GC.ColorList;
+      };
+
+      void SetColorTile(Colors colorTile) {
+        if (colorTile != settings.GC.ColorTile)
+          settingsChanged = true;
+        settings.GC.ColorTile = colorTile;
+      };
+      Colors GetColorTile() const {
+        return settings.GC.ColorTile;
       };
 
       void SetAppMenu(uint8_t menu) {
@@ -213,7 +236,7 @@ namespace Pinetime {
     private:
       Pinetime::Controllers::FS& fs;
 
-      static constexpr uint32_t settingsVersion = 0x0003;
+      static constexpr uint32_t settingsVersion = 0x0004;
       struct SettingsData {
         uint32_t version = settingsVersion;
         uint32_t stepsGoal = 10000;
@@ -226,6 +249,8 @@ namespace Pinetime {
         ChimesOption chimesOption = ChimesOption::None;
 
         PineTimeStyle PTS;
+
+        GlobalColors GC;
 
         std::bitset<4> wakeUpMode {0};
         uint16_t shakeWakeThreshold = 150;

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -45,6 +45,8 @@ namespace Pinetime {
       struct GlobalColors {
         Colors ColorList = Colors::Cyan;
         Colors ColorTile = Colors::Cyan;
+        int Opacity = 51;
+        //const int Opacity = {51, 102, 153, 204, 255};
       };
 
       Settings(Pinetime::Controllers::FS& fs);
@@ -115,6 +117,16 @@ namespace Pinetime {
       };
       Colors GetColorTile() const {
         return settings.GC.ColorTile;
+      };
+
+      void SetOpacity(int opacity) {
+        if (opacity != settings.GC.Opacity) {
+          settings.GC.Opacity = opacity;
+          settingsChanged = true;
+        }
+      };
+      int GetOpacity() const {
+        return settings.GC.Opacity;
       };
 
       void SetAppMenu(uint8_t menu) {

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -45,8 +45,7 @@ namespace Pinetime {
       struct GlobalColors {
         Colors ColorList = Colors::Cyan;
         Colors ColorTile = Colors::Cyan;
-        int Opacity = 51;
-        //const int Opacity = {51, 102, 153, 204, 255};
+        uint8_t Opacity = 51;
       };
 
       Settings(Pinetime::Controllers::FS& fs);

--- a/src/displayapp/Apps.h
+++ b/src/displayapp/Apps.h
@@ -39,6 +39,7 @@ namespace Pinetime {
       SettingChimes,
       SettingShakeThreshold,
       SettingAirplaneMode,
+      SettingColor,
       Error
     };
   }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -50,6 +50,7 @@
 #include "displayapp/screens/settings/SettingChimes.h"
 #include "displayapp/screens/settings/SettingShakeThreshold.h"
 #include "displayapp/screens/settings/SettingAirplaneMode.h"
+#include "displayapp/screens/settings/SettingColor.h"
 
 #include "libs/lv_conf.h"
 
@@ -436,6 +437,10 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       break;
     case Apps::SettingAirplaneMode:
       currentScreen = std::make_unique<Screens::SettingAirplaneMode>(this, settingsController);
+      ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
+      break;
+    case Apps::SettingColor:
+      currentScreen = std::make_unique<Screens::SettingColor>(this, settingsController);
       ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::BatteryInfo:

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -469,7 +469,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       currentScreen = std::make_unique<Screens::Paddle>(this, lvgl);
       break;
     case Apps::Music:
-      currentScreen = std::make_unique<Screens::Music>(this, systemTask->nimble().music());
+      currentScreen = std::make_unique<Screens::Music>(this, systemTask->nimble().music(), settingsController);
       break;
     case Apps::Navigation:
       currentScreen = std::make_unique<Screens::Navigation>(this, systemTask->nimble().navigation());

--- a/src/displayapp/screens/List.cpp
+++ b/src/displayapp/screens/List.cpp
@@ -71,7 +71,7 @@ List::List(uint8_t screenID,
       itemApps[i] = lv_btn_create(container1, nullptr);
       lv_obj_set_style_local_bg_opa(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_60);
       lv_obj_set_style_local_radius(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 57);
-      lv_obj_set_style_local_bg_color(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetPTSColorTime()));
+      lv_obj_set_style_local_bg_color(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorList()));
 
       lv_obj_set_width(itemApps[i], LV_HOR_RES - 8);
       lv_obj_set_height(itemApps[i], 57);

--- a/src/displayapp/screens/List.cpp
+++ b/src/displayapp/screens/List.cpp
@@ -69,7 +69,7 @@ List::List(uint8_t screenID,
     if (applications[i].application != Apps::None) {
 
       itemApps[i] = lv_btn_create(container1, nullptr);
-      lv_obj_set_style_local_bg_opa(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_60);
+      lv_obj_set_style_local_bg_opa(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, settingsController.GetOpacity());
       lv_obj_set_style_local_radius(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 57);
       lv_obj_set_style_local_bg_color(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorList()));
 

--- a/src/displayapp/screens/List.cpp
+++ b/src/displayapp/screens/List.cpp
@@ -1,6 +1,7 @@
 #include "displayapp/screens/List.h"
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Symbols.h"
+#include <displayapp/Colors.h>
 
 using namespace Pinetime::Applications::Screens;
 
@@ -68,9 +69,9 @@ List::List(uint8_t screenID,
     if (applications[i].application != Apps::None) {
 
       itemApps[i] = lv_btn_create(container1, nullptr);
-      lv_obj_set_style_local_bg_opa(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_20);
+      lv_obj_set_style_local_bg_opa(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_60);
       lv_obj_set_style_local_radius(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 57);
-      lv_obj_set_style_local_bg_color(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_AQUA);
+      lv_obj_set_style_local_bg_color(itemApps[i], LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetPTSColorTime()));
 
       lv_obj_set_width(itemApps[i], LV_HOR_RES - 8);
       lv_obj_set_height(itemApps[i], 57);

--- a/src/displayapp/screens/Music.cpp
+++ b/src/displayapp/screens/Music.cpp
@@ -23,6 +23,7 @@
 #include "displayapp/icons/music/disc.cpp"
 #include "displayapp/icons/music/disc_f_1.cpp"
 #include "displayapp/icons/music/disc_f_2.cpp"
+#include <displayapp/Colors.h>
 
 using namespace Pinetime::Applications::Screens;
 
@@ -47,13 +48,19 @@ inline void lv_img_set_src_arr(lv_obj_t* img, const lv_img_dsc_t* src_img) {
  *
  * TODO: Investigate Apple Media Service and AVRCPv1.6 support for seamless integration
  */
-Music::Music(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::MusicService& music) : Screen(app), musicService(music) {
+Music::Music(Pinetime::Applications::DisplayApp* app, 
+             Pinetime::Controllers::MusicService& music, 
+             Pinetime::Controllers::Settings& settingsController) 
+: Screen(app), 
+musicService(music), 
+settingsController {settingsController} 
+{
   lv_obj_t* label;
 
   lv_style_init(&btn_style);
   lv_style_set_radius(&btn_style, LV_STATE_DEFAULT, 20);
-  lv_style_set_bg_color(&btn_style, LV_STATE_DEFAULT, LV_COLOR_AQUA);
-  lv_style_set_bg_opa(&btn_style, LV_STATE_DEFAULT, LV_OPA_20);
+  lv_style_set_bg_color(&btn_style, LV_STATE_DEFAULT, Convert(settingsController.GetColorTile()));
+  lv_style_set_bg_opa(&btn_style, LV_STATE_DEFAULT, settingsController.GetOpacity());
 
   btnVolDown = lv_btn_create(lv_scr_act(), nullptr);
   btnVolDown->user_data = this;

--- a/src/displayapp/screens/Music.cpp
+++ b/src/displayapp/screens/Music.cpp
@@ -23,7 +23,7 @@
 #include "displayapp/icons/music/disc.cpp"
 #include "displayapp/icons/music/disc_f_1.cpp"
 #include "displayapp/icons/music/disc_f_2.cpp"
-#include <displayapp/Colors.h>
+#include "displayapp/Colors.h"
 
 using namespace Pinetime::Applications::Screens;
 
@@ -52,8 +52,8 @@ Music::Music(Pinetime::Applications::DisplayApp* app,
              Pinetime::Controllers::MusicService& music, 
              Pinetime::Controllers::Settings& settingsController) 
 : Screen(app), 
-musicService(music), 
-settingsController {settingsController} 
+  musicService(music), 
+  settingsController {settingsController} 
 {
   lv_obj_t* label;
 

--- a/src/displayapp/screens/Music.h
+++ b/src/displayapp/screens/Music.h
@@ -21,6 +21,7 @@
 #include <lvgl/src/lv_core/lv_obj.h>
 #include <string>
 #include "displayapp/screens/Screen.h"
+#include "components/settings/Settings.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -31,7 +32,7 @@ namespace Pinetime {
     namespace Screens {
       class Music : public Screen {
       public:
-        Music(DisplayApp* app, Pinetime::Controllers::MusicService& music);
+        Music(DisplayApp* app, Pinetime::Controllers::MusicService& music, Pinetime::Controllers::Settings& settingsController);
 
         ~Music() override;
 
@@ -63,6 +64,7 @@ namespace Pinetime {
         bool frameB;
 
         Pinetime::Controllers::MusicService& musicService;
+        Pinetime::Controllers::Settings& settingsController;
 
         std::string artist;
         std::string album;

--- a/src/displayapp/screens/Tile.cpp
+++ b/src/displayapp/screens/Tile.cpp
@@ -1,6 +1,7 @@
 #include "displayapp/screens/Tile.h"
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/BatteryIcon.h"
+#include <displayapp/Colors.h>
 
 using namespace Pinetime::Applications::Screens;
 
@@ -87,8 +88,8 @@ Tile::Tile(uint8_t screenID,
   lv_obj_align(btnm1, NULL, LV_ALIGN_CENTER, 0, 10);
 
   lv_obj_set_style_local_radius(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, 20);
-  lv_obj_set_style_local_bg_opa(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, LV_OPA_20);
-  lv_obj_set_style_local_bg_color(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, LV_COLOR_AQUA);
+  lv_obj_set_style_local_bg_opa(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, LV_OPA_60);
+  lv_obj_set_style_local_bg_color(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, Convert(settingsController.GetPTSColorTime()));
   lv_obj_set_style_local_bg_opa(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DISABLED, LV_OPA_20);
   lv_obj_set_style_local_bg_color(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DISABLED, lv_color_hex(0x111111));
   lv_obj_set_style_local_pad_all(btnm1, LV_BTNMATRIX_PART_BG, LV_STATE_DEFAULT, 0);

--- a/src/displayapp/screens/Tile.cpp
+++ b/src/displayapp/screens/Tile.cpp
@@ -89,7 +89,7 @@ Tile::Tile(uint8_t screenID,
 
   lv_obj_set_style_local_radius(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, 20);
   lv_obj_set_style_local_bg_opa(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, LV_OPA_60);
-  lv_obj_set_style_local_bg_color(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, Convert(settingsController.GetPTSColorTime()));
+  lv_obj_set_style_local_bg_color(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, Convert(settingsController.GetColorTile()));
   lv_obj_set_style_local_bg_opa(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DISABLED, LV_OPA_20);
   lv_obj_set_style_local_bg_color(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DISABLED, lv_color_hex(0x111111));
   lv_obj_set_style_local_pad_all(btnm1, LV_BTNMATRIX_PART_BG, LV_STATE_DEFAULT, 0);

--- a/src/displayapp/screens/Tile.cpp
+++ b/src/displayapp/screens/Tile.cpp
@@ -88,7 +88,7 @@ Tile::Tile(uint8_t screenID,
   lv_obj_align(btnm1, NULL, LV_ALIGN_CENTER, 0, 10);
 
   lv_obj_set_style_local_radius(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, 20);
-  lv_obj_set_style_local_bg_opa(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, LV_OPA_60);
+  lv_obj_set_style_local_bg_opa(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, settingsController.GetOpacity());
   lv_obj_set_style_local_bg_color(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DEFAULT, Convert(settingsController.GetColorTile()));
   lv_obj_set_style_local_bg_opa(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DISABLED, LV_OPA_20);
   lv_obj_set_style_local_bg_color(btnm1, LV_BTNMATRIX_PART_BTN, LV_STATE_DISABLED, lv_color_hex(0x111111));

--- a/src/displayapp/screens/settings/SettingColor.cpp
+++ b/src/displayapp/screens/settings/SettingColor.cpp
@@ -17,14 +17,16 @@ SettingColor::SettingColor(Pinetime::Applications::DisplayApp* app, Pinetime::Co
   : Screen(app), settingsController {settingsController} {
   listColor = lv_obj_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_bg_color(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorList()));
-  lv_obj_set_style_local_radius(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
-  lv_obj_set_size(listColor, 60, 60);
+  lv_obj_set_style_local_bg_opa(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, settingsController.GetOpacity());
+  lv_obj_set_style_local_radius(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 15);
+  lv_obj_set_size(listColor, 220, 60);
   lv_obj_align(listColor, lv_scr_act(), LV_ALIGN_CENTER, 0, -80);
 
   tileColor = lv_obj_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_bg_color(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorTile()));
-  lv_obj_set_style_local_radius(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
-  lv_obj_set_size(tileColor, 60, 60);
+  lv_obj_set_style_local_bg_opa(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, settingsController.GetOpacity());
+  lv_obj_set_style_local_radius(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 15);
+  lv_obj_set_size(tileColor, 220, 60);
   lv_obj_align(tileColor, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
 
   backgroundLabel = lv_label_create(lv_scr_act(), nullptr);
@@ -36,41 +38,65 @@ SettingColor::SettingColor(Pinetime::Applications::DisplayApp* app, Pinetime::Co
 
   btnNextList = lv_btn_create(lv_scr_act(), nullptr);
   btnNextList->user_data = this;
-  lv_obj_set_size(btnNextList, 60, 60);
-  lv_obj_align(btnNextList, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -15, -80);
-  lv_obj_set_style_local_bg_opa(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_30);
-  lv_obj_set_style_local_value_str(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, ">");
+  lv_obj_set_size(btnNextList, 110, 60);
+  lv_obj_align(btnNextList, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -10, -80);
+  //lv_obj_set_style_local_bg_color(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorList()));
+  lv_obj_set_style_local_bg_opa(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
+  //lv_obj_set_style_local_radius(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_style_local_value_str(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "    >");
   lv_obj_set_event_cb(btnNextList, event_handler);
 
   btnPrevList = lv_btn_create(lv_scr_act(), nullptr);
   btnPrevList->user_data = this;
-  lv_obj_set_size(btnPrevList, 60, 60);
-  lv_obj_align(btnPrevList, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 15, -80);
-  lv_obj_set_style_local_bg_opa(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_30);
-  lv_obj_set_style_local_value_str(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "<");
+  lv_obj_set_size(btnPrevList, 110, 60);
+  lv_obj_align(btnPrevList, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 10, -80);
+  //lv_obj_set_style_local_bg_color(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorList()));
+  lv_obj_set_style_local_bg_opa(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
+  //lv_obj_set_style_local_radius(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_style_local_value_str(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "<    ");
   lv_obj_set_event_cb(btnPrevList, event_handler);
+
+  labelList = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(labelList, "Settings");
+  lv_obj_align(labelList, lv_scr_act(), LV_ALIGN_CENTER, 0, -80);
 
   btnNextTile = lv_btn_create(lv_scr_act(), nullptr);
   btnNextTile->user_data = this;
-  lv_obj_set_size(btnNextTile, 60, 60);
-  lv_obj_align(btnNextTile, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -15, 0);
-  lv_obj_set_style_local_bg_opa(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_30);
-  lv_obj_set_style_local_value_str(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, ">");
+  lv_obj_set_size(btnNextTile, 110, 60);
+  lv_obj_align(btnNextTile, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -10, 0);
+  //lv_obj_set_style_local_bg_color(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorTile()));
+  lv_obj_set_style_local_bg_opa(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
+  //lv_obj_set_style_local_radius(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_style_local_value_str(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "    >");
   lv_obj_set_event_cb(btnNextTile, event_handler);
 
   btnPrevTile = lv_btn_create(lv_scr_act(), nullptr);
   btnPrevTile->user_data = this;
-  lv_obj_set_size(btnPrevTile, 60, 60);
-  lv_obj_align(btnPrevTile, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 15, 0);
-  lv_obj_set_style_local_bg_opa(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_30);
-  lv_obj_set_style_local_value_str(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "<");
+  lv_obj_set_size(btnPrevTile, 110, 60);
+  lv_obj_align(btnPrevTile, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 10, 0);
+  //lv_obj_set_style_local_bg_color(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorTile()));
+  lv_obj_set_style_local_bg_opa(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
+  //lv_obj_set_style_local_radius(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_style_local_value_str(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "<    ");
   lv_obj_set_event_cb(btnPrevTile, event_handler);
+
+  labelTile = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(labelTile, "Apps");
+  lv_obj_align(labelTile, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
+
+  btnOpacity = lv_btn_create(lv_scr_act(), nullptr);
+  btnOpacity->user_data = this;
+  lv_obj_set_size(btnOpacity, 150, 60);
+  lv_obj_align(btnOpacity, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 10, 80);
+  lv_obj_set_style_local_bg_opa(btnOpacity, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
+  lv_obj_set_style_local_value_str(btnOpacity, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Opacity");
+  lv_obj_set_event_cb(btnOpacity, event_handler);
 
   btnReset = lv_btn_create(lv_scr_act(), nullptr);
   btnReset->user_data = this;
   lv_obj_set_size(btnReset, 60, 60);
-  lv_obj_align(btnReset, lv_scr_act(), LV_ALIGN_CENTER, 0, 80);
-  lv_obj_set_style_local_bg_opa(btnReset, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_30);
+  lv_obj_align(btnReset, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -10, 80);
+  lv_obj_set_style_local_bg_opa(btnReset, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
   lv_obj_set_style_local_value_str(btnReset, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Rst");
   lv_obj_set_event_cb(btnReset, event_handler);
 
@@ -84,41 +110,69 @@ SettingColor::~SettingColor() {
 void SettingColor::UpdateSelected(lv_obj_t* object, lv_event_t event) {
   auto valueList = settingsController.GetColorList();
   auto valueTile = settingsController.GetColorTile();
+  auto valueOpacity = settingsController.GetOpacity();
 
   if (event == LV_EVENT_CLICKED) {
     if (object == btnNextList) {
       valueList = GetNext(valueList);
       if(valueList == Controllers::Settings::Colors::White)
-        valueTile = GetNext(valueList);
+        valueList = GetNext(valueList);
+      if(valueList == Controllers::Settings::Colors::Black)
+        valueList = GetNext(valueList);
       settingsController.SetColorList(valueList);
       lv_obj_set_style_local_bg_color(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
+      //lv_obj_set_style_local_bg_color(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
+      //lv_obj_set_style_local_bg_color(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
     }
     if (object == btnPrevList) {
       valueList = GetPrevious(valueList);
       if(valueList == Controllers::Settings::Colors::White)
         valueList = GetPrevious(valueList);
+      if(valueList == Controllers::Settings::Colors::Black)
+        valueList = GetPrevious(valueList);
       settingsController.SetColorList(valueList);
       lv_obj_set_style_local_bg_color(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
+      //lv_obj_set_style_local_bg_color(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
+      //lv_obj_set_style_local_bg_color(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
     }
     if (object == btnNextTile) {
       valueTile = GetNext(valueTile);
       if(valueTile == Controllers::Settings::Colors::White)
         valueTile = GetNext(valueTile);
+      if(valueTile == Controllers::Settings::Colors::Black)
+        valueTile = GetNext(valueTile);
       settingsController.SetColorTile(valueTile);
       lv_obj_set_style_local_bg_color(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
+      //lv_obj_set_style_local_bg_color(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
+      //lv_obj_set_style_local_bg_color(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
     }
     if (object == btnPrevTile) {
       valueTile = GetPrevious(valueTile);
       if(valueTile == Controllers::Settings::Colors::White)
         valueTile = GetPrevious(valueTile);
+      if(valueTile == Controllers::Settings::Colors::Black)
+        valueTile = GetPrevious(valueTile);
       settingsController.SetColorTile(valueTile);
       lv_obj_set_style_local_bg_color(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
+      //lv_obj_set_style_local_bg_color(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
+      //lv_obj_set_style_local_bg_color(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
+    }
+    if (object == btnOpacity) {
+      valueOpacity = valueOpacity + 51; 
+      if (valueOpacity > 255)
+        valueOpacity = 51;
+      settingsController.SetOpacity(valueOpacity);
+      lv_obj_set_style_local_bg_opa(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, valueOpacity);
+      lv_obj_set_style_local_bg_opa(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, valueOpacity);
     }
      if (object == btnReset) {
       settingsController.SetColorList(Controllers::Settings::Colors::Cyan);
       lv_obj_set_style_local_bg_color(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(Controllers::Settings::Colors::Cyan));
       settingsController.SetColorTile(Controllers::Settings::Colors::Cyan);
       lv_obj_set_style_local_bg_color(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(Controllers::Settings::Colors::Cyan));
+      settingsController.SetOpacity(51);
+      lv_obj_set_style_local_bg_opa(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 51);
+      lv_obj_set_style_local_bg_opa(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 51);
     }
   }
 }

--- a/src/displayapp/screens/settings/SettingColor.cpp
+++ b/src/displayapp/screens/settings/SettingColor.cpp
@@ -1,0 +1,147 @@
+#include "SettingColor.h"
+#include <lvgl/lvgl.h>
+#include <displayapp/Colors.h>
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Symbols.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  static void event_handler(lv_obj_t* obj, lv_event_t event) {
+    SettingColor* screen = static_cast<SettingColor*>(obj->user_data);
+    screen->UpdateSelected(obj, event);
+  }
+}
+
+SettingColor::SettingColor(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
+  : Screen(app), settingsController {settingsController} {
+  listColor = lv_obj_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_bg_color(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorList()));
+  lv_obj_set_style_local_radius(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_size(listColor, 60, 60);
+  lv_obj_align(listColor, lv_scr_act(), LV_ALIGN_CENTER, 0, -80);
+
+  tileColor = lv_obj_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_bg_color(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorTile()));
+  lv_obj_set_style_local_radius(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_size(tileColor, 60, 60);
+  lv_obj_align(tileColor, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
+
+  backgroundLabel = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_click(backgroundLabel, true);
+  lv_label_set_long_mode(backgroundLabel, LV_LABEL_LONG_CROP);
+  lv_obj_set_size(backgroundLabel, 240, 240);
+  lv_obj_set_pos(backgroundLabel, 0, 0);
+  lv_label_set_text(backgroundLabel, "");
+
+  btnNextList = lv_btn_create(lv_scr_act(), nullptr);
+  btnNextList->user_data = this;
+  lv_obj_set_size(btnNextList, 60, 60);
+  lv_obj_align(btnNextList, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -15, -80);
+  lv_obj_set_style_local_bg_opa(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_30);
+  lv_obj_set_style_local_value_str(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, ">");
+  lv_obj_set_event_cb(btnNextList, event_handler);
+
+  btnPrevList = lv_btn_create(lv_scr_act(), nullptr);
+  btnPrevList->user_data = this;
+  lv_obj_set_size(btnPrevList, 60, 60);
+  lv_obj_align(btnPrevList, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 15, -80);
+  lv_obj_set_style_local_bg_opa(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_30);
+  lv_obj_set_style_local_value_str(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "<");
+  lv_obj_set_event_cb(btnPrevList, event_handler);
+
+  btnNextTile = lv_btn_create(lv_scr_act(), nullptr);
+  btnNextTile->user_data = this;
+  lv_obj_set_size(btnNextTile, 60, 60);
+  lv_obj_align(btnNextTile, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -15, 0);
+  lv_obj_set_style_local_bg_opa(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_30);
+  lv_obj_set_style_local_value_str(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, ">");
+  lv_obj_set_event_cb(btnNextTile, event_handler);
+
+  btnPrevTile = lv_btn_create(lv_scr_act(), nullptr);
+  btnPrevTile->user_data = this;
+  lv_obj_set_size(btnPrevTile, 60, 60);
+  lv_obj_align(btnPrevTile, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 15, 0);
+  lv_obj_set_style_local_bg_opa(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_30);
+  lv_obj_set_style_local_value_str(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "<");
+  lv_obj_set_event_cb(btnPrevTile, event_handler);
+
+  btnReset = lv_btn_create(lv_scr_act(), nullptr);
+  btnReset->user_data = this;
+  lv_obj_set_size(btnReset, 60, 60);
+  lv_obj_align(btnReset, lv_scr_act(), LV_ALIGN_CENTER, 0, 80);
+  lv_obj_set_style_local_bg_opa(btnReset, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_30);
+  lv_obj_set_style_local_value_str(btnReset, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Rst");
+  lv_obj_set_event_cb(btnReset, event_handler);
+
+}
+
+SettingColor::~SettingColor() {
+  lv_obj_clean(lv_scr_act());
+  settingsController.SaveSettings();
+}
+
+void SettingColor::UpdateSelected(lv_obj_t* object, lv_event_t event) {
+  auto valueList = settingsController.GetColorList();
+  auto valueTile = settingsController.GetColorTile();
+
+  if (event == LV_EVENT_CLICKED) {
+    if (object == btnNextList) {
+      valueList = GetNext(valueList);
+      if(valueList == Controllers::Settings::Colors::White)
+        valueTile = GetNext(valueList);
+      settingsController.SetColorList(valueList);
+      lv_obj_set_style_local_bg_color(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
+    }
+    if (object == btnPrevList) {
+      valueList = GetPrevious(valueList);
+      if(valueList == Controllers::Settings::Colors::White)
+        valueList = GetPrevious(valueList);
+      settingsController.SetColorList(valueList);
+      lv_obj_set_style_local_bg_color(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
+    }
+    if (object == btnNextTile) {
+      valueTile = GetNext(valueTile);
+      if(valueTile == Controllers::Settings::Colors::White)
+        valueTile = GetNext(valueTile);
+      settingsController.SetColorTile(valueTile);
+      lv_obj_set_style_local_bg_color(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
+    }
+    if (object == btnPrevTile) {
+      valueTile = GetPrevious(valueTile);
+      if(valueTile == Controllers::Settings::Colors::White)
+        valueTile = GetPrevious(valueTile);
+      settingsController.SetColorTile(valueTile);
+      lv_obj_set_style_local_bg_color(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
+    }
+     if (object == btnReset) {
+      settingsController.SetColorList(Controllers::Settings::Colors::Cyan);
+      lv_obj_set_style_local_bg_color(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(Controllers::Settings::Colors::Cyan));
+      settingsController.SetColorTile(Controllers::Settings::Colors::Cyan);
+      lv_obj_set_style_local_bg_color(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(Controllers::Settings::Colors::Cyan));
+    }
+  }
+}
+
+Pinetime::Controllers::Settings::Colors SettingColor::GetNext(Pinetime::Controllers::Settings::Colors color) {
+  auto colorAsInt = static_cast<uint8_t>(color);
+  Pinetime::Controllers::Settings::Colors nextColor;
+  if (colorAsInt < 16) {
+    nextColor = static_cast<Controllers::Settings::Colors>(colorAsInt + 1);
+  } else {
+    nextColor = static_cast<Controllers::Settings::Colors>(0);
+  }
+  return nextColor;
+}
+
+Pinetime::Controllers::Settings::Colors SettingColor::GetPrevious(Pinetime::Controllers::Settings::Colors color) {
+  auto colorAsInt = static_cast<uint8_t>(color);
+  Pinetime::Controllers::Settings::Colors prevColor;
+
+  if (colorAsInt > 0) {
+    prevColor = static_cast<Controllers::Settings::Colors>(colorAsInt - 1);
+  } else {
+    prevColor = static_cast<Controllers::Settings::Colors>(16);
+  }
+  return prevColor;
+}

--- a/src/displayapp/screens/settings/SettingColor.cpp
+++ b/src/displayapp/screens/settings/SettingColor.cpp
@@ -1,6 +1,6 @@
-#include "SettingColor.h"
+#include "displayapp/screens/settings/SettingColor.h"
 #include <lvgl/lvgl.h>
-#include <displayapp/Colors.h>
+#include "displayapp/Colors.h"
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Symbols.h"
 
@@ -40,9 +40,7 @@ SettingColor::SettingColor(Pinetime::Applications::DisplayApp* app, Pinetime::Co
   btnNextList->user_data = this;
   lv_obj_set_size(btnNextList, 110, 60);
   lv_obj_align(btnNextList, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -10, -80);
-  //lv_obj_set_style_local_bg_color(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorList()));
   lv_obj_set_style_local_bg_opa(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
-  //lv_obj_set_style_local_radius(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_style_local_value_str(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "    >");
   lv_obj_set_event_cb(btnNextList, event_handler);
 
@@ -50,9 +48,7 @@ SettingColor::SettingColor(Pinetime::Applications::DisplayApp* app, Pinetime::Co
   btnPrevList->user_data = this;
   lv_obj_set_size(btnPrevList, 110, 60);
   lv_obj_align(btnPrevList, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 10, -80);
-  //lv_obj_set_style_local_bg_color(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorList()));
   lv_obj_set_style_local_bg_opa(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
-  //lv_obj_set_style_local_radius(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_style_local_value_str(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "<    ");
   lv_obj_set_event_cb(btnPrevList, event_handler);
 
@@ -64,9 +60,7 @@ SettingColor::SettingColor(Pinetime::Applications::DisplayApp* app, Pinetime::Co
   btnNextTile->user_data = this;
   lv_obj_set_size(btnNextTile, 110, 60);
   lv_obj_align(btnNextTile, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -10, 0);
-  //lv_obj_set_style_local_bg_color(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorTile()));
   lv_obj_set_style_local_bg_opa(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
-  //lv_obj_set_style_local_radius(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_style_local_value_str(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "    >");
   lv_obj_set_event_cb(btnNextTile, event_handler);
 
@@ -74,9 +68,7 @@ SettingColor::SettingColor(Pinetime::Applications::DisplayApp* app, Pinetime::Co
   btnPrevTile->user_data = this;
   lv_obj_set_size(btnPrevTile, 110, 60);
   lv_obj_align(btnPrevTile, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 10, 0);
-  //lv_obj_set_style_local_bg_color(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(settingsController.GetColorTile()));
   lv_obj_set_style_local_bg_opa(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
-  //lv_obj_set_style_local_radius(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_style_local_value_str(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "<    ");
   lv_obj_set_event_cb(btnPrevTile, event_handler);
 
@@ -121,8 +113,6 @@ void SettingColor::UpdateSelected(lv_obj_t* object, lv_event_t event) {
         valueList = GetNext(valueList);
       settingsController.SetColorList(valueList);
       lv_obj_set_style_local_bg_color(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
-      //lv_obj_set_style_local_bg_color(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
-      //lv_obj_set_style_local_bg_color(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
     }
     if (object == btnPrevList) {
       valueList = GetPrevious(valueList);
@@ -132,8 +122,6 @@ void SettingColor::UpdateSelected(lv_obj_t* object, lv_event_t event) {
         valueList = GetPrevious(valueList);
       settingsController.SetColorList(valueList);
       lv_obj_set_style_local_bg_color(listColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
-      //lv_obj_set_style_local_bg_color(btnNextList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
-      //lv_obj_set_style_local_bg_color(btnPrevList, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueList));
     }
     if (object == btnNextTile) {
       valueTile = GetNext(valueTile);
@@ -143,8 +131,6 @@ void SettingColor::UpdateSelected(lv_obj_t* object, lv_event_t event) {
         valueTile = GetNext(valueTile);
       settingsController.SetColorTile(valueTile);
       lv_obj_set_style_local_bg_color(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
-      //lv_obj_set_style_local_bg_color(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
-      //lv_obj_set_style_local_bg_color(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
     }
     if (object == btnPrevTile) {
       valueTile = GetPrevious(valueTile);
@@ -154,8 +140,6 @@ void SettingColor::UpdateSelected(lv_obj_t* object, lv_event_t event) {
         valueTile = GetPrevious(valueTile);
       settingsController.SetColorTile(valueTile);
       lv_obj_set_style_local_bg_color(tileColor, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
-      //lv_obj_set_style_local_bg_color(btnNextTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
-      //lv_obj_set_style_local_bg_color(btnPrevTile, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Convert(valueTile));
     }
     if (object == btnOpacity) {
       valueOpacity = valueOpacity + 51; 

--- a/src/displayapp/screens/settings/SettingColor.h
+++ b/src/displayapp/screens/settings/SettingColor.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include <lvgl/lvgl.h>
+#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
+
+namespace Pinetime {
+
+  namespace Applications {
+    namespace Screens {
+
+      class SettingColor : public Screen{
+        public:
+          SettingColor(DisplayApp* app, Pinetime::Controllers::Settings &settingsController);
+          ~SettingColor() override;
+
+          void UpdateSelected(lv_obj_t *object, lv_event_t event);
+         
+        private:          
+          Controllers::Settings& settingsController;
+
+          Pinetime::Controllers::Settings::Colors GetNext(Controllers::Settings::Colors color);
+          Pinetime::Controllers::Settings::Colors GetPrevious(Controllers::Settings::Colors color);
+
+          lv_obj_t * btnNextList;
+          lv_obj_t * btnPrevList;
+          lv_obj_t * btnNextTile;
+          lv_obj_t * btnPrevTile;
+          lv_obj_t * btnReset;
+          lv_obj_t * listColor;
+          lv_obj_t * tileColor;
+          lv_obj_t * backgroundLabel;
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingColor.h
+++ b/src/displayapp/screens/settings/SettingColor.h
@@ -27,9 +27,12 @@ namespace Pinetime {
           lv_obj_t * btnPrevList;
           lv_obj_t * btnNextTile;
           lv_obj_t * btnPrevTile;
+          lv_obj_t * btnOpacity;
           lv_obj_t * btnReset;
           lv_obj_t * listColor;
           lv_obj_t * tileColor;
+          lv_obj_t * labelList;
+          lv_obj_t * labelTile;
           lv_obj_t * backgroundLabel;
       };
     }

--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -73,7 +73,7 @@ std::unique_ptr<Screen> Settings::CreateScreen3() {
 std::unique_ptr<Screen> Settings::CreateScreen4() {
 
   std::array<Screens::List::Applications, 4> applications {{
-    {Symbols::paintbrush, "Colors", Apps::SettingColor},
+    {Symbols::paintbrush, "UI Colors", Apps::SettingColor},
     {Symbols::list, "About", Apps::SysInfo},
     {Symbols::none, "None", Apps::None},
     {Symbols::none, "None", Apps::None}

--- a/src/displayapp/screens/settings/Settings.cpp
+++ b/src/displayapp/screens/settings/Settings.cpp
@@ -73,8 +73,8 @@ std::unique_ptr<Screen> Settings::CreateScreen3() {
 std::unique_ptr<Screen> Settings::CreateScreen4() {
 
   std::array<Screens::List::Applications, 4> applications {{
+    {Symbols::paintbrush, "Colors", Apps::SettingColor},
     {Symbols::list, "About", Apps::SysInfo},
-    {Symbols::none, "None", Apps::None},
     {Symbols::none, "None", Apps::None},
     {Symbols::none, "None", Apps::None}
   }};


### PR DESCRIPTION
This PR implements a color and opacity selector for the settings menu and app drawer icons, and also uses the app drawer icon color for the buttons in the Music app. It's based on the PTS color picker code, which I think is fairly well tested by now, and adds about 1.5kB to the overall firmware size.
The opacity is stored as an integer, 51,102,153,204,255, rather than LV_OPA values, but they line up exactly so it didn't seem worth the effort of complicating it further. Black and white are skipped in the color selection to avoid confusion/invisible buttons/text.


![Peek 2022-03-20 13-55](https://user-images.githubusercontent.com/3533345/159168266-adad3c24-9b58-4915-91f5-b7a6191b6ccb.gif)

