### PR TITLE
Flashlight app update

### DIFF
--- a/src/displayapp/screens/FlashLight.cpp
+++ b/src/displayapp/screens/FlashLight.cpp
@@ -4,51 +4,27 @@
 
 using namespace Pinetime::Applications::Screens;
 
-namespace {
-  void event_handler(lv_obj_t* obj, lv_event_t event) {
-    auto* screen = static_cast<FlashLight*>(obj->user_data);
-    screen->OnClickEvent(obj, event);
-  }
-}
-
 FlashLight::FlashLight(Pinetime::Applications::DisplayApp* app,
                        System::SystemTask& systemTask,
                        Controllers::BrightnessController& brightnessController)
-  : Screen(app),
-    systemTask {systemTask},
-    brightnessController {brightnessController}
-
-{
-  brightnessController.Backup();
-
-  brightnessLevel = brightnessController.Level();
+  : Screen(app), systemTask {systemTask}, brightnessController {brightnessController} {
 
   flashLight = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_sys_48);
   lv_label_set_text_static(flashLight, Symbols::highlight);
   lv_obj_align(flashLight, nullptr, LV_ALIGN_CENTER, 0, 0);
 
-  for (auto & i : indicators) {
-    i = lv_obj_create(lv_scr_act(), nullptr);
-    lv_obj_set_size(i, 15, 10);
-    lv_obj_set_style_local_border_width(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, 2);
-  }
+  brightnessController.Backup();
 
-  lv_obj_align(indicators[1], flashLight, LV_ALIGN_OUT_BOTTOM_MID, 0, 5);
-  lv_obj_align(indicators[0], indicators[1], LV_ALIGN_OUT_LEFT_MID, -8, 0);
-  lv_obj_align(indicators[2], indicators[1], LV_ALIGN_OUT_RIGHT_MID, 8, 0);
+  SetBrightness();
 
-  SetIndicators();
   SetColors();
 
-  backgroundAction = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_long_mode(backgroundAction, LV_LABEL_LONG_CROP);
-  lv_obj_set_size(backgroundAction, 240, 240);
-  lv_obj_set_pos(backgroundAction, 0, 0);
-  lv_label_set_text_static(backgroundAction, "");
-  lv_obj_set_click(backgroundAction, true);
-  backgroundAction->user_data = this;
-  lv_obj_set_event_cb(backgroundAction, event_handler);
+  backgroundLabel = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_long_mode(backgroundLabel, LV_LABEL_LONG_CROP);
+  lv_obj_set_size(backgroundLabel, 240, 240);
+  lv_obj_set_pos(backgroundLabel, 0, 0);
+  lv_label_set_text_static(backgroundLabel, "");
 
   systemTask.PushMessage(Pinetime::System::Messages::DisableSleeping);
 }
@@ -64,69 +40,46 @@ void FlashLight::SetColors() {
   if (isOn) {
     lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
     lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
-    for (auto & i : indicators) {
-      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
-      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DISABLED, LV_COLOR_WHITE);
-      lv_obj_set_style_local_border_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
-    }
   } else {
     lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-    lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-    for (auto & i : indicators) {
-      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DISABLED, LV_COLOR_BLACK);
-      lv_obj_set_style_local_border_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+    if (highBrightness) {
+      lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+    } else {
+      lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GRAY);
     }
   }
 }
 
-void FlashLight::SetIndicators() {
-  using namespace Pinetime::Controllers;
-
-  if (brightnessLevel == BrightnessController::Levels::High) {
-    lv_obj_set_state(indicators[1], LV_STATE_DEFAULT);
-    lv_obj_set_state(indicators[2], LV_STATE_DEFAULT);
-  } else if (brightnessLevel == BrightnessController::Levels::Medium) {
-    lv_obj_set_state(indicators[1], LV_STATE_DEFAULT);
-    lv_obj_set_state(indicators[2], LV_STATE_DISABLED);
+void FlashLight::SetBrightness() {
+  if (highBrightness) {
+    if (isOn) {
+      brightnessController.Set(Controllers::BrightnessController::Levels::High);
+    } else {
+      brightnessController.Restore();
+    }
   } else {
-    lv_obj_set_state(indicators[1], LV_STATE_DISABLED);
-    lv_obj_set_state(indicators[2], LV_STATE_DISABLED);
-  }
-}
-
-void FlashLight::OnClickEvent(lv_obj_t* obj, lv_event_t event) {
-  if (obj == backgroundAction && event == LV_EVENT_CLICKED) {
-    isOn = !isOn;
-    SetColors();
+    brightnessController.Set(Controllers::BrightnessController::Levels::Low);
   }
 }
 
 bool FlashLight::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
-  using namespace Pinetime::Controllers;
-
-  if (event == TouchEvents::SwipeLeft) {
-    if (brightnessLevel == BrightnessController::Levels::High) {
-      brightnessLevel = BrightnessController::Levels::Medium;
-      brightnessController.Set(brightnessLevel);
-      SetIndicators();
-    } else if (brightnessLevel == BrightnessController::Levels::Medium) {
-      brightnessLevel = BrightnessController::Levels::Low;
-      brightnessController.Set(brightnessLevel);
-      SetIndicators();
+  if (event == TouchEvents::SwipeLeft || event == TouchEvents::SwipeRight) {
+    highBrightness = !highBrightness;
+    SetBrightness();
+    if (!isOn) {
+      SetColors();
     }
     return true;
   }
-  if (event == TouchEvents::SwipeRight) {
-    if (brightnessLevel == BrightnessController::Levels::Low) {
-      brightnessLevel = BrightnessController::Levels::Medium;
-      brightnessController.Set(brightnessLevel);
-      SetIndicators();
-    } else if (brightnessLevel == BrightnessController::Levels::Medium) {
-      brightnessLevel = BrightnessController::Levels::High;
-      brightnessController.Set(brightnessLevel);
-      SetIndicators();
+  if (event == TouchEvents::Tap) {
+    // When launching the app, one tap event gets erronously handled. Ignore it in app for now.
+    if (!firstTapDone) {
+      firstTapDone = true;
+      return true;
     }
+    isOn = !isOn;
+    SetColors();
+    SetBrightness();
     return true;
   }
 

--- a/src/displayapp/screens/FlashLight.h
+++ b/src/displayapp/screens/FlashLight.h
@@ -17,21 +17,19 @@ namespace Pinetime {
         ~FlashLight() override;
 
         bool OnTouchEvent(Pinetime::Applications::TouchEvents event) override;
-        void OnClickEvent(lv_obj_t* obj, lv_event_t event);
 
       private:
-        void SetIndicators();
         void SetColors();
+        void SetBrightness();
 
         Pinetime::System::SystemTask& systemTask;
         Controllers::BrightnessController& brightnessController;
 
-        Controllers::BrightnessController::Levels brightnessLevel;
-
         lv_obj_t* flashLight;
-        lv_obj_t* backgroundAction;
-        lv_obj_t* indicators[3];
+        lv_obj_t* backgroundLabel;
         bool isOn = false;
+        bool highBrightness = true;
+        bool firstTapDone = false;
       };
     }
   }


### PR DESCRIPTION
~Start with the flashlight on.~
Remove middle brightness option.
~Long press the app icon to launch with low brightness.~

When the flashlight is off in high brightness mode, the backlight level will be the system backlight level. In low brightness mode, the backlight brightness will always be low. The flashlight icon dims slightly in low brightness mode, so you can distinguish the modes when the system brightness is low.

This uses the tap touch event instead of an LVGL click to toggle the flashlight, since even though it's slightly slower, it doesn't accidentally activate when swiping.

This video is outdated. The flashlight will default to off and the long press option is removed

https://user-images.githubusercontent.com/37774658/163480241-ace88433-873f-4545-b623-9e267e6cd10c.mp4

Fixes #836