### PR TITLE
Timer UI redesign

### DIFF
--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -96,8 +96,9 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
 
   uint32_t seconds = timerController.GetTimeRemaining() / 1000;
   lv_label_set_text_fmt(time, "%02lu:%02lu", seconds / 60, seconds % 60);
+  lv_obj_set_style_local_text_letter_space(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, -3);
 
-  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, -20);
+  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 10, -20);
   
 
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -58,7 +58,6 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_obj_set_style_local_bg_grad_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_dir(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
-  lv_obj_set_parent(bgMinutesUp, backgroundLabel);
   lv_obj_set_size(bgMinutesUp, 100, 90);
   lv_obj_align(bgMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, -60, -75);
  
@@ -67,7 +66,6 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_obj_set_style_local_bg_grad_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_dir(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
-  lv_obj_set_parent(bgMinutesDown, backgroundLabel);
   lv_obj_set_size(bgMinutesDown, 100, 90);
   lv_obj_align(bgMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, -60, 15);
 
@@ -76,7 +74,6 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_obj_set_style_local_bg_grad_color(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_dir(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
-  lv_obj_set_parent(bgSecondsUp, backgroundLabel);
   lv_obj_set_size(bgSecondsUp, 100, 90);
   lv_obj_align(bgSecondsUp, lv_scr_act(), LV_ALIGN_CENTER, 60, -75);
 
@@ -85,7 +82,6 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_obj_set_style_local_bg_grad_color(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_dir(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
-  lv_obj_set_parent(bgSecondsDown, backgroundLabel);
   lv_obj_set_size(bgSecondsDown, 100, 90);
   lv_obj_align(bgSecondsDown, lv_scr_act(), LV_ALIGN_CENTER, 60, 15);
 

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -11,57 +11,35 @@ static void btnEventHandler(lv_obj_t* obj, lv_event_t event) {
 }
 
 void Timer::CreateButtons() {
-  btnMinutesUp = lv_btn_create(lv_scr_act(), nullptr);
+  btnMinutesUp = lv_btn_create(lv_scr_act(), bgMinutesUp);
   btnMinutesUp->user_data = this;
   lv_obj_set_event_cb(btnMinutesUp, btnEventHandler);
-  lv_obj_align(btnMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, -65, -90);
-  //lv_obj_set_style_local_bg_opa(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_set_style_local_bg_color(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-  lv_obj_set_style_local_bg_grad_color(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-  lv_obj_set_style_local_bg_grad_dir(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_bg_opa(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
   lv_obj_set_style_local_radius(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
-  lv_obj_move_background(btnMinutesUp);
-  lv_obj_set_size(btnMinutesUp, 100, 90);
   txtMUp = lv_label_create(btnMinutesUp, nullptr);
   lv_label_set_text_static(txtMUp, "+");
-  //lv_obj_align(txtMUp, btnMinutesUp, LV_ALIGN_CENTER, 0, -20);
 
-  btnMinutesDown = lv_btn_create(lv_scr_act(), nullptr);
+  btnMinutesDown = lv_btn_create(lv_scr_act(), bgMinutesDown);
   btnMinutesDown->user_data = this;
   lv_obj_set_event_cb(btnMinutesDown, btnEventHandler);
-  lv_obj_align(btnMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, -65, 0);
-  lv_obj_set_style_local_bg_color(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-  lv_obj_set_style_local_bg_grad_color(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-  lv_obj_set_style_local_bg_grad_dir(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_bg_opa(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
   lv_obj_set_style_local_radius(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
-  lv_obj_move_background(btnMinutesDown);
-  lv_obj_set_size(btnMinutesDown, 100, 90);
   txtMDown = lv_label_create(btnMinutesDown, nullptr);
   lv_label_set_text_static(txtMDown, "-");
 
-  btnSecondsUp = lv_btn_create(lv_scr_act(), nullptr);
+  btnSecondsUp = lv_btn_create(lv_scr_act(), bgSecondsUp);
   btnSecondsUp->user_data = this;
   lv_obj_set_event_cb(btnSecondsUp, btnEventHandler);
-  lv_obj_align(btnSecondsUp, lv_scr_act(), LV_ALIGN_CENTER, 65, -90);
-  lv_obj_set_style_local_bg_color(btnSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-  lv_obj_set_style_local_bg_grad_color(btnSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-  lv_obj_set_style_local_bg_grad_dir(btnSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
-  lv_obj_set_style_local_radius(btnSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
-  lv_obj_move_background(btnSecondsUp);
-  lv_obj_set_size(btnSecondsUp, 100, 90);
+  lv_obj_set_style_local_bg_opa(btnSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
+  lv_obj_set_style_local_radius(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtSUp = lv_label_create(btnSecondsUp, nullptr);
   lv_label_set_text_static(txtSUp, "+");
 
-  btnSecondsDown = lv_btn_create(lv_scr_act(), nullptr);
+  btnSecondsDown = lv_btn_create(lv_scr_act(), bgSecondsDown);
   btnSecondsDown->user_data = this;
   lv_obj_set_event_cb(btnSecondsDown, btnEventHandler);
-  lv_obj_align(btnSecondsDown, lv_scr_act(), LV_ALIGN_CENTER, 65, 0);
-  lv_obj_set_style_local_bg_color(btnSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-  lv_obj_set_style_local_bg_grad_color(btnSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-  lv_obj_set_style_local_bg_grad_dir(btnSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_bg_opa(btnSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
   lv_obj_set_style_local_radius(btnSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
-  lv_obj_move_background(btnSecondsDown);
-  lv_obj_set_size(btnSecondsDown, 100, 90);
   txtSDown = lv_label_create(btnSecondsDown, nullptr);
   lv_label_set_text_static(txtSDown, "-");
 }
@@ -74,6 +52,43 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_obj_set_size(backgroundLabel, 240, 240);
   lv_obj_set_pos(backgroundLabel, 0, 0);
   lv_label_set_text_static(backgroundLabel, "");
+
+  bgMinutesUp = lv_btn_create(lv_scr_act(), nullptr);
+  lv_obj_align(bgMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, -65, -90);
+  lv_obj_set_style_local_bg_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_dir(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_parent(bgMinutesUp, backgroundLabel);
+  lv_obj_set_size(bgMinutesUp, 100, 90);
+ 
+  bgMinutesDown = lv_btn_create(lv_scr_act(), nullptr);
+  lv_obj_align(bgMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, -65, 0);
+  lv_obj_set_style_local_bg_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_dir(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_parent(bgMinutesDown, backgroundLabel);
+  lv_obj_set_size(bgMinutesDown, 100, 90);
+
+  bgSecondsUp = lv_btn_create(lv_scr_act(), nullptr);
+  lv_obj_align(bgSecondsUp, lv_scr_act(), LV_ALIGN_CENTER, 65, -90);
+  lv_obj_set_style_local_bg_color(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_color(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_dir(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_parent(bgSecondsUp, backgroundLabel);
+  lv_obj_set_size(bgSecondsUp, 100, 90);
+
+  bgSecondsDown = lv_btn_create(lv_scr_act(), nullptr);
+  lv_obj_align(bgSecondsDown, lv_scr_act(), LV_ALIGN_CENTER, 65, 0);
+  lv_obj_set_style_local_bg_color(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_color(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_dir(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_parent(bgSecondsDown, backgroundLabel);
+  lv_obj_set_size(bgSecondsDown, 100, 90);
+
 
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
@@ -136,6 +151,7 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
         btnMinutesDown = nullptr;
         lv_obj_del(btnMinutesUp);
         btnMinutesUp = nullptr;
+        
       }
     } else {
       if (!timerController.IsRunning()) {

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -54,40 +54,40 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_label_set_text_static(backgroundLabel, "");
 
   bgMinutesUp = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, -60, -95);
   lv_obj_set_style_local_bg_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_dir(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_parent(bgMinutesUp, backgroundLabel);
   lv_obj_set_size(bgMinutesUp, 100, 90);
+  lv_obj_align(bgMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, -60, -75);
  
   bgMinutesDown = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, -60, -5);
   lv_obj_set_style_local_bg_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_dir(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_parent(bgMinutesDown, backgroundLabel);
   lv_obj_set_size(bgMinutesDown, 100, 90);
+  lv_obj_align(bgMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, -60, 15);
 
   bgSecondsUp = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgSecondsUp, lv_scr_act(), LV_ALIGN_CENTER, 60, -95);
   lv_obj_set_style_local_bg_color(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_color(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_dir(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_parent(bgSecondsUp, backgroundLabel);
   lv_obj_set_size(bgSecondsUp, 100, 90);
+  lv_obj_align(bgSecondsUp, lv_scr_act(), LV_ALIGN_CENTER, 60, -75);
 
   bgSecondsDown = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgSecondsDown, lv_scr_act(), LV_ALIGN_CENTER, 60, -5);
   lv_obj_set_style_local_bg_color(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_color(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_dir(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_parent(bgSecondsDown, backgroundLabel);
   lv_obj_set_size(bgSecondsDown, 100, 90);
+  lv_obj_align(bgSecondsDown, lv_scr_act(), LV_ALIGN_CENTER, 60, 15);
 
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
@@ -102,15 +102,15 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_label_set_text_fmt(time, "%02lu:%02lu", seconds / 60, seconds % 60);
   lv_obj_set_style_local_text_letter_space(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, -6);
 
-  lv_obj_align(time, lv_scr_act(), LV_ALIGN_CENTER, -1, -20);
-  lv_obj_align(colon, lv_scr_act(), LV_ALIGN_CENTER, 0, -25);
+  lv_obj_align(time, lv_scr_act(), LV_ALIGN_CENTER, -1, -30);
+  lv_obj_align(colon, lv_scr_act(), LV_ALIGN_CENTER, 0, -35);
 
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
   btnPlayPause->user_data = this;
   lv_obj_set_event_cb(btnPlayPause, btnEventHandler);
-  lv_obj_align(btnPlayPause, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
   lv_obj_set_style_local_bg_color(btnPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_SILVER);
   lv_obj_set_size(btnPlayPause, 120, 50);
+  lv_obj_align(btnPlayPause, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
   txtPlayPause = lv_label_create(btnPlayPause, nullptr);
   if (timerController.IsRunning()) {
     lv_label_set_text_static(txtPlayPause, Symbols::pause);

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -14,32 +14,54 @@ void Timer::CreateButtons() {
   btnMinutesUp = lv_btn_create(lv_scr_act(), nullptr);
   btnMinutesUp->user_data = this;
   lv_obj_set_event_cb(btnMinutesUp, btnEventHandler);
-  lv_obj_set_size(btnMinutesUp, 60, 40);
-  lv_obj_align(btnMinutesUp, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 20, -85);
+  lv_obj_align(btnMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, -65, -90);
+  //lv_obj_set_style_local_bg_opa(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
+  lv_obj_set_style_local_bg_color(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_color(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_dir(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_move_background(btnMinutesUp);
+  lv_obj_set_size(btnMinutesUp, 100, 90);
   txtMUp = lv_label_create(btnMinutesUp, nullptr);
   lv_label_set_text_static(txtMUp, "+");
+  //lv_obj_align(txtMUp, btnMinutesUp, LV_ALIGN_CENTER, 0, -20);
 
   btnMinutesDown = lv_btn_create(lv_scr_act(), nullptr);
   btnMinutesDown->user_data = this;
   lv_obj_set_event_cb(btnMinutesDown, btnEventHandler);
-  lv_obj_set_size(btnMinutesDown, 60, 40);
-  lv_obj_align(btnMinutesDown, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 20, 35);
+  lv_obj_align(btnMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, -65, 0);
+  lv_obj_set_style_local_bg_color(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_color(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_dir(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_move_background(btnMinutesDown);
+  lv_obj_set_size(btnMinutesDown, 100, 90);
   txtMDown = lv_label_create(btnMinutesDown, nullptr);
   lv_label_set_text_static(txtMDown, "-");
 
   btnSecondsUp = lv_btn_create(lv_scr_act(), nullptr);
   btnSecondsUp->user_data = this;
   lv_obj_set_event_cb(btnSecondsUp, btnEventHandler);
-  lv_obj_set_size(btnSecondsUp, 60, 40);
-  lv_obj_align(btnSecondsUp, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -20, -85);
+  lv_obj_align(btnSecondsUp, lv_scr_act(), LV_ALIGN_CENTER, 65, -90);
+  lv_obj_set_style_local_bg_color(btnSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_color(btnSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_dir(btnSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(btnSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_move_background(btnSecondsUp);
+  lv_obj_set_size(btnSecondsUp, 100, 90);
   txtSUp = lv_label_create(btnSecondsUp, nullptr);
   lv_label_set_text_static(txtSUp, "+");
 
   btnSecondsDown = lv_btn_create(lv_scr_act(), nullptr);
   btnSecondsDown->user_data = this;
   lv_obj_set_event_cb(btnSecondsDown, btnEventHandler);
-  lv_obj_set_size(btnSecondsDown, 60, 40);
-  lv_obj_align(btnSecondsDown, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -20, 35);
+  lv_obj_align(btnSecondsDown, lv_scr_act(), LV_ALIGN_CENTER, 65, 0);
+  lv_obj_set_style_local_bg_color(btnSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_color(btnSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_dir(btnSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(btnSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_move_background(btnSecondsDown);
+  lv_obj_set_size(btnSecondsDown, 100, 90);
   txtSDown = lv_label_create(btnSecondsDown, nullptr);
   lv_label_set_text_static(txtSDown, "-");
 }
@@ -59,7 +81,9 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
 
   uint32_t seconds = timerController.GetTimeRemaining() / 1000;
   lv_label_set_text_fmt(time, "%02lu:%02lu", seconds / 60, seconds % 60);
-  lv_obj_align(time, lv_scr_act(), LV_ALIGN_CENTER, 0, -25);
+
+  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, -20);
+  
 
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
   btnPlayPause->user_data = this;

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -203,7 +203,7 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
           if (minutesToSet >= 59) {
             minutesToSet = 0;
           } else {
-            minutesToSet = (minutesToSet + 2);
+            minutesToSet++;
           }
           lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
 
@@ -211,7 +211,7 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
           if (minutesToSet <= 0) {
             minutesToSet = 59;
           } else {
-            minutesToSet = (minutesToSet - 2);
+            minutesToSet--;
           }
           lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
 
@@ -219,7 +219,7 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
           if (secondsToSet >= 59) {
             secondsToSet = 0;
           } else {
-            secondsToSet = (secondsToSet + 2);
+            secondsToSet++;
           }
           lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
 
@@ -227,7 +227,7 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
           if (secondsToSet <= 0) {
             secondsToSet = 59;
           } else {
-            secondsToSet = (secondsToSet - 2);
+            secondsToSet--;
           }
           lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
         }

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -18,6 +18,8 @@ void Timer::CreateButtons() {
   lv_obj_set_style_local_radius(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtMUp = lv_label_create(btnMinutesUp, nullptr);
   lv_label_set_text_static(txtMUp, "+");
+  lv_btn_set_layout(btnMinutesUp, LV_LAYOUT_OFF);
+  lv_obj_align(txtMUp, btnMinutesUp, LV_ALIGN_CENTER, 0, -10);
 
   btnMinutesDown = lv_btn_create(lv_scr_act(), bgMinutesDown);
   btnMinutesDown->user_data = this;
@@ -26,6 +28,8 @@ void Timer::CreateButtons() {
   lv_obj_set_style_local_radius(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtMDown = lv_label_create(btnMinutesDown, nullptr);
   lv_label_set_text_static(txtMDown, "-");
+  lv_btn_set_layout(btnMinutesDown, LV_LAYOUT_OFF);
+  lv_obj_align(txtMDown, btnMinutesDown, LV_ALIGN_CENTER, 0, 10);
 
   btnSecondsUp = lv_btn_create(lv_scr_act(), bgSecondsUp);
   btnSecondsUp->user_data = this;
@@ -34,6 +38,8 @@ void Timer::CreateButtons() {
   lv_obj_set_style_local_radius(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtSUp = lv_label_create(btnSecondsUp, nullptr);
   lv_label_set_text_static(txtSUp, "+");
+  lv_btn_set_layout(btnSecondsUp, LV_LAYOUT_OFF);
+  lv_obj_align(txtSUp, btnSecondsUp, LV_ALIGN_CENTER, 0, -10);
 
   btnSecondsDown = lv_btn_create(lv_scr_act(), bgSecondsDown);
   btnSecondsDown->user_data = this;
@@ -42,6 +48,8 @@ void Timer::CreateButtons() {
   lv_obj_set_style_local_radius(btnSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtSDown = lv_label_create(btnSecondsDown, nullptr);
   lv_label_set_text_static(txtSDown, "-");
+  lv_btn_set_layout(btnSecondsDown, LV_LAYOUT_OFF);
+  lv_obj_align(txtSDown, btnSecondsDown, LV_ALIGN_CENTER, 0, 10);
 }
 
 Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -54,7 +54,7 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_label_set_text_static(backgroundLabel, "");
 
   bgMinutesUp = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, -65, -90);
+  lv_obj_align(bgMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, -60, -95);
   lv_obj_set_style_local_bg_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_dir(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
@@ -63,7 +63,7 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_obj_set_size(bgMinutesUp, 100, 90);
  
   bgMinutesDown = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, -65, 0);
+  lv_obj_align(bgMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, -60, -5);
   lv_obj_set_style_local_bg_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_dir(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
@@ -72,7 +72,7 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_obj_set_size(bgMinutesDown, 100, 90);
 
   bgSecondsUp = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgSecondsUp, lv_scr_act(), LV_ALIGN_CENTER, 65, -90);
+  lv_obj_align(bgSecondsUp, lv_scr_act(), LV_ALIGN_CENTER, 60, -95);
   lv_obj_set_style_local_bg_color(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_color(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_dir(bgSecondsUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
@@ -81,7 +81,7 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_obj_set_size(bgSecondsUp, 100, 90);
 
   bgSecondsDown = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgSecondsDown, lv_scr_act(), LV_ALIGN_CENTER, 65, 0);
+  lv_obj_align(bgSecondsDown, lv_scr_act(), LV_ALIGN_CENTER, 60, -5);
   lv_obj_set_style_local_bg_color(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_color(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_dir(bgSecondsDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
@@ -89,28 +89,35 @@ Timer::Timer(DisplayApp* app, Controllers::TimerController& timerController)
   lv_obj_set_parent(bgSecondsDown, backgroundLabel);
   lv_obj_set_size(bgSecondsDown, 100, 90);
 
-
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
-  lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0xb0, 0xb0, 0xb0));
+  lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+
+  colon = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_font(colon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
+  lv_obj_set_style_local_text_color(colon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_label_set_text_static(colon, ":");
 
   uint32_t seconds = timerController.GetTimeRemaining() / 1000;
   lv_label_set_text_fmt(time, "%02lu:%02lu", seconds / 60, seconds % 60);
-  lv_obj_set_style_local_text_letter_space(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, -3);
+  lv_obj_set_style_local_text_letter_space(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, -6);
 
-  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 10, -20);
-  
+  lv_obj_align(time, lv_scr_act(), LV_ALIGN_CENTER, -1, -20);
+  lv_obj_align(colon, lv_scr_act(), LV_ALIGN_CENTER, 0, -25);
 
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
   btnPlayPause->user_data = this;
   lv_obj_set_event_cb(btnPlayPause, btnEventHandler);
-  lv_obj_set_size(btnPlayPause, 120, 50);
   lv_obj_align(btnPlayPause, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
+  lv_obj_set_style_local_bg_color(btnPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_SILVER);
+  lv_obj_set_size(btnPlayPause, 120, 50);
   txtPlayPause = lv_label_create(btnPlayPause, nullptr);
   if (timerController.IsRunning()) {
     lv_label_set_text_static(txtPlayPause, Symbols::pause);
+    lv_obj_set_style_local_text_color(txtPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   } else {
     lv_label_set_text_static(txtPlayPause, Symbols::play);
+    lv_obj_set_style_local_text_color(txtPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
     CreateButtons();
   }
 
@@ -165,7 +172,7 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
           lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
 
         } else if (obj == btnMinutesDown) {
-          if (minutesToSet == 0) {
+          if (minutesToSet <= 0) {
             minutesToSet = 59;
           } else {
             minutesToSet--;
@@ -181,7 +188,7 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
           lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
 
         } else if (obj == btnSecondsDown) {
-          if (secondsToSet == 0) {
+          if (secondsToSet <= 0) {
             secondsToSet = 59;
           } else {
             secondsToSet--;
@@ -189,6 +196,41 @@ void Timer::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
           lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
         }
       }
+    }
+  } else if (event == LV_EVENT_LONG_PRESSED_REPEAT) {
+    if (!timerController.IsRunning()) {
+        if (obj == btnMinutesUp) {
+          if (minutesToSet >= 59) {
+            minutesToSet = 0;
+          } else {
+            minutesToSet = (minutesToSet + 2);
+          }
+          lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
+
+        } else if (obj == btnMinutesDown) {
+          if (minutesToSet <= 0) {
+            minutesToSet = 59;
+          } else {
+            minutesToSet = (minutesToSet - 2);
+          }
+          lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
+
+        } else if (obj == btnSecondsUp) {
+          if (secondsToSet >= 59) {
+            secondsToSet = 0;
+          } else {
+            secondsToSet = (secondsToSet + 2);
+          }
+          lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
+
+        } else if (obj == btnSecondsDown) {
+          if (secondsToSet <= 0) {
+            secondsToSet = 59;
+          } else {
+            secondsToSet = (secondsToSet - 2);
+          }
+          lv_label_set_text_fmt(time, "%02d:%02d", minutesToSet, secondsToSet);
+        }
     }
   }
 }

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -26,6 +26,7 @@ namespace Pinetime::Applications::Screens {
     Controllers::TimerController& timerController;
     lv_obj_t* backgroundLabel;
     lv_obj_t* time;
+    lv_obj_t* colon;
     lv_obj_t* msecTime;
     lv_obj_t* btnPlayPause;
     lv_obj_t* txtPlayPause;

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -33,6 +33,10 @@ namespace Pinetime::Applications::Screens {
     lv_obj_t* btnMinutesDown;
     lv_obj_t* btnSecondsUp;
     lv_obj_t* btnSecondsDown;
+    lv_obj_t* bgMinutesUp;
+    lv_obj_t* bgMinutesDown;
+    lv_obj_t* bgSecondsUp;
+    lv_obj_t* bgSecondsDown;
     lv_obj_t* txtMUp;
     lv_obj_t* txtMDown;
     lv_obj_t* txtSUp;


### PR DESCRIPTION
The main goal of this PR is to increase the button size in the timer app to make incrementing and decrementing the time easier. To do this I've made the buttons transparent and put a gradient behind them to give a roller-type look, the buttons are now 100x90 instead of 60x40. 

I've changed the text color to black on the light background to increase contrast/readability, and added a long-press fast increment in preparation for #1093 

I had planned to split the minutes and seconds into separate labels to allow the colon between to be a different color, but using the letter_spacing setting I was able to get the alignment pretty good, and I overlaid a white colon - bit of a hack but I hope it's forgivable.

I think this would probably be usable on the alarm app, the info button might be a bit tricky but it should work. It could be theme-able later but I aimed for maximum contrast for now.

It looks like this:

![image](https://user-images.githubusercontent.com/3533345/165362483-d4d64a0b-ea83-453f-8785-91cc7cc129eb.png)

