### PR TITLE
Added vibration on new navigation instructions and optimized layout

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -467,7 +467,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       currentScreen = std::make_unique<Screens::Music>(this, systemTask->nimble().music());
       break;
     case Apps::Navigation:
-      currentScreen = std::make_unique<Screens::Navigation>(this, systemTask->nimble().navigation());
+      currentScreen = std::make_unique<Screens::Navigation>(this, systemTask->nimble().navigation(), motorController);
       break;
     case Apps::HeartRate:
       currentScreen = std::make_unique<Screens::HeartRate>(this, heartRateController, *systemTask);

--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -128,21 +128,21 @@ namespace {
  * Navigation watchapp
  *
  */
-Navigation::Navigation(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::NavigationService& nav)
-  : Screen(app), navService(nav) {
+Navigation::Navigation(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::NavigationService& nav, Controllers::MotorController& motorController)
+  : Screen(app), navService(nav), motorController {motorController} {
 
   imgFlag = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(imgFlag, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_navi_80);
   lv_obj_set_style_local_text_color(imgFlag, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_CYAN);
   lv_label_set_text(imgFlag, iconForName("flag"));
-  lv_obj_align(imgFlag, nullptr, LV_ALIGN_CENTER, 0, -60);
+  lv_obj_align(imgFlag, nullptr, LV_ALIGN_CENTER, 0, -78);
 
   txtNarrative = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtNarrative, LV_LABEL_LONG_BREAK);
   lv_obj_set_width(txtNarrative, LV_HOR_RES);
-  lv_label_set_text(txtNarrative, "Navigation");
+  lv_label_set_text(txtNarrative, "Navigation\n\nwatiting for\ninstructions ...");
   lv_label_set_align(txtNarrative, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(txtNarrative, nullptr, LV_ALIGN_CENTER, 0, 10);
+  lv_obj_align(txtNarrative, nullptr, LV_ALIGN_CENTER, 0, 32);
 
   txtManDist = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtManDist, LV_LABEL_LONG_BREAK);
@@ -150,7 +150,7 @@ Navigation::Navigation(Pinetime::Applications::DisplayApp* app, Pinetime::Contro
   lv_obj_set_width(txtManDist, LV_HOR_RES);
   lv_label_set_text(txtManDist, "--M");
   lv_label_set_align(txtManDist, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(txtManDist, nullptr, LV_ALIGN_CENTER, 0, 60);
+  lv_obj_align(txtManDist, nullptr, LV_ALIGN_CENTER, 0, 110);
 
   // Route Progress
   barProgress = lv_bar_create(lv_scr_act(), nullptr);
@@ -174,11 +174,13 @@ void Navigation::Refresh() {
   if (flag != navService.getFlag()) {
     flag = navService.getFlag();
     lv_label_set_text(imgFlag, iconForName(flag));
+    motorController.RunForDuration(90);
   }
 
   if (narrative != navService.getNarrative()) {
     narrative = navService.getNarrative();
     lv_label_set_text(txtNarrative, narrative.data());
+    motorController.RunForDuration(90);
   }
 
   if (manDist != navService.getManDist()) {

--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -135,7 +135,7 @@ Navigation::Navigation(Pinetime::Applications::DisplayApp* app, Pinetime::Contro
   lv_obj_set_style_local_text_font(imgFlag, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_navi_80);
   lv_obj_set_style_local_text_color(imgFlag, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_CYAN);
   lv_label_set_text(imgFlag, iconForName("flag"));
-  lv_obj_align(imgFlag, nullptr, LV_ALIGN_CENTER, 0, -78);
+  lv_obj_align(imgFlag, nullptr, LV_ALIGN_IN_TOP_MID, 0, 2);
 
   txtNarrative = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtNarrative, LV_LABEL_LONG_BREAK);
@@ -150,7 +150,7 @@ Navigation::Navigation(Pinetime::Applications::DisplayApp* app, Pinetime::Contro
   lv_obj_set_width(txtManDist, LV_HOR_RES);
   lv_label_set_text(txtManDist, "--M");
   lv_label_set_align(txtManDist, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(txtManDist, nullptr, LV_ALIGN_CENTER, 0, 110);
+  lv_obj_align(txtManDist, nullptr, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
 
   // Route Progress
   barProgress = lv_bar_create(lv_scr_act(), nullptr);

--- a/src/displayapp/screens/Navigation.h
+++ b/src/displayapp/screens/Navigation.h
@@ -21,6 +21,7 @@
 #include <lvgl/src/lv_core/lv_obj.h>
 #include <string>
 #include "displayapp/screens/Screen.h"
+#include "components/motor/MotorController.h"
 #include <array>
 
 namespace Pinetime {
@@ -32,7 +33,7 @@ namespace Pinetime {
     namespace Screens {
       class Navigation : public Screen {
       public:
-        Navigation(DisplayApp* app, Pinetime::Controllers::NavigationService& nav);
+        Navigation(DisplayApp* app, Pinetime::Controllers::NavigationService& nav, Controllers::MotorController& motorController);
         ~Navigation() override;
 
         void Refresh() override;
@@ -43,6 +44,7 @@ namespace Pinetime {
         lv_obj_t* txtManDist;
         lv_obj_t* barProgress;
 
+        Controllers::MotorController& motorController;
         Pinetime::Controllers::NavigationService& navService;
 
         std::string flag;


### PR DESCRIPTION
### Motor Vibration in Navigation
On new navigation instructions or navigation image changes a short motor vibration is added to inform the user. Distance updates don't trigger any motor vibration as it is updated too frequently.

### Navigation App layout optimized
Additionally the layout is optimized for longer text instructions as experience showed that text overlapped distance figures and navigation images (relocated to top and bottom and centered text):

![nav-layout-optimized](https://user-images.githubusercontent.com/12826261/161439210-9abeba1d-38c7-4882-9d46-74393611ef0b.png)
