### PR TITLE
Nimble: Reduce power usage, add compatibility to LFCLK calibration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -778,6 +778,7 @@ add_definitions(-DNRF52 -DNRF52832 -DNRF52832_XXAA -DNRF52_PAN_74 -DNRF52_PAN_64
 add_definitions(-DFREERTOS)
 add_definitions(-D__STACK_SIZE=1024)
 add_definitions(-D__HEAP_SIZE=4096)
+add_definitions(-DMYNEWT_VAL_BLE_LL_RFMGMT_ENABLE_TIME=1500)
 
 # Note: Only use this for debugging
 # Derive the low frequency clock from the main clock (SYNT)

--- a/src/libs/mynewt-nimble/nimble/drivers/nrf52/src/ble_phy.c
+++ b/src/libs/mynewt-nimble/nimble/drivers/nrf52/src/ble_phy.c
@@ -37,6 +37,7 @@
 #else
 #include "core_cm4.h"
 #endif
+#include <legacy/nrf_drv_clock.h>
 
 #if MYNEWT_VAL(BLE_LL_CFG_FEAT_LE_CODED_PHY)
 #if !MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52840) && !MYNEWT_VAL_CHOICE(MCU_TARGET, nRF52811)
@@ -2101,7 +2102,7 @@ ble_phy_rfclk_enable(void)
 #if MYNEWT
     nrf52_clock_hfxo_request();
 #else
-    NRF_CLOCK->TASKS_HFCLKSTART = 1;
+    nrf_drv_clock_hfclk_request(NULL);
 #endif
 }
 
@@ -2111,6 +2112,6 @@ ble_phy_rfclk_disable(void)
 #if MYNEWT
     nrf52_clock_hfxo_release();
 #else
-    NRF_CLOCK->TASKS_HFCLKSTOP = 1;
+    nrf_drv_clock_hfclk_release();
 #endif
 }

--- a/src/libs/mynewt-nimble/porting/nimble/include/logcfg/logcfg.h
+++ b/src/libs/mynewt-nimble/porting/nimble/include/logcfg/logcfg.h
@@ -8,7 +8,7 @@
 #include "modlog/modlog.h"
 #include "log_common/log_common.h"
 
-#define BLE_HS_LOG_DEBUG(...) IGNORE(__VA_ARGS__)
+#define BLE_HS_LOG_DEBUG(...) MODLOG_DEBUG(4, __VA_ARGS__)
 #define BLE_HS_LOG_INFO(...) MODLOG_INFO(4, __VA_ARGS__)
 #define BLE_HS_LOG_WARN(...) MODLOG_WARN(4, __VA_ARGS__)
 #define BLE_HS_LOG_ERROR(...) MODLOG_ERROR(4, __VA_ARGS__)

--- a/src/libs/mynewt-nimble/porting/nimble/include/modlog/modlog.h
+++ b/src/libs/mynewt-nimble/porting/nimble/include/modlog/modlog.h
@@ -20,7 +20,8 @@
 #ifndef H_MODLOG_
 #define H_MODLOG_
 
-#include <stdio.h>
+#include "SEGGER_RTT.h"
+#define printf(...) SEGGER_RTT_printf(0, __VA_ARGS__)
 
 #include "log_common/log_common.h"
 #include "log/log.h"

--- a/src/libs/mynewt-nimble/porting/npl/freertos/include/nimble/nimble_npl_os.h
+++ b/src/libs/mynewt-nimble/porting/npl/freertos/include/nimble/nimble_npl_os.h
@@ -37,6 +37,8 @@ extern "C" {
 
 #define BLE_NPL_TIME_FOREVER    portMAX_DELAY
 
+extern volatile int ble_npl_in_critical;
+
 /* This should be compatible with TickType_t */
 typedef uint32_t ble_npl_time_t;
 typedef int32_t ble_npl_stime_t;
@@ -282,14 +284,22 @@ static inline uint32_t
 ble_npl_hw_enter_critical(void)
 {
     //vPortEnterCritical();
-  return npl_freertos_hw_enter_critical();
+    ++ble_npl_in_critical;
+    return npl_freertos_hw_enter_critical();
 }
 
 static inline void
 ble_npl_hw_exit_critical(uint32_t ctx)
 {
-  npl_freertos_hw_exit_critical(ctx);
+    --ble_npl_in_critical;
+    npl_freertos_hw_exit_critical(ctx);
+}
 
+static inline bool
+ble_npl_hw_is_in_critical(void)
+{
+    // Do the same as RIOT and keep track of the critical state manually
+    return (ble_npl_in_critical > 0);
 }
 
 #ifdef __cplusplus

--- a/src/libs/mynewt-nimble/porting/npl/freertos/src/npl_os_freertos.c
+++ b/src/libs/mynewt-nimble/porting/npl/freertos/src/npl_os_freertos.c
@@ -22,6 +22,8 @@
 #include <string.h>
 #include "nimble/nimble_npl.h"
 
+volatile int ble_npl_in_critical = 0;
+
 static inline bool
 in_isr(void)
 {


### PR DESCRIPTION
This PR has been broken out of https://github.com/InfiniTimeOrg/InfiniTime/pull/1050 .

- Reduce BLE power usage by only powering up radio peripherals and the high frequency clock when needed (`BLE_LL_RFMGMT_ENABLE_TIME` parameter)
- Use NRF SDK to access high frequency clock, in order to not interfere with potential LFRC calibration.