### PR TITLE
Fix app loading and event management in DisplayApp

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -306,13 +306,13 @@ void DisplayApp::Refresh() {
     }
   }
 
+  if (touchHandler.IsTouching()) {
+    currentScreen->OnTouchEvent(touchHandler.GetX(), touchHandler.GetY());
+  }
+
   if (nextApp != Apps::None) {
     LoadApp(nextApp, nextDirection);
     nextApp = Apps::None;
-  }
-
-  if (touchHandler.IsTouching()) {
-    currentScreen->OnTouchEvent(touchHandler.GetX(), touchHandler.GetY());
   }
 }
 


### PR DESCRIPTION
In display app, call the event handler of the current app before loading the new one. This way, we ensure that lv_task_refresh() is called before sending event to the newly loaded app.

Fix #1023 