### PR TITLE
Add clang-format check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,34 @@
+name: Code formatting
+
+on:
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  test-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1000
+
+      - name: Configure git
+        run: |
+          git config --global user.email "-"
+          git config --global user.name "Autoformatter"
+          git fetch origin "$GITHUB_BASE_REF":"$GITHUB_BASE_REF" --depth=1000
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install clang-format-12
+
+      - name: Check formatting
+        run: tests/test-format.sh "$GITHUB_BASE_REF"
+
+      - name: Upload patches
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Patches
+          path: ./*.patch

--- a/tests/test-format.sh
+++ b/tests/test-format.sh
@@ -12,6 +12,7 @@ CHANGED=0
 
 for file in $CHANGED_FILES
 do
+  [ -e "$file" ] || continue
   case "$file" in
   *.cpp|*.h)
     echo Checking "$file"

--- a/tests/test-format.sh
+++ b/tests/test-format.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+[ -z "$1" ] && exit
+
+basebranch=$1
+
+CHANGED_FILES=$(git diff --name-only "$basebranch"...HEAD)
+
+CHANGED=0
+
+for file in $CHANGED_FILES
+do
+  case "$file" in
+  *.cpp|*.h)
+    echo Checking "$file"
+    clang-format -i "$file"
+    if ! git diff --quiet "$basebranch"...HEAD
+    then
+      printf "\033[31mError:\033[0m Formatting error in %s\n" "$file"
+      CHANGED=1
+      git add "$file"
+      git commit -q -m "Apply clang-format to $(basename "$file")"
+      printf "Creating patch "
+      git format-patch HEAD~
+    fi
+  esac
+done
+
+if [ $CHANGED = 1 ]
+then
+  printf "\033[31mError:\033[0m Issues found. You may use the patches provided as artifacts to format the code."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Add a GitHub action that clang-formats the changed cpp files, checks them for changes, and if it finds any, create patches for them and upload them as artifacts.

Automating code review will save a lot of time.

An example of this can be seen here https://github.com/Riksu9000/InfiniTime/pull/7

```
Checking src/displayapp/DisplayApp.cpp
Error: Formatting error in src/displayapp/DisplayApp.cpp
Creating patch 0001-Apply-clang-format-to-DisplayApp.cpp.patch
Error: Issues found. You may use the patches provided as artifacts to format the code.
Error: Process completed with exit code 1.
```
[Patches.zip](https://github.com/InfiniTimeOrg/InfiniTime/files/8598505/Patches.zip)
