### PR TITLE
Heart Rate measurements regularly every 60 seconds

### DIFF
--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -6,12 +6,13 @@
 using namespace Pinetime::Applications;
 
 HeartRateTask::HeartRateTask(Drivers::Hrs3300& heartRateSensor, Controllers::HeartRateController& controller)
-  : heartRateSensor {heartRateSensor}, controller {controller}, ppg{} {
+  : heartRateSensor {heartRateSensor}, controller {controller}, ppg {} {
 }
 
 void HeartRateTask::Start() {
   messageQueue = xQueueCreate(10, 1);
   controller.SetHeartRateTask(this);
+  lastRegularMeasurementTick = xTaskGetTickCount();
 
   if (pdPASS != xTaskCreate(HeartRateTask::Process, "Heartrate", 500, this, 0, &taskHandle))
     APP_ERROR_HANDLER(NRF_ERROR_NO_MEM);
@@ -27,40 +28,71 @@ void HeartRateTask::Work() {
   while (true) {
     Messages msg;
     uint32_t delay;
-    if (state == States::Running) {
-      if (measurementStarted)
+    if (state == States::Running || regularMeasurementStarted) {
+      if (measurementStarted) {
         delay = 40;
-      else
+      } else {
         delay = 100;
-    } else
+      }
+    } else {
       delay = portMAX_DELAY;
-
+    }
     if (xQueueReceive(messageQueue, &msg, delay)) {
       switch (msg) {
         case Messages::GoToSleep:
+          // we don't want the regular measurement to stop if the watch goes to sleep, although we do want it to stop if it was
+          // started by a user, to save power
+          if (regularMeasurementStarted) {
+            break;
+          }
           StopMeasurement();
           state = States::Idle;
           break;
         case Messages::WakeUp:
           state = States::Running;
-          if (measurementStarted) {
+          // if the user started a measurement it was paused by GoToSleep so needs to be started again. If there is a regular Measurement
+          // it was never stopped and must not be started again (as that would all currently collected data)
+          if (userStartedMeasurement && !regularMeasurementStarted) {
             lastBpm = 0;
             StartMeasurement();
           }
           break;
         case Messages::StartMeasurement:
-          if (measurementStarted)
+          if (measurementStarted) {
+            // the user started a measurement
+            userStartedMeasurement = true;
             break;
+          }
           lastBpm = 0;
           StartMeasurement();
           measurementStarted = true;
           break;
         case Messages::StopMeasurement:
-          if (!measurementStarted)
-            break;
-          StopMeasurement();
+          if (measurementStarted) {
+            StopMeasurement();
+          }
+
+          // if the user stops a measurement manually the regular measurement is cancelled as well
+          // keeping the sensor on even after pressing the stop button could be confusing (although it turns on a tenth of a second later
+          // again anyway)
           measurementStarted = false;
+          userStartedMeasurement = false;
+          regularMeasurementStarted = false;
           break;
+      }
+    }
+    // compare if a Measurement should be started
+    if (
+      // if the variable is set to zero the feature is disabled and no measurement is supposed to be started
+      regularMeasurmentWait != 0 &&
+      // check if enough seconds have passed since the last measurement
+      ((xTaskGetTickCount() - lastRegularMeasurementTick) / configTICK_RATE_HZ) > regularMeasurmentWait && !regularMeasurementStarted) {
+      regularMeasurementStarted = true;
+      // if there currently is a measurement it must not be started again, as that would invalidate all currently collected data
+      if (!measurementStarted) {
+        lastBpm = 0;
+        StartMeasurement();
+        measurementStarted = true;
       }
     }
 
@@ -72,7 +104,17 @@ void HeartRateTask::Work() {
         controller.Update(Controllers::HeartRateController::States::NotEnoughData, 0);
       if (bpm != 0) {
         lastBpm = bpm;
+        // this method handles a ble service as well, so nothing has to be done with the collected heart rate
         controller.Update(Controllers::HeartRateController::States::Running, lastBpm);
+        if (regularMeasurementStarted) {
+          regularMeasurementStarted = false;
+          lastRegularMeasurementTick = xTaskGetTickCount();
+          // we only want to turn the sensor off, if the user isn't currently manually measuring the heart rate
+          if (!userStartedMeasurement) {
+            StopMeasurement();
+            measurementStarted = false;
+          }
+        }
       }
     }
   }

--- a/src/heartratetask/HeartRateTask.h
+++ b/src/heartratetask/HeartRateTask.h
@@ -33,7 +33,16 @@ namespace Pinetime {
       Drivers::Hrs3300& heartRateSensor;
       Controllers::HeartRateController& controller;
       Controllers::Ppg ppg;
+      // did the user manually start a measurement?
+      bool userStartedMeasurement = false;
+      // is there any measurement started?
       bool measurementStarted = false;
+      // is there a regular measurement running atm?
+      bool regularMeasurementStarted = false;
+      // last time a measurement was done (in tickks)
+      uint32_t lastRegularMeasurementTick;
+      // time to wait between measurements (in seconds)
+      const uint8_t regularMeasurmentWait = 60;
     };
 
   }


### PR DESCRIPTION
This pull requests starts a Heart Rate measurement every 60 seconds. 
It's a bit wanky if the user wants to stop the heart rate sensor in the app while a measurement is running. At the moment it turns off the sensor, but will turn it back on the next time it checks if it needs to go on (currently 1 tenth of a second I think), because I thought it would be confusing if the sensor wouldn't turn off at all.
It's also not detected by the Heart Rate App yet if the sensor is running before the app is started, so it still gives the option to start the sensor, even though it is on, the press has no effect though (except that the app starts to show the current heart Rate). The digi watch face was able to detect the heart rate and showed that a measurement is going on.

In the future it might be a good idea to average out the heart rate over a prolonged period instead of taking the first avaible value to reduce noise, this would depend on #1092.

This might be useful for general fitness tracking (#749), sleep tracking (#307) or just to keep track of your heart rate (#895).
The intervall could easily be implemented as a setting, I don't know how to implement new settings though, especially if they are supposed to be persistent.
60 Seconds does seem quite often when my watch was just laying aroung on the table, so the standard might be something more like 90/120. 
I'll let the watch run overnight to see how much power would be consumed by this feature.