### PR TITLE
Add basic hardware configuration options for P8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,13 +54,8 @@ if(BUILD_DFU)
   set(BUILD_DFU true)
 endif()
 
-option(WATCH_COLMI_P8 "Build for the Colmi P8" OFF)
-set(TARGET_DEVICE "PineTime")
-
-if(WATCH_COLMI_P8)
-  set(TARGET_DEVICE "Colmi P8")
-  add_definitions(-DWATCH_P8)
-endif()
+set(TARGET_DEVICE "PINETIME" CACHE STRING "Target device")
+set_property(CACHE TARGET_DEVICE PROPERTY STRINGS PINETIME MOY-TFK5 MOY-TIN5 MOY-TON5 MOY-UNK)
 
 set(PROJECT_GIT_COMMIT_HASH "")
 

--- a/doc/buildAndProgram.md
+++ b/doc/buildAndProgram.md
@@ -39,7 +39,7 @@ CMake configures the project according to variables you specify the command line
 **GDB_CLIENT_BIN_PATH**|Path to arm-none-eabi-gdb executable. Used only if `USE_GDB_CLIENT` is 1.|`-DGDB_CLIENT_BIN_PATH=/home/jf/nrf52/gcc-arm-none-eabi-9-2019-q4-major/bin/arm-none-eabi-gdb`
 **GDB_CLIENT_TARGET_REMOTE**|Target remote connection string. Used only if `USE_GDB_CLIENT` is 1.|`-DGDB_CLIENT_TARGET_REMOTE=/dev/ttyACM0`
 **BUILD_DFU (\*\*)**|Build DFU files while building (needs [adafruit-nrfutil](https://github.com/adafruit/Adafruit_nRF52_nrfutil)).|`-DBUILD_DFU=1`
-**WATCH_COLMI_P8**|Use pin configuration for Colmi P8 watch|`-DWATCH_COLMI_P8=1`
+**TARGET_DEVICE**|Target device, used for hardware configuration. Allowed: `PINETIME, MOY-TFK5, MOY-TIN5, MOY-TON5, MOY-UNK`|`-DTARGET_DEVICE=PINETIME` (Default)
 
 ####(**) Note about **CMAKE_BUILD_TYPE**:
 By default, this variable is set to *Release*. It compiles the code with size and speed optimizations. We use this value for all the binaries we publish when we [release](https://github.com/InfiniTimeOrg/InfiniTime/releases) new versions of InfiniTime.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -779,6 +779,35 @@ add_definitions(-DFREERTOS)
 add_definitions(-D__STACK_SIZE=1024)
 add_definitions(-D__HEAP_SIZE=4096)
 
+# Note: Only use this for debugging
+# Derive the low frequency clock from the main clock (SYNT)
+# add_definitions(-DCLOCK_CONFIG_LF_SRC=2)
+
+# Target hardware configuration options
+add_definitions(-DTARGET_DEVICE_${TARGET_DEVICE})
+if(TARGET_DEVICE STREQUAL "PINETIME")
+  add_definitions(-DDRIVER_PINMAP_PINETIME)
+  add_definitions(-DCLOCK_CONFIG_LF_SRC=1) # XTAL
+elseif(TARGET_DEVICE STREQUAL "MOY-TFK5") # P8a
+  add_definitions(-DDRIVER_PINMAP_P8)
+  add_definitions(-DCLOCK_CONFIG_LF_SRC=1) # XTAL
+elseif(TARGET_DEVICE STREQUAL "MOY-TIN5") # P8a variant 2
+  add_definitions(-DDRIVER_PINMAP_P8)
+  add_definitions(-DCLOCK_CONFIG_LF_SRC=1) # XTAL
+elseif(TARGET_DEVICE STREQUAL "MOY-TON5") # P8b
+  add_definitions(-DDRIVER_PINMAP_P8)
+  add_definitions(-DCLOCK_CONFIG_LF_SRC=0) # RC
+  add_definitions(-DMYNEWT_VAL_BLE_LL_SCA=500)
+  add_definitions(-DCLOCK_CONFIG_LF_CAL_ENABLED=1)
+elseif(TARGET_DEVICE STREQUAL "MOY-UNK") # P8b mirrored
+  add_definitions(-DDRIVER_PINMAP_P8)
+  add_definitions(-DCLOCK_CONFIG_LF_SRC=0) # RC
+  add_definitions(-DMYNEWT_VAL_BLE_LL_SCA=500)
+  add_definitions(-DCLOCK_CONFIG_LF_CAL_ENABLED=1)
+else()
+  message(FATAL_ERROR "Invalid TARGET_DEVICE")
+endif()
+
 # Debug configuration
 if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
   add_definitions(-DDEBUG)

--- a/src/drivers/PinMap.h
+++ b/src/drivers/PinMap.h
@@ -4,8 +4,8 @@
 namespace Pinetime {
   namespace PinMap {
 
-#ifdef WATCH_P8
-    // COLMI P8
+#if defined(DRIVER_PINMAP_P8)
+    // COLMI P8 and variants
     static constexpr uint8_t Charging = 19;
     static constexpr uint8_t Cst816sReset = 13;
     static constexpr uint8_t Button = 17;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -312,10 +312,15 @@ int main(void) {
   nrf_drv_clock_init();
   nrf_drv_clock_lfclk_request(NULL);
 
-// The RC source for the LF clock has to be calibrated
-#if (CLOCK_CONFIG_LF_SRC == NRF_CLOCK_LFCLK_RC)
+  // When loading the firmware via the Wasp-OS reloader-factory, which uses the used internal LF RC oscillator,
+  // the LF clock has to be explicitly restarted because InfiniTime uses the external crystal oscillator if available.
+  // If the clock is not restarted, the Bluetooth timers fail to initialize.
+  nrfx_clock_lfclk_start();
   while (!nrf_clock_lf_is_running()) {
   }
+
+// The RC source for the LF clock has to be calibrated
+#if (CLOCK_CONFIG_LF_SRC == NRF_CLOCK_LFCLK_RC)
   nrf_drv_clock_calibration_start(0, calibrate_lf_clock_rc);
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -300,10 +300,24 @@ void nimble_port_ll_task_func(void* args) {
 }
 }
 
+void calibrate_lf_clock_rc(nrf_drv_clock_evt_type_t event) {
+  // 16 * 0.25s = 4s calibration cycle
+  // Not recursive, call is deferred via internal calibration timer
+  nrf_drv_clock_calibration_start(16, calibrate_lf_clock_rc);
+}
+
 int main(void) {
   logger.Init();
 
   nrf_drv_clock_init();
+  nrf_drv_clock_lfclk_request(NULL);
+
+// The RC source for the LF clock has to be calibrated
+#if (CLOCK_CONFIG_LF_SRC == NRF_CLOCK_LFCLK_RC)
+  while (!nrf_clock_lf_is_running()) {
+  }
+  nrf_drv_clock_calibration_start(0, calibrate_lf_clock_rc);
+#endif
 
   // Unblock i2c?
   nrf_gpio_cfg(Pinetime::PinMap::TwiScl,


### PR DESCRIPTION
This PR has been broken out of https://github.com/InfiniTimeOrg/InfiniTime/pull/1050.

This enables the compile-time configuration of the LFCLK source, as well as the target hardware board pin configuration.

The `WATCH_COLMI_P8` compilation option has been replaced with `TARGET_DEVICE`, see `doc/buildAndProgram.md`.