### PR TITLE
Stopwatch fixes

### DIFF
--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -10,11 +10,12 @@ using namespace Pinetime::Applications::Screens;
 
 namespace {
   TimeSeparated_t convertTicksToTimeSegments(const TickType_t timeElapsed) {
-    const int timeElapsedMillis = timeElapsed * 1000 / configTICK_RATE_HZ;
+    // Centiseconds
+    const int timeElapsedCentis = timeElapsed * 100 / configTICK_RATE_HZ;
 
-    const int hundredths = (timeElapsedMillis % 1000) / 10; // Get only the first two digits and ignore the last
-    const int secs = (timeElapsedMillis / 1000) % 60;
-    const int mins = (timeElapsedMillis / 1000) / 60;
+    const int hundredths = (timeElapsedCentis % 100);
+    const int secs = (timeElapsedCentis / 100) % 60;
+    const int mins = (timeElapsedCentis / 100) / 60;
     return TimeSeparated_t {mins, secs, hundredths};
   }
 

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -8,10 +8,9 @@
 
 using namespace Pinetime::Applications::Screens;
 
-// Anonymous namespace for local functions
 namespace {
   TimeSeparated_t convertTicksToTimeSegments(const TickType_t timeElapsed) {
-    const int timeElapsedMillis = (static_cast<float>(timeElapsed) / static_cast<float>(configTICK_RATE_HZ)) * 1000;
+    const int timeElapsedMillis = timeElapsed * 1000 / configTICK_RATE_HZ;
 
     const int hundredths = (timeElapsedMillis % 1000) / 10; // Get only the first two digits and ignore the last
     const int secs = (timeElapsedMillis / 1000) % 60;
@@ -19,27 +18,15 @@ namespace {
     return TimeSeparated_t {mins, secs, hundredths};
   }
 
-  TickType_t calculateDelta(const TickType_t startTime, const TickType_t currentTime) {
-    TickType_t delta = 0;
-    // Take care of overflow
-    if (startTime > currentTime) {
-      delta = 0xffffffff - startTime;
-      delta += (currentTime + 1);
-    } else {
-      delta = currentTime - startTime;
-    }
-    return delta;
+  void play_pause_event_handler(lv_obj_t* obj, lv_event_t event) {
+    auto* stopWatch = static_cast<StopWatch*>(obj->user_data);
+    stopWatch->playPauseBtnEventHandler(event);
   }
-}
 
-static void play_pause_event_handler(lv_obj_t* obj, lv_event_t event) {
-  auto stopWatch = static_cast<StopWatch*>(obj->user_data);
-  stopWatch->playPauseBtnEventHandler(event);
-}
-
-static void stop_lap_event_handler(lv_obj_t* obj, lv_event_t event) {
-  auto stopWatch = static_cast<StopWatch*>(obj->user_data);
-  stopWatch->stopLapBtnEventHandler(event);
+  void stop_lap_event_handler(lv_obj_t* obj, lv_event_t event) {
+    auto* stopWatch = static_cast<StopWatch*>(obj->user_data);
+    stopWatch->stopLapBtnEventHandler(event);
+  }
 }
 
 StopWatch::StopWatch(DisplayApp* app, System::SystemTask& systemTask)
@@ -67,8 +54,7 @@ StopWatch::StopWatch(DisplayApp* app, System::SystemTask& systemTask)
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
   btnPlayPause->user_data = this;
   lv_obj_set_event_cb(btnPlayPause, play_pause_event_handler);
-  lv_obj_set_height(btnPlayPause, 50);
-  lv_obj_set_width(btnPlayPause, 115);
+  lv_obj_set_size(btnPlayPause, 115, 50);
   lv_obj_align(btnPlayPause, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
   txtPlayPause = lv_label_create(btnPlayPause, nullptr);
   lv_label_set_text(txtPlayPause, Symbols::play);
@@ -76,8 +62,7 @@ StopWatch::StopWatch(DisplayApp* app, System::SystemTask& systemTask)
   btnStopLap = lv_btn_create(lv_scr_act(), nullptr);
   btnStopLap->user_data = this;
   lv_obj_set_event_cb(btnStopLap, stop_lap_event_handler);
-  lv_obj_set_height(btnStopLap, 50);
-  lv_obj_set_width(btnStopLap, 115);
+  lv_obj_set_size(btnStopLap, 115, 50);
   lv_obj_align(btnStopLap, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
   lv_obj_set_style_local_bg_color(btnStopLap, LV_BTN_PART_MAIN, LV_STATE_DISABLED, lv_color_hex(0x080808));
   txtStopLap = lv_label_create(btnStopLap, nullptr);
@@ -107,7 +92,7 @@ StopWatch::~StopWatch() {
   lv_obj_clean(lv_scr_act());
 }
 
-void StopWatch::reset() {
+void StopWatch::Reset() {
   currentState = States::Init;
   oldTimeElapsed = 0;
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
@@ -124,7 +109,7 @@ void StopWatch::reset() {
   lv_obj_set_state(txtStopLap, LV_STATE_DISABLED);
 }
 
-void StopWatch::start() {
+void StopWatch::Start() {
   lv_obj_set_state(btnStopLap, LV_STATE_DEFAULT);
   lv_obj_set_state(txtStopLap, LV_STATE_DEFAULT);
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GREEN);
@@ -136,7 +121,7 @@ void StopWatch::start() {
   systemTask.PushMessage(Pinetime::System::Messages::DisableSleeping);
 }
 
-void StopWatch::pause() {
+void StopWatch::Pause() {
   startTime = 0;
   // Store the current time elapsed in cache
   oldTimeElapsed += timeElapsed;
@@ -150,7 +135,7 @@ void StopWatch::pause() {
 
 void StopWatch::Refresh() {
   if (currentState == States::Running) {
-    timeElapsed = calculateDelta(startTime, xTaskGetTickCount());
+    timeElapsed = xTaskGetTickCount() - startTime;
     currentTimeSeparated = convertTicksToTimeSegments((oldTimeElapsed + timeElapsed));
 
     lv_label_set_text_fmt(time, "%02d:%02d", currentTimeSeparated.mins, currentTimeSeparated.secs);
@@ -163,11 +148,11 @@ void StopWatch::playPauseBtnEventHandler(lv_event_t event) {
     return;
   }
   if (currentState == States::Init) {
-    start();
+    Start();
   } else if (currentState == States::Running) {
-    pause();
+    Pause();
   } else if (currentState == States::Halted) {
-    start();
+    Start();
   }
 }
 
@@ -187,13 +172,13 @@ void StopWatch::stopLapBtnEventHandler(lv_event_t event) {
       lv_label_set_text_fmt(lapTwoText, "#%2d   %2d:%02d.%02d", lapNr, lapBuffer[0]->mins, lapBuffer[0]->secs, lapBuffer[0]->hundredths);
     }
   } else if (currentState == States::Halted) {
-    reset();
+    Reset();
   }
 }
 
 bool StopWatch::OnButtonPushed() {
   if (currentState == States::Running) {
-    pause();
+    Pause();
     return true;
   }
   return false;

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -70,9 +70,9 @@ namespace Pinetime::Applications::Screens {
     void stopLapBtnEventHandler(lv_event_t event);
     bool OnButtonPushed() override;
 
-    void reset();
-    void start();
-    void pause();
+    void Reset();
+    void Start();
+    void Pause();
 
   private:
     Pinetime::System::SystemTask& systemTask;


### PR DESCRIPTION
`calculateDelta()` isn't necessary, because `TickType_t` handles overflow naturally.
Use centiseconds in a conversion function instead of milliseconds, so the math uses smaller numbers and the last digit wasn't used anyway.
Other small fixes.