### PR TITLE
generalize lv-font creation

### DIFF
--- a/doc/buildAndProgram.md
+++ b/doc/buildAndProgram.md
@@ -15,8 +15,7 @@ To build this project, you'll need:
  - lv_font_conv, to generate the font .c files
    - see [lv_font_conv](https://github.com/lvgl/lv_font_conv#install-the-script)
    - install npm (commonly done via the package manager)
-   - install lv_font_conv: `npm i lv_font_conv -g`
-   - if installed non-globally, make sure `lv_font_conv` is in the PATH
+   - install lv_font_conv: `npm install lv_font_conv`
 
 ## Build steps 
 ### Clone the repo

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -373,7 +373,6 @@ list(APPEND IMAGE_FILES
         displayapp/icons/bluetooth/os_bt_disconnected.c
 
         )
-include(displayapp/fonts/CMakeLists.txt)
 list(APPEND SOURCE_FILES
         BootloaderVersion.cpp
         logging/NrfLogger.cpp
@@ -465,7 +464,6 @@ list(APPEND SOURCE_FILES
         components/ble/MusicService.cpp
         components/ble/weather/WeatherService.cpp
         components/ble/NavigationService.cpp
-        displayapp/fonts/lv_font_navi_80.c
         components/ble/BatteryInformationService.cpp
         components/ble/FSService.cpp
         components/ble/ImmediateAlertService.cpp
@@ -484,12 +482,6 @@ list(APPEND SOURCE_FILES
         FreeRTOS/port_cmsis.c
 
         displayapp/LittleVgl.cpp
-        displayapp/fonts/jetbrains_mono_extrabold_compressed.c
-        displayapp/fonts/jetbrains_mono_bold_20.c
-        displayapp/fonts/jetbrains_mono_76.c
-        displayapp/fonts/jetbrains_mono_42.c
-        displayapp/fonts/lv_font_sys_48.c
-        displayapp/fonts/open_sans_light.c
         displayapp/lv_pinetime_theme.c
 
         systemtask/SystemTask.cpp
@@ -803,6 +795,15 @@ if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
 endif ()
 
+add_subdirectory(displayapp/fonts)
+target_compile_options(infinitime_fonts PUBLIC
+        $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:DEBUG>>: ${COMMON_FLAGS} -Og -g3>
+        $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:RELEASE>>: ${COMMON_FLAGS} -Os>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:DEBUG>>: ${COMMON_FLAGS} -Og -g3 -fno-rtti>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CONFIG:RELEASE>>: ${COMMON_FLAGS} -Os -fno-rtti>
+        $<$<COMPILE_LANGUAGE:ASM>: -MP -MD -x assembler-with-cpp>
+        )
+
 # NRF SDK
 add_library(nrf-sdk STATIC ${SDK_SOURCE_FILES})
 target_include_directories(nrf-sdk SYSTEM PUBLIC . ../)
@@ -876,7 +877,7 @@ set(EXECUTABLE_FILE_NAME ${EXECUTABLE_NAME}-${pinetime_VERSION_MAJOR}.${pinetime
 set(NRF5_LINKER_SCRIPT "${CMAKE_SOURCE_DIR}/gcc_nrf52.ld")
 add_executable(${EXECUTABLE_NAME} ${SOURCE_FILES})
 set_target_properties(${EXECUTABLE_NAME} PROPERTIES OUTPUT_NAME ${EXECUTABLE_FILE_NAME})
-target_link_libraries(${EXECUTABLE_NAME} nimble nrf-sdk lvgl littlefs QCBOR)
+target_link_libraries(${EXECUTABLE_NAME} nimble nrf-sdk lvgl littlefs QCBOR infinitime_fonts)
 target_compile_options(${EXECUTABLE_NAME} PUBLIC
         $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:DEBUG>>: ${COMMON_FLAGS} -Wextra -Wformat -Wno-missing-field-initializers -Wno-unused-parameter -Og -g3>
         $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:RELEASE>>: ${COMMON_FLAGS} -Wextra -Wformat -Wno-missing-field-initializers -Wno-unused-parameter -Os>
@@ -904,7 +905,7 @@ set(IMAGE_MCUBOOT_FILE_NAME ${EXECUTABLE_MCUBOOT_NAME}-image-${pinetime_VERSION_
 set(DFU_MCUBOOT_FILE_NAME ${EXECUTABLE_MCUBOOT_NAME}-dfu-${pinetime_VERSION_MAJOR}.${pinetime_VERSION_MINOR}.${pinetime_VERSION_PATCH}.zip)
 set(NRF5_LINKER_SCRIPT_MCUBOOT "${CMAKE_SOURCE_DIR}/gcc_nrf52-mcuboot.ld")
 add_executable(${EXECUTABLE_MCUBOOT_NAME} ${SOURCE_FILES})
-target_link_libraries(${EXECUTABLE_MCUBOOT_NAME} nimble nrf-sdk lvgl littlefs QCBOR)
+target_link_libraries(${EXECUTABLE_MCUBOOT_NAME} nimble nrf-sdk lvgl littlefs QCBOR infinitime_fonts)
 set_target_properties(${EXECUTABLE_MCUBOOT_NAME} PROPERTIES OUTPUT_NAME ${EXECUTABLE_MCUBOOT_FILE_NAME})
 target_compile_options(${EXECUTABLE_MCUBOOT_NAME} PUBLIC
         $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:DEBUG>>: ${COMMON_FLAGS} -Og -g3>
@@ -940,7 +941,7 @@ endif()
 set(EXECUTABLE_RECOVERY_NAME "pinetime-recovery")
 set(EXECUTABLE_RECOVERY_FILE_NAME ${EXECUTABLE_RECOVERY_NAME}-${pinetime_VERSION_MAJOR}.${pinetime_VERSION_MINOR}.${pinetime_VERSION_PATCH})
 add_executable(${EXECUTABLE_RECOVERY_NAME} ${RECOVERY_SOURCE_FILES})
-target_link_libraries(${EXECUTABLE_RECOVERY_NAME} nimble nrf-sdk littlefs QCBOR)
+target_link_libraries(${EXECUTABLE_RECOVERY_NAME} nimble nrf-sdk littlefs QCBOR infinitime_fonts)
 set_target_properties(${EXECUTABLE_RECOVERY_NAME} PROPERTIES OUTPUT_NAME ${EXECUTABLE_RECOVERY_FILE_NAME})
 target_compile_definitions(${EXECUTABLE_RECOVERY_NAME} PUBLIC "PINETIME_IS_RECOVERY")
 target_compile_options(${EXECUTABLE_RECOVERY_NAME} PUBLIC
@@ -970,7 +971,7 @@ set(EXECUTABLE_RECOVERY_MCUBOOT_FILE_NAME ${EXECUTABLE_RECOVERY_MCUBOOT_NAME}-${
 set(IMAGE_RECOVERY_MCUBOOT_FILE_NAME ${EXECUTABLE_RECOVERY_MCUBOOT_NAME}-image-${pinetime_VERSION_MAJOR}.${pinetime_VERSION_MINOR}.${pinetime_VERSION_PATCH}.bin)
 set(DFU_RECOVERY_MCUBOOT_FILE_NAME ${EXECUTABLE_RECOVERY_MCUBOOT_NAME}-dfu-${pinetime_VERSION_MAJOR}.${pinetime_VERSION_MINOR}.${pinetime_VERSION_PATCH}.zip)
 add_executable(${EXECUTABLE_RECOVERY_MCUBOOT_NAME} ${RECOVERY_SOURCE_FILES})
-target_link_libraries(${EXECUTABLE_RECOVERY_MCUBOOT_NAME} nimble nrf-sdk littlefs QCBOR)
+target_link_libraries(${EXECUTABLE_RECOVERY_MCUBOOT_NAME} nimble nrf-sdk littlefs QCBOR infinitime_fonts)
 set_target_properties(${EXECUTABLE_RECOVERY_MCUBOOT_NAME} PROPERTIES OUTPUT_NAME ${EXECUTABLE_RECOVERY_MCUBOOT_FILE_NAME})
 target_compile_definitions(${EXECUTABLE_RECOVERY_MCUBOOT_NAME} PUBLIC "PINETIME_IS_RECOVERY")
 target_compile_options(${EXECUTABLE_RECOVERY_MCUBOOT_NAME} PUBLIC
@@ -1008,7 +1009,7 @@ endif()
 set(EXECUTABLE_RECOVERYLOADER_NAME "pinetime-recovery-loader")
 set(EXECUTABLE_RECOVERYLOADER_FILE_NAME ${EXECUTABLE_RECOVERYLOADER_NAME}-${pinetime_VERSION_MAJOR}.${pinetime_VERSION_MINOR}.${pinetime_VERSION_PATCH})
 add_executable(${EXECUTABLE_RECOVERYLOADER_NAME} ${RECOVERYLOADER_SOURCE_FILES})
-target_link_libraries(${EXECUTABLE_RECOVERYLOADER_NAME} nrf-sdk QCBOR)
+target_link_libraries(${EXECUTABLE_RECOVERYLOADER_NAME} nrf-sdk QCBOR infinitime_fonts)
 set_target_properties(${EXECUTABLE_RECOVERYLOADER_NAME} PROPERTIES OUTPUT_NAME ${EXECUTABLE_RECOVERYLOADER_FILE_NAME})
 target_compile_options(${EXECUTABLE_RECOVERYLOADER_NAME} PUBLIC
         $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:DEBUG>>: ${COMMON_FLAGS} -Og -g3>
@@ -1041,7 +1042,7 @@ set(EXECUTABLE_MCUBOOT_RECOVERYLOADER_FILE_NAME ${EXECUTABLE_MCUBOOT_RECOVERYLOA
 set(IMAGE_MCUBOOT_RECOVERYLOADER_FILE_NAME ${EXECUTABLE_MCUBOOT_RECOVERYLOADER_NAME}-image-${pinetime_VERSION_MAJOR}.${pinetime_VERSION_MINOR}.${pinetime_VERSION_PATCH}.bin)
 set(DFU_MCUBOOT_RECOVERYLOADER_FILE_NAME ${EXECUTABLE_MCUBOOT_RECOVERYLOADER_NAME}-dfu-${pinetime_VERSION_MAJOR}.${pinetime_VERSION_MINOR}.${pinetime_VERSION_PATCH}.zip)
 add_executable(${EXECUTABLE_MCUBOOT_RECOVERYLOADER_NAME} ${RECOVERYLOADER_SOURCE_FILES})
-target_link_libraries(${EXECUTABLE_MCUBOOT_RECOVERYLOADER_NAME} nrf-sdk QCBOR)
+target_link_libraries(${EXECUTABLE_MCUBOOT_RECOVERYLOADER_NAME} nrf-sdk QCBOR infinitime_fonts)
 set_target_properties(${EXECUTABLE_MCUBOOT_RECOVERYLOADER_NAME} PROPERTIES OUTPUT_NAME ${EXECUTABLE_MCUBOOT_RECOVERYLOADER_FILE_NAME})
 target_compile_options(${EXECUTABLE_MCUBOOT_RECOVERYLOADER_NAME} PUBLIC
         $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:DEBUG>>: ${COMMON_FLAGS} -Og -g3>

--- a/src/displayapp/fonts/CMakeLists.txt
+++ b/src/displayapp/fonts/CMakeLists.txt
@@ -1,19 +1,35 @@
-cmake_minimum_required(VERSION 3.10)
-
 set(FONTS jetbrains_mono_42 jetbrains_mono_76 jetbrains_mono_bold_20
    jetbrains_mono_extrabold_compressed lv_font_navi_80 lv_font_sys_48
    open_sans_light)
-find_program(LV_FONT_CONV "lv_font_conv" NO_CACHE REQUIRED)
+find_program(LV_FONT_CONV "lv_font_conv" NO_CACHE REQUIRED
+   HINTS "${CMAKE_SOURCE_DIR}/node_modules/.bin")
+message(STATUS "Using ${LV_FONT_CONV} to generate font files")
 configure_file(${CMAKE_CURRENT_LIST_DIR}/jetbrains_mono_bold_20.c_zero.patch
-   displayapp/fonts/jetbrains_mono_bold_20.c_zero.patch COPYONLY)
-foreach(FONT ${FONTS})
-   set_source_files_properties(displayapp/fonts/${FONT}.c
-      PROPERTIES GENERATED TRUE)
+   ${CMAKE_CURRENT_BINARY_DIR}/jetbrains_mono_bold_20.c_zero.patch COPYONLY)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+   # FindPython3 module introduces with CMake 3.12
+   # https://cmake.org/cmake/help/latest/module/FindPython3.html
+   find_package(Python3 REQUIRED)
+else()
+   set(Python3_EXECUTABLE "python")
+endif()
 
-   add_custom_command(OUTPUT displayapp/fonts/${FONT}.c
-      COMMAND python ${CMAKE_CURRENT_LIST_DIR}/generate.py
-      -f ${FONT} ${CMAKE_CURRENT_LIST_DIR}/fonts.json
-      DEPENDS ${CMAKE_CURRENT_LIST_DIR}/fonts.json
-      WORKING_DIRECTORY displayapp/fonts
-      )
+# create static library building fonts
+add_library(infinitime_fonts STATIC)
+# add include directory to lvgl headers needed to compile the font files on its own
+target_include_directories(infinitime_fonts PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../libs")
+foreach(FONT ${FONTS})
+   add_custom_command(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${FONT}.c
+      COMMAND "${Python3_EXECUTABLE}" ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
+      --lv-font-conv "${LV_FONT_CONV}"
+      --font ${FONT} ${CMAKE_CURRENT_SOURCE_DIR}/fonts.json
+      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/fonts.json
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+   )
+   add_custom_target(infinitime_fonts_${FONT}
+      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${FONT}.c
+   )
+   target_sources(infinitime_fonts PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/${FONT}.c")
+   add_dependencies(infinitime_fonts infinitime_fonts_${FONT})
 endforeach()

--- a/src/displayapp/fonts/generate.py
+++ b/src/displayapp/fonts/generate.py
@@ -18,8 +18,8 @@ class Source(object):
         self.symbols = d.get('symbols')
 
 
-def gen_lvconv_line(dest: str, size: int, bpp: int, sources: typing.List[Source], compress:bool=False):
-    args = ['lv_font_conv', '--size', str(size), '--output', dest, '--bpp', str(bpp), '--format', 'lvgl']
+def gen_lvconv_line(lv_font_conv: str, dest: str, size: int, bpp: int, sources: typing.List[Source], compress:bool=False):
+    args = [lv_font_conv, '--size', str(size), '--output', dest, '--bpp', str(bpp), '--format', 'lvgl']
     if not compress:
         args.append('--no-compress')
     for source in sources:
@@ -35,9 +35,10 @@ def main():
     ap = argparse.ArgumentParser(description='auto generate LVGL font files from fonts')
     ap.add_argument('config', type=str, help='config file to use')
     ap.add_argument('-f', '--font', type=str, action='append', help='Choose specific fonts to generate (default: all)', default=[])
+    ap.add_argument('--lv-font-conv', type=str, help='Path to "lv_font_conf" executable', default="lv_font_conv")
     args = ap.parse_args()
 
-    if not shutil.which('lv_font_conv'):
+    if not shutil.which(args.lv_font_conv):
         sys.exit(f'Missing lv_font_conv. (make sure it is installed and in PATH)')
     if not os.path.exists(args.config):
         sys.exit(f'Error: the config file {args.config} does not exist.')
@@ -62,7 +63,7 @@ def main():
         sources = font.pop('sources')
         patches = font.pop('patches') if 'patches' in font else  []
         font['sources'] = [Source(thing) for thing in sources]
-        line = gen_lvconv_line(f'{name}.c', **font)
+        line = gen_lvconv_line(args.lv_font_conv, f'{name}.c', **font)
         subprocess.check_call(line)
         if patches:
             for patch in patches:

--- a/src/displayapp/fonts/generate.py
+++ b/src/displayapp/fonts/generate.py
@@ -39,7 +39,7 @@ def main():
     args = ap.parse_args()
 
     if not shutil.which(args.lv_font_conv):
-        sys.exit(f'Missing lv_font_conv. (make sure it is installed and in PATH)')
+        sys.exit(f"Missing lv_font_conv. Make sure it's findable (in PATH) or specify it manually")
     if not os.path.exists(args.config):
         sys.exit(f'Error: the config file {args.config} does not exist.')
     if not os.access(args.config, os.R_OK):


### PR DESCRIPTION
In https://github.com/InfiniTimeOrg/InfiniTime/pull/1097 new font
generation capabilites were added. Generalize the font creation to
make it possible to reuse the `displayapp/fonts/CMakeLists.txt` file
for `InfiniSim` and just add the new cmake file to the project and
link against the new `infinitime_fonts` target.

In the following a list of changes.

Allow non-global installed `lv_font_conv` executable installed with

```sh
npm install lv_font_conv@1.5.2
```

In CMake we search for `lv_font_conv` executable. Add the found
executable to the python script `generate.py`, to remove the need for
`lv_font_conv` to be in the path.

Search for `python3` executable, if CMake version 3.12 is available.
Otherwise use `python` as hard coded executable.

Instead of adding the generated fonts to `SOURCE_FILES` variable, create
a static library `infinitime_fonts` instead. Link this library to the
executables instead.