### PR TITLE
Keep preset backlight setting for flashlight app in off mode

### DIFF
--- a/src/displayapp/screens/FlashLight.h
+++ b/src/displayapp/screens/FlashLight.h
@@ -20,8 +20,7 @@ namespace Pinetime {
         void OnClickEvent(lv_obj_t* obj, lv_event_t event);
 
       private:
-        void SetIndicators();
-        void SetColors();
+        void Update(bool on, Pinetime::Controllers::BrightnessController::Levels level);
 
         Pinetime::System::SystemTask& systemTask;
         Controllers::BrightnessController& brightnessController;


### PR DESCRIPTION
Currently the flashlight app starts off and the user can turn it on by tapping the screen.

This modification is meant to reduce battery usage by restoring the previously-set backlight level when the user taps the screen to turn the light off.

In addition, for ease of usage the app is started with the flashlight on.

I tried to simplify and streamline the code a bit, saving 12 bytes in the compiled binary.