### PR TITLE
Workflow cleanup and artifact renaming

### DIFF
--- a/.github/workflows/lv_sim.yml
+++ b/.github/workflows/lv_sim.yml
@@ -60,7 +60,7 @@ jobs:
           cmake --build build_lv_sim
 
       - name: Upload simulator executable
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: infinisim
+          name: infinisim-${{ github.head_ref }}
           path: build_lv_sim/infinisim

--- a/.github/workflows/lv_sim.yml
+++ b/.github/workflows/lv_sim.yml
@@ -1,24 +1,15 @@
 # GitHub Actions Workflow to build Simulator for PineTime Smart Watch LVGL Interface
 
-# Name of this Workflow
 name: Build PineTime LVGL Simulator
 
-# When to run this Workflow...
 on:
-
-  # Run this Workflow when files are updated (Pushed) in the "master" and "develop" Branch
   push:
     branches: [ master, develop ]
-
-  # Also run this Workflow when a Pull Request is created or updated in the "master" and "develop" Branch
   pull_request:
     branches: [ master, develop ]
 
-# Steps to run for the Workflow
 jobs:
   build:
-
-    # Run these steps on Ubuntu
     runs-on: ubuntu-latest
 
     steps:
@@ -63,9 +54,6 @@ jobs:
 
       #########################################################################################
       # Build and Upload simulator
-
-      # For Debugging Builds: Remove "make" option "-j" for clearer output. Add "--trace" to see details.
-      # For Faster Builds: Add "make" option "-j"
 
       - name: Build simulator executable
         run:  |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,7 @@ jobs:
         shell: bash
         env:
           SOURCES_DIR: .
-        run: |
-          /opt/build.sh all
+        run: /opt/build.sh all
       # Unzip the package because Upload Artifact will zip up the files
       - name: Unzip DFU package
         run: unzip ./build/output/pinetime-mcuboot-app-dfu-*.zip -d ./build/output/pinetime-mcuboot-app-dfu
@@ -45,5 +44,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: InfiniTime MCUBoot image ${{ github.head_ref }}
-          path: |
-            ./build/output/pinetime-mcuboot-app-image-*.bin
+          path: ./build/output/pinetime-mcuboot-app-image-*.bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,14 @@ jobs:
           SOURCES_DIR: .
         run: |
           /opt/build.sh all
+      # Unzip the package because Upload Artifact will zip up the files
+      - name: Unzip DFU package
+        run: unzip ./build/output/pinetime-mcuboot-app-dfu-*.zip -d ./build/output/pinetime-mcuboot-app-dfu
       - name: Upload DFU artifacts
         uses: actions/upload-artifact@v3
         with:
           name: InfiniTime DFU ${{ github.head_ref }}
-          path: |
-            ./build/output/pinetime-mcuboot-app-dfu-*.zip
+          path: ./build/output/pinetime-mcuboot-app-dfu/*
       - name: Upload MCUBoot image artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,14 +34,14 @@ jobs:
         run: |
           /opt/build.sh all
       - name: Upload DFU artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: InfiniTime DFU file
+          name: InfiniTime DFU ${{ github.head_ref }}
           path: |
             ./build/output/pinetime-mcuboot-app-dfu-*.zip
       - name: Upload MCUBoot image artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: InfiniTime MCUBoot image file
+          name: InfiniTime MCUBoot image ${{ github.head_ref }}
           path: |
             ./build/output/pinetime-mcuboot-app-image-*.bin

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,21 +3,14 @@
 # Based on https://github.com/JF002/InfiniTime/blob/master/doc/buildAndProgram.md
 # and https://github.com/JF002/InfiniTime/blob/master/bootloader/README.md
 
-# Name of this Workflow
 name: Build PineTime Firmware
 
-# When to run this Workflow...
 on:
-
-  # Run this Workflow when files are updated (Pushed) in the "master" and "develop" Branch
   push:
     branches: [ master, develop ]
-
-  # Also run this Workflow when a Pull Request is created or updated in the "master" and "develop" Branch
   pull_request:
     branches: [ master, develop ]
 
-# Steps to run for the Workflow
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove unnecessary comments in workflows.
Rename uploaded artifacts with the source branch name. The InfiniSim binary doesn't get renamed, only the zip.

Fixes #795