### PR TITLE
Convert ScreenList from array to vector for dynamic generation of Screens

### DIFF
--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -25,7 +25,7 @@ namespace Pinetime {
         Pinetime::Controllers::Battery& batteryController;
         Controllers::DateTime& dateTimeController;
 
-        ScreenList<2> screens;
+        ScreenList screens;
         std::unique_ptr<Screen> CreateScreen1();
         std::unique_ptr<Screen> CreateScreen2();
         // std::unique_ptr<Screen> CreateScreen3();

--- a/src/displayapp/screens/ScreenList.h
+++ b/src/displayapp/screens/ScreenList.h
@@ -11,11 +11,11 @@ namespace Pinetime {
     namespace Screens {
 
       enum class ScreenListModes { UpDown, RightLeft, LongPress };
-      template <size_t N> class ScreenList : public Screen {
+      class ScreenList : public Screen {
       public:
         ScreenList(DisplayApp* app,
                    uint8_t initScreen,
-                   const std::array<std::function<std::unique_ptr<Screen>()>, N>&& screens,
+                   const std::vector<std::function<std::unique_ptr<Screen>()>>&& screens,
                    ScreenListModes mode)
           : Screen(app), initScreen {initScreen}, screens {std::move(screens)}, mode {mode}, screenIndex{initScreen}, current {this->screens[initScreen]()} {
 
@@ -97,7 +97,7 @@ namespace Pinetime {
 
       private:
         uint8_t initScreen = 0;
-        const std::array<std::function<std::unique_ptr<Screen>()>, N> screens;
+        const std::vector<std::function<std::unique_ptr<Screen>()>> screens;
         ScreenListModes mode = ScreenListModes::UpDown;
 
         uint8_t screenIndex = 0;

--- a/src/displayapp/screens/ScreenList.h
+++ b/src/displayapp/screens/ScreenList.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <functional>
 #include <memory>
+#include <vector>
 #include "displayapp/screens/Screen.h"
 #include "displayapp/DisplayApp.h"
 

--- a/src/displayapp/screens/SystemInfo.h
+++ b/src/displayapp/screens/SystemInfo.h
@@ -42,7 +42,7 @@ namespace Pinetime {
         Pinetime::Controllers::MotionController& motionController;
         Pinetime::Drivers::Cst816S& touchPanel;
 
-        ScreenList<5> screens;
+        ScreenList screens;
 
         static bool sortById(const TaskStatus_t& lhs, const TaskStatus_t& rhs);
 

--- a/src/displayapp/screens/Weather.h
+++ b/src/displayapp/screens/Weather.h
@@ -28,7 +28,7 @@ namespace Pinetime {
         Pinetime::Controllers::DateTime& dateTimeController;
         Controllers::WeatherService& weatherService;
 
-        ScreenList<5> screens;
+        ScreenList screens;
 
         std::unique_ptr<Screen> CreateScreenTemperature();
 

--- a/src/displayapp/screens/settings/Settings.h
+++ b/src/displayapp/screens/settings/Settings.h
@@ -19,7 +19,7 @@ namespace Pinetime {
       private:
         Controllers::Settings& settingsController;
 
-        ScreenList<4> screens;
+        ScreenList screens;
 
         std::unique_ptr<Screen> CreateScreen1();
         std::unique_ptr<Screen> CreateScreen2();


### PR DESCRIPTION
For some applications, such as the ApplicationList, it's easier to make the ScreenList a vector instead of a precompiled array. This makes it a lot easier to dynamically add or remove screens, for example based on incoming BLE data or user input. 
Some examples include creating multiple alarms/timers, home automation apps, multiple cities in the Weather display etc. 