### PR TITLE
Format workflow improvements

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,6 +3,10 @@ name: Code formatting
 on:
   pull_request:
     branches: [ master, develop ]
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - '!src/libs/**'
 
 jobs:
   test-format:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get -y install clang-format-12
 
       - name: Check formatting
-        run: tests/test-format.sh "$GITHUB_BASE_REF"
+        run: tests/test-format.sh
 
       - name: Upload patches
         uses: actions/upload-artifact@v3

--- a/tests/test-format.sh
+++ b/tests/test-format.sh
@@ -2,11 +2,13 @@
 
 set -e
 
-[ -z "$1" ] && exit
+if [ -z "$GITHUB_BASE_REF" ]
+then
+  echo "This script is only meant to be run in a GitHub Workflow"
+  exit 1
+fi
 
-basebranch=$1
-
-CHANGED_FILES=$(git diff --name-only "$basebranch"...HEAD)
+CHANGED_FILES=$(git diff --name-only "$GITHUB_BASE_REF"...HEAD)
 
 CHANGED=0
 

--- a/tests/test-format.sh
+++ b/tests/test-format.sh
@@ -16,6 +16,7 @@ for file in $CHANGED_FILES
 do
   [ -e "$file" ] || continue
   case "$file" in
+  src/libs/*) continue ;;
   *.cpp|*.h)
     echo Checking "$file"
     clang-format -i "$file"


### PR DESCRIPTION
Don't run the workflow when not necessary.
Ignore libs folder.
Don't allow test-format.sh to be run locally.

Tested here https://github.com/Riksu9000/InfiniTime/pull/7