### PR TITLE
Alarm UI redesign

### DIFF
--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -137,7 +137,7 @@ Alarm::Alarm(DisplayApp* app,
   btnStop = lv_btn_create(lv_scr_act(), nullptr);
   btnStop->user_data = this;
   lv_obj_set_event_cb(btnStop, btnEventHandler);
-  lv_obj_set_size(btnStop, 115, 50);
+  lv_obj_set_size(btnStop, 85, 50);
   lv_obj_align(btnStop, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
   lv_obj_set_style_local_bg_color(btnStop, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_RED);
   txtStop = lv_label_create(btnStop, nullptr);

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -38,6 +38,38 @@ Alarm::Alarm(DisplayApp* app,
              System::SystemTask& systemTask)
   : Screen(app), alarmController {alarmController}, settingsController {settingsController}, systemTask {systemTask} {
 
+  bgHoursUp = lv_btn_create(lv_scr_act(), nullptr);
+  lv_obj_align(bgHoursUp, lv_scr_act(), LV_ALIGN_CENTER, 60, -95);
+  lv_obj_set_style_local_bg_color(bgHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_color(bgHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_dir(bgHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(bgHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_size(bgHoursUp, 100, 90);
+
+  bgHoursDown = lv_btn_create(lv_scr_act(), nullptr);
+  lv_obj_align(bgHoursDown, lv_scr_act(), LV_ALIGN_CENTER, 60, -5);
+  lv_obj_set_style_local_bg_color(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_color(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_dir(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_size(bgHoursDown, 100, 90);
+
+  bgMinutesUp = lv_btn_create(lv_scr_act(), nullptr);
+  lv_obj_align(bgMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, -60, -95);
+  lv_obj_set_style_local_bg_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_dir(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_size(bgMinutesUp, 100, 90);
+
+  bgMinutesDown = lv_btn_create(lv_scr_act(), nullptr);
+  lv_obj_align(bgMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, -60, -5);
+  lv_obj_set_style_local_bg_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_obj_set_style_local_bg_grad_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_bg_grad_dir(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
+  lv_obj_set_style_local_radius(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_size(bgMinutesDown, 100, 90);
+
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0xb0, 0xb0, 0xb0));
@@ -55,35 +87,35 @@ Alarm::Alarm(DisplayApp* app,
   lv_label_set_align(lblampm, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(lblampm, lv_scr_act(), LV_ALIGN_CENTER, 0, 30);
 
-  btnHoursUp = lv_btn_create(lv_scr_act(), nullptr);
+  btnHoursUp = lv_btn_create(lv_scr_act(), bgHoursUp);
   btnHoursUp->user_data = this;
   lv_obj_set_event_cb(btnHoursUp, btnEventHandler);
-  lv_obj_set_size(btnHoursUp, 60, 40);
-  lv_obj_align(btnHoursUp, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 20, -85);
+  lv_obj_set_style_local_bg_opa(btnHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
+  lv_obj_set_style_local_radius(btnHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtHrUp = lv_label_create(btnHoursUp, nullptr);
   lv_label_set_text_static(txtHrUp, "+");
 
-  btnHoursDown = lv_btn_create(lv_scr_act(), nullptr);
+  btnHoursDown = lv_btn_create(lv_scr_act(), bgHoursDown);
   btnHoursDown->user_data = this;
   lv_obj_set_event_cb(btnHoursDown, btnEventHandler);
-  lv_obj_set_size(btnHoursDown, 60, 40);
-  lv_obj_align(btnHoursDown, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 20, 35);
+  lv_obj_set_style_local_bg_opa(btnHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
+  lv_obj_set_style_local_radius(btnHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtHrDown = lv_label_create(btnHoursDown, nullptr);
   lv_label_set_text_static(txtHrDown, "-");
 
-  btnMinutesUp = lv_btn_create(lv_scr_act(), nullptr);
+  btnMinutesUp = lv_btn_create(lv_scr_act(), bgMinutesUp);
   btnMinutesUp->user_data = this;
   lv_obj_set_event_cb(btnMinutesUp, btnEventHandler);
-  lv_obj_set_size(btnMinutesUp, 60, 40);
-  lv_obj_align(btnMinutesUp, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -20, -85);
+  lv_obj_set_style_local_bg_opa(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
+  lv_obj_set_style_local_radius(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtMinUp = lv_label_create(btnMinutesUp, nullptr);
   lv_label_set_text_static(txtMinUp, "+");
 
-  btnMinutesDown = lv_btn_create(lv_scr_act(), nullptr);
+  btnMinutesDown = lv_btn_create(lv_scr_act(), bgMinutesDown);
   btnMinutesDown->user_data = this;
   lv_obj_set_event_cb(btnMinutesDown, btnEventHandler);
-  lv_obj_set_size(btnMinutesDown, 60, 40);
-  lv_obj_align(btnMinutesDown, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -20, 35);
+  lv_obj_set_style_local_bg_opa(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
+  lv_obj_set_style_local_radius(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtMinDown = lv_label_create(btnMinutesDown, nullptr);
   lv_label_set_text_static(txtMinDown, "-");
 

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -39,36 +39,37 @@ Alarm::Alarm(DisplayApp* app,
   : Screen(app), alarmController {alarmController}, settingsController {settingsController}, systemTask {systemTask} {
 
   bgHoursUp = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgHoursUp, lv_scr_act(), LV_ALIGN_CENTER, -60, -95);
   lv_obj_set_style_local_bg_color(bgHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_color(bgHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_dir(bgHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_size(bgHoursUp, 100, 90);
+  lv_obj_align(bgHoursUp, lv_scr_act(), LV_ALIGN_CENTER, -60, -75);
+
 
   bgHoursDown = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgHoursDown, lv_scr_act(), LV_ALIGN_CENTER, -60, -5);
   lv_obj_set_style_local_bg_color(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_color(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_dir(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_size(bgHoursDown, 100, 90);
+  lv_obj_align(bgHoursDown, lv_scr_act(), LV_ALIGN_CENTER, -60, 15);
 
   bgMinutesUp = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, 60, -95);
   lv_obj_set_style_local_bg_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_dir(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_size(bgMinutesUp, 100, 90);
+  lv_obj_align(bgMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, 60, -75);
 
   bgMinutesDown = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, 60, -5);
   lv_obj_set_style_local_bg_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_dir(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
   lv_obj_set_style_local_radius(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_size(bgMinutesDown, 100, 90);
+  lv_obj_align(bgMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, 60, 15);
 
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
@@ -84,8 +85,8 @@ Alarm::Alarm(DisplayApp* app,
   lv_label_set_text_fmt(time, "%02hhu:%02hhu", alarmHours, alarmMinutes);
 
   lv_obj_set_style_local_text_letter_space(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, -6);
-  lv_obj_align(time, lv_scr_act(), LV_ALIGN_CENTER, -1, -20);
-  lv_obj_align(colon, lv_scr_act(), LV_ALIGN_CENTER, 0, -25);
+  lv_obj_align(time, lv_scr_act(), LV_ALIGN_CENTER, -1, -30);
+  lv_obj_align(colon, lv_scr_act(), LV_ALIGN_CENTER, 0, -35);
 
   lblampm = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(lblampm, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -139,7 +139,7 @@ Alarm::Alarm(DisplayApp* app,
   btnRecur = lv_btn_create(lv_scr_act(), nullptr);
   btnRecur->user_data = this;
   lv_obj_set_event_cb(btnRecur, btnEventHandler);
-  lv_obj_set_size(btnRecur, 115, 50);
+  lv_obj_set_size(btnRecur, 95, 50);
   lv_obj_align(btnRecur, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
   lv_obj_set_style_local_bg_color(btnRecur, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_SILVER);
   txtRecur = lv_label_create(btnRecur, nullptr);
@@ -149,8 +149,8 @@ Alarm::Alarm(DisplayApp* app,
   btnInfo = lv_btn_create(lv_scr_act(), nullptr);
   btnInfo->user_data = this;
   lv_obj_set_event_cb(btnInfo, btnEventHandler);
-  lv_obj_set_size(btnInfo, 50, 40);
-  lv_obj_align(btnInfo, lv_scr_act(), LV_ALIGN_CENTER, 0, -95);
+  lv_obj_set_size(btnInfo, 50, 50);
+  lv_obj_align(btnInfo, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, -5, 0);
   lv_obj_set_style_local_bg_color(btnInfo, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_SILVER);
   txtInfo = lv_label_create(btnInfo, nullptr);
   lv_label_set_text_static(txtInfo, "i");
@@ -159,11 +159,11 @@ Alarm::Alarm(DisplayApp* app,
   enableSwitch = lv_switch_create(lv_scr_act(), nullptr);
   enableSwitch->user_data = this;
   lv_obj_set_event_cb(enableSwitch, btnEventHandler);
-  lv_obj_set_size(enableSwitch, 100, 50);
-  // Align to the center of 115px from edge
-  lv_obj_align(enableSwitch, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 7, 0);
+  lv_obj_set_size(enableSwitch, 85, 50);
+  lv_obj_align(enableSwitch, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
   lv_obj_set_style_local_bg_color(enableSwitch, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_SILVER);
   lv_obj_set_style_local_bg_color(enableSwitch, LV_SWITCH_PART_KNOB, LV_STATE_DEFAULT, LV_COLOR_GRAY);
+  lv_obj_set_style_local_bg_color(enableSwitch, LV_SWITCH_PART_KNOB, LV_STATE_CHECKED, LV_COLOR_GRAY);
 
 
   UpdateAlarmTime();

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -101,6 +101,8 @@ Alarm::Alarm(DisplayApp* app,
   lv_obj_set_style_local_radius(btnHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtHrUp = lv_label_create(btnHoursUp, nullptr);
   lv_label_set_text_static(txtHrUp, "+");
+  lv_btn_set_layout(btnHoursUp, LV_LAYOUT_OFF);
+  lv_obj_align(txtHrUp, btnHoursUp, LV_ALIGN_CENTER, 0, -10);
 
   btnHoursDown = lv_btn_create(lv_scr_act(), bgHoursDown);
   btnHoursDown->user_data = this;
@@ -109,6 +111,8 @@ Alarm::Alarm(DisplayApp* app,
   lv_obj_set_style_local_radius(btnHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtHrDown = lv_label_create(btnHoursDown, nullptr);
   lv_label_set_text_static(txtHrDown, "-");
+  lv_btn_set_layout(btnHoursDown, LV_LAYOUT_OFF);
+  lv_obj_align(txtHrDown, btnHoursDown, LV_ALIGN_CENTER, 0, 10);
 
   btnMinutesUp = lv_btn_create(lv_scr_act(), bgMinutesUp);
   btnMinutesUp->user_data = this;
@@ -117,6 +121,8 @@ Alarm::Alarm(DisplayApp* app,
   lv_obj_set_style_local_radius(btnMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtMinUp = lv_label_create(btnMinutesUp, nullptr);
   lv_label_set_text_static(txtMinUp, "+");
+  lv_btn_set_layout(btnMinutesUp, LV_LAYOUT_OFF);
+  lv_obj_align(txtMinUp, btnMinutesUp, LV_ALIGN_CENTER, 0, -10);
 
   btnMinutesDown = lv_btn_create(lv_scr_act(), bgMinutesDown);
   btnMinutesDown->user_data = this;
@@ -125,6 +131,8 @@ Alarm::Alarm(DisplayApp* app,
   lv_obj_set_style_local_radius(btnMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 0);
   txtMinDown = lv_label_create(btnMinutesDown, nullptr);
   lv_label_set_text_static(txtMinDown, "-");
+  lv_btn_set_layout(btnMinutesDown, LV_LAYOUT_OFF);
+  lv_obj_align(txtMinDown, btnMinutesDown, LV_ALIGN_CENTER, 0, 10);
 
   btnStop = lv_btn_create(lv_scr_act(), nullptr);
   btnStop->user_data = this;

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -39,7 +39,7 @@ Alarm::Alarm(DisplayApp* app,
   : Screen(app), alarmController {alarmController}, settingsController {settingsController}, systemTask {systemTask} {
 
   bgHoursUp = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgHoursUp, lv_scr_act(), LV_ALIGN_CENTER, 60, -95);
+  lv_obj_align(bgHoursUp, lv_scr_act(), LV_ALIGN_CENTER, -60, -95);
   lv_obj_set_style_local_bg_color(bgHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_color(bgHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_dir(bgHoursUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
@@ -47,7 +47,7 @@ Alarm::Alarm(DisplayApp* app,
   lv_obj_set_size(bgHoursUp, 100, 90);
 
   bgHoursDown = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgHoursDown, lv_scr_act(), LV_ALIGN_CENTER, 60, -5);
+  lv_obj_align(bgHoursDown, lv_scr_act(), LV_ALIGN_CENTER, -60, -5);
   lv_obj_set_style_local_bg_color(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_color(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_dir(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
@@ -55,7 +55,7 @@ Alarm::Alarm(DisplayApp* app,
   lv_obj_set_size(bgHoursDown, 100, 90);
 
   bgMinutesUp = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, -60, -95);
+  lv_obj_align(bgMinutesUp, lv_scr_act(), LV_ALIGN_CENTER, 60, -95);
   lv_obj_set_style_local_bg_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_color(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_dir(bgMinutesUp, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
@@ -63,7 +63,7 @@ Alarm::Alarm(DisplayApp* app,
   lv_obj_set_size(bgMinutesUp, 100, 90);
 
   bgMinutesDown = lv_btn_create(lv_scr_act(), nullptr);
-  lv_obj_align(bgMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, -60, -5);
+  lv_obj_align(bgMinutesDown, lv_scr_act(), LV_ALIGN_CENTER, 60, -5);
   lv_obj_set_style_local_bg_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_color(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_bg_grad_dir(bgMinutesDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_GRAD_DIR_VER);
@@ -72,13 +72,20 @@ Alarm::Alarm(DisplayApp* app,
 
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
-  lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0xb0, 0xb0, 0xb0));
+  lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+
+  colon = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_font(colon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
+  lv_obj_set_style_local_text_color(colon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  lv_label_set_text_static(colon, ":");
 
   alarmHours = alarmController.Hours();
   alarmMinutes = alarmController.Minutes();
   lv_label_set_text_fmt(time, "%02hhu:%02hhu", alarmHours, alarmMinutes);
 
-  lv_obj_align(time, lv_scr_act(), LV_ALIGN_CENTER, 0, -25);
+  lv_obj_set_style_local_text_letter_space(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, -6);
+  lv_obj_align(time, lv_scr_act(), LV_ALIGN_CENTER, -1, -20);
+  lv_obj_align(colon, lv_scr_act(), LV_ALIGN_CENTER, 0, -25);
 
   lblampm = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(lblampm, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
@@ -134,16 +141,20 @@ Alarm::Alarm(DisplayApp* app,
   lv_obj_set_event_cb(btnRecur, btnEventHandler);
   lv_obj_set_size(btnRecur, 115, 50);
   lv_obj_align(btnRecur, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
+  lv_obj_set_style_local_bg_color(btnRecur, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_SILVER);
   txtRecur = lv_label_create(btnRecur, nullptr);
+  lv_obj_set_style_local_text_color(txtRecur, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   SetRecurButtonState();
 
   btnInfo = lv_btn_create(lv_scr_act(), nullptr);
   btnInfo->user_data = this;
   lv_obj_set_event_cb(btnInfo, btnEventHandler);
   lv_obj_set_size(btnInfo, 50, 40);
-  lv_obj_align(btnInfo, lv_scr_act(), LV_ALIGN_CENTER, 0, -85);
+  lv_obj_align(btnInfo, lv_scr_act(), LV_ALIGN_CENTER, 0, -95);
+  lv_obj_set_style_local_bg_color(btnInfo, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_SILVER);
   txtInfo = lv_label_create(btnInfo, nullptr);
   lv_label_set_text_static(txtInfo, "i");
+  lv_obj_set_style_local_text_color(txtInfo, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
 
   enableSwitch = lv_switch_create(lv_scr_act(), nullptr);
   enableSwitch->user_data = this;
@@ -151,6 +162,9 @@ Alarm::Alarm(DisplayApp* app,
   lv_obj_set_size(enableSwitch, 100, 50);
   // Align to the center of 115px from edge
   lv_obj_align(enableSwitch, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 7, 0);
+  lv_obj_set_style_local_bg_color(enableSwitch, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_SILVER);
+  lv_obj_set_style_local_bg_color(enableSwitch, LV_SWITCH_PART_KNOB, LV_STATE_DEFAULT, LV_COLOR_GRAY);
+
 
   UpdateAlarmTime();
 

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -46,7 +46,6 @@ Alarm::Alarm(DisplayApp* app,
   lv_obj_set_size(bgHoursUp, 100, 90);
   lv_obj_align(bgHoursUp, lv_scr_act(), LV_ALIGN_CENTER, -60, -75);
 
-
   bgHoursDown = lv_btn_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_bg_color(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_obj_set_style_local_bg_grad_color(bgHoursDown, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
@@ -250,6 +249,43 @@ void Alarm::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
     }
     if (obj == btnRecur) {
       ToggleRecurrence();
+    }
+  } else if (event == LV_EVENT_LONG_PRESSED_REPEAT) {
+    if (obj == btnMinutesUp) {
+      if (alarmMinutes >= 59) {
+        alarmMinutes = 0;
+      } else {
+        alarmMinutes++;
+      }
+      UpdateAlarmTime();
+      return;
+    }
+    if (obj == btnMinutesDown) {
+      if (alarmMinutes <= 0) {
+        alarmMinutes = 59;
+      } else {
+        alarmMinutes--;
+      }
+      UpdateAlarmTime();
+      return;
+    }
+    if (obj == btnHoursUp) {
+      if (alarmHours >= 23) {
+        alarmHours = 0;
+      } else {
+        alarmHours++;
+      }
+      UpdateAlarmTime();
+      return;
+    }
+    if (obj == btnHoursDown) {
+      if (alarmHours <= 0) {
+        alarmHours = 23;
+      } else {
+        alarmHours--;
+      }
+      UpdateAlarmTime();
+      return;
     }
   }
 }

--- a/src/displayapp/screens/Alarm.h
+++ b/src/displayapp/screens/Alarm.h
@@ -45,7 +45,7 @@ namespace Pinetime {
         Controllers::Settings& settingsController;
         System::SystemTask& systemTask;
 
-        lv_obj_t *time, *lblampm, *btnStop, *txtStop, *btnMinutesUp, *btnMinutesDown, *btnHoursUp, *btnHoursDown, *txtMinUp,
+        lv_obj_t *time, *lblampm, *btnStop, *txtStop, *btnMinutesUp, *btnMinutesDown, *btnHoursUp, *btnHoursDown, *bgMinutesUp, *bgMinutesDown, *bgHoursUp, *bgHoursDown, *txtMinUp,
           *txtMinDown, *txtHrUp, *txtHrDown, *btnRecur, *txtRecur, *btnInfo, *txtInfo, *enableSwitch;
         lv_obj_t* txtMessage = nullptr;
         lv_obj_t* btnMessage = nullptr;

--- a/src/displayapp/screens/Alarm.h
+++ b/src/displayapp/screens/Alarm.h
@@ -45,7 +45,7 @@ namespace Pinetime {
         Controllers::Settings& settingsController;
         System::SystemTask& systemTask;
 
-        lv_obj_t *time, *lblampm, *btnStop, *txtStop, *btnMinutesUp, *btnMinutesDown, *btnHoursUp, *btnHoursDown, *bgMinutesUp, *bgMinutesDown, *bgHoursUp, *bgHoursDown, *txtMinUp,
+        lv_obj_t *time, *colon, *lblampm, *btnStop, *txtStop, *btnMinutesUp, *btnMinutesDown, *btnHoursUp, *btnHoursDown, *bgMinutesUp, *bgMinutesDown, *bgHoursUp, *bgHoursDown, *txtMinUp,
           *txtMinDown, *txtHrUp, *txtHrDown, *btnRecur, *txtRecur, *btnInfo, *txtInfo, *enableSwitch;
         lv_obj_t* txtMessage = nullptr;
         lv_obj_t* btnMessage = nullptr;


### PR DESCRIPTION
Redesign of the alarm UI to match #1109, increases button size and adds fast change on long press.

The AM/PM indicator is a touch too wide to fit where it is but I don't hate it... I can change it if anyone has strong feelings about it. I moved the info button down to the bottom and shrank the other buttons to fit, it's a little cramped but usable. I thought a smaller stop button was probably best to avoid accidentally hitting it, but it could be enlarged to cover the info button if it's too small.

![image](https://user-images.githubusercontent.com/3533345/166103108-de948e76-4e88-4b05-84d3-f299adad8fd2.png)
![image](https://user-images.githubusercontent.com/3533345/166103128-b515d0b1-d809-47bb-87fc-3372f17dd7e3.png)

Fixes #1101 and maybe #933 ?