### PR TITLE
SpiNorFlash: use C++ style struct in C++ only header

### DIFF
--- a/src/drivers/SpiNorFlash.h
+++ b/src/drivers/SpiNorFlash.h
@@ -13,11 +13,11 @@ namespace Pinetime {
       SpiNorFlash(SpiNorFlash&&) = delete;
       SpiNorFlash& operator=(SpiNorFlash&&) = delete;
 
-      typedef struct __attribute__((packed)) {
+      struct __attribute__((packed)) Identification {
         uint8_t manufacturer = 0;
         uint8_t type = 0;
         uint8_t density = 0;
-      } Identification;
+      };
 
       Identification ReadIdentificaion();
       uint8_t ReadStatusRegister();


### PR DESCRIPTION
`SpiNorFlash.h` is a C++ header, but the `Identification` struct is
created in a C style using `typedef struct`. Clang issues a warining
about this discrepancy:

```
In file included from /home/nero/repos/pinetime/InfiniSim/InfiniTime/src/systemtask/SystemTask.cpp:13:
/home/nero/repos/pinetime/InfiniSim/sim/drivers/SpiNorFlash.h:16:21: warning: anonymous non-C-compatible type given name for linkage purposes by typedef declaration; add a tag name here [-Wnon-c-typedef-for-linkage]
      typedef struct __attribute__((packed)) {
                    ^
                     Identification
/home/nero/repos/pinetime/InfiniSim/sim/drivers/SpiNorFlash.h:17:9: note: type is not C-compatible due to this default member initializer
        uint8_t manufacturer = 0;
        ^~~~~~~~~~~~~~~~~~~~
/home/nero/repos/pinetime/InfiniSim/sim/drivers/SpiNorFlash.h:20:9: note: type is given name 'Identification' for linkage purposes by this typedef declaration
      } Identification;
        ^
1 warning generated.
```

The easy fix is to use a C++ style struct.