### PR TITLE
List: add missing array include

### DIFF
--- a/src/displayapp/screens/List.h
+++ b/src/displayapp/screens/List.h
@@ -2,7 +2,7 @@
 
 #include <lvgl/lvgl.h>
 #include <cstdint>
-#include <memory>
+#include <array>
 #include "displayapp/screens/Screen.h"
 #include "displayapp/Apps.h"
 #include "components/settings/Settings.h"


### PR DESCRIPTION
List.h uses `std::array` as container, but is missing the `<array>`
include. Add it to make the header self contained.