### PR TITLE
Terminal large face

### DIFF
--- a/src/displayapp/screens/WatchFaceTerminal.cpp
+++ b/src/displayapp/screens/WatchFaceTerminal.cpp
@@ -198,12 +198,12 @@ void WatchFaceTerminal::Refresh() {
     uint8_t minute = time.minutes().count();
     uint8_t second = time.seconds().count();
 
-    const auto time_display_changed = displayedBigTime != bigTime ||
+    const bool timeDisplayChanged = displayedBigTime != bigTime ||
         displayedHour != hour ||
         displayedMinute != minute ||
         displayedSecond != second;
 
-    if (!bigTime && time_display_changed) {
+    if (!bigTime && timeDisplayChanged) {
       displayedHour = hour;
       displayedMinute = minute;
       displayedSecond = second;
@@ -224,13 +224,13 @@ void WatchFaceTerminal::Refresh() {
       }
     }
 
-    const auto date_display_changed = displayedBigTime != bigTime ||
+    const bool dateDisplayChanged = displayedBigTime != bigTime ||
         (year != currentYear) ||
         (month != currentMonth) ||
         (dayOfWeek != currentDayOfWeek) ||
         (day != currentDay);
 
-    if (!bigTime && date_display_changed) {
+    if (!bigTime && dateDisplayChanged) {
       lv_label_set_text_fmt(label_date, "[DATE]#007fff %04d.%02d.%02d#", short(year), char(month), char(day));
 
       currentYear = year;
@@ -238,7 +238,7 @@ void WatchFaceTerminal::Refresh() {
       currentDayOfWeek = dayOfWeek;
       currentDay = day;
     }
-    if (bigTime && time_display_changed) {
+    if (bigTime && timeDisplayChanged) {
       lv_label_set_text_fmt(label_time, "#11cc55 %s%s %s%s %s%s#",
               BIG_DIGITS[hour/10][0],
               BIG_DIGITS[hour%10][0],

--- a/src/displayapp/screens/WatchFaceTerminal.h
+++ b/src/displayapp/screens/WatchFaceTerminal.h
@@ -32,17 +32,21 @@ namespace Pinetime {
                           Controllers::MotionController& motionController);
         ~WatchFaceTerminal() override;
 
+        bool OnTouchEvent(TouchEvents event) override;
+
         void Refresh() override;
 
       private:
         uint8_t displayedHour = -1;
         uint8_t displayedMinute = -1;
         uint8_t displayedSecond = -1;
+        uint8_t displayedBigTime = -1;
 
         uint16_t currentYear = 1970;
         Pinetime::Controllers::DateTime::Months currentMonth = Pinetime::Controllers::DateTime::Months::Unknown;
         Pinetime::Controllers::DateTime::Days currentDayOfWeek = Pinetime::Controllers::DateTime::Days::Unknown;
         uint8_t currentDay = 0;
+        bool bigTime = false;
 
         DirtyValue<int> batteryPercentRemaining {};
         DirtyValue<bool> powerPresent {};


### PR DESCRIPTION
I found this useful to see the time better with my aging eyes - feel free to take or not!

On a tap, the time/date/batt lines are replaced by a larger ASCII 7-segment time display.

I haven't been able to run clang-format: neither v10 or v12 likes the configuration.
clang-tidy complained about the wrong include ordering, but it's not something I've changed.