### PR TITLE
DigitalWatchFace & WatchFacePineTimeStyle: show clock icon when alarm is active

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -325,7 +325,8 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
                                                        notificationManager,
                                                        settingsController,
                                                        heartRateController,
-                                                       motionController);
+                                                       motionController,
+                                                       alarmController);
       break;
 
     case Apps::Error:

--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -22,7 +22,8 @@ Clock::Clock(DisplayApp* app,
              Controllers::NotificationManager& notificatioManager,
              Controllers::Settings& settingsController,
              Controllers::HeartRateController& heartRateController,
-             Controllers::MotionController& motionController)
+             Controllers::MotionController& motionController,
+             Controllers::AlarmController& alarmController)
   : Screen(app),
     dateTimeController {dateTimeController},
     batteryController {batteryController},
@@ -31,6 +32,7 @@ Clock::Clock(DisplayApp* app,
     settingsController {settingsController},
     heartRateController {heartRateController},
     motionController {motionController},
+    alarmController {alarmController},
     screen {[this, &settingsController]() {
       switch (settingsController.GetClockFace()) {
         case 0:
@@ -71,7 +73,8 @@ std::unique_ptr<Screen> Clock::WatchFaceDigitalScreen() {
                                                      notificatioManager,
                                                      settingsController,
                                                      heartRateController,
-                                                     motionController);
+                                                     motionController,
+                                                     alarmController);
 }
 
 std::unique_ptr<Screen> Clock::WatchFaceAnalogScreen() {

--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -84,7 +84,7 @@ std::unique_ptr<Screen> Clock::WatchFaceAnalogScreen() {
 
 std::unique_ptr<Screen> Clock::WatchFacePineTimeStyleScreen() {
   return std::make_unique<Screens::WatchFacePineTimeStyle>(
-    app, dateTimeController, batteryController, bleController, notificatioManager, settingsController, motionController);
+    app, dateTimeController, batteryController, bleController, notificatioManager, settingsController, motionController, alarmController);
 }
 
 std::unique_ptr<Screen> Clock::WatchFaceTerminalScreen() {

--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -15,6 +15,7 @@ namespace Pinetime {
     class Ble;
     class NotificationManager;
     class MotionController;
+    class AlarmController;
   }
 
   namespace Applications {
@@ -28,7 +29,8 @@ namespace Pinetime {
               Controllers::NotificationManager& notificatioManager,
               Controllers::Settings& settingsController,
               Controllers::HeartRateController& heartRateController,
-              Controllers::MotionController& motionController);
+              Controllers::MotionController& motionController,
+              Controllers::AlarmController& alarmController);
         ~Clock() override;
 
         bool OnTouchEvent(TouchEvents event) override;
@@ -42,6 +44,7 @@ namespace Pinetime {
         Controllers::Settings& settingsController;
         Controllers::HeartRateController& heartRateController;
         Controllers::MotionController& motionController;
+        Controllers::AlarmController& alarmController;
 
         std::unique_ptr<Screen> screen;
         std::unique_ptr<Screen> WatchFaceDigitalScreen();

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -22,7 +22,8 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
                                    Controllers::NotificationManager& notificatioManager,
                                    Controllers::Settings& settingsController,
                                    Controllers::HeartRateController& heartRateController,
-                                   Controllers::MotionController& motionController)
+                                   Controllers::MotionController& motionController,
+                                   Controllers::AlarmController& alarmController)
   : Screen(app),
     currentDateTime {{}},
     dateTimeController {dateTimeController},
@@ -31,7 +32,8 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
     notificatioManager {notificatioManager},
     settingsController {settingsController},
     heartRateController {heartRateController},
-    motionController {motionController} {
+    motionController {motionController},
+    alarmController {alarmController} {
 
   batteryIcon.Create(lv_scr_act());
   lv_obj_align(batteryIcon.GetObject(), lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, 0, 0);
@@ -45,6 +47,10 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   lv_obj_set_style_local_text_color(bleIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x0082FC));
   lv_label_set_text_static(bleIcon, Symbols::bluetooth);
   lv_obj_align(bleIcon, batteryPlug, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+
+  alarmIcon = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(alarmIcon, Symbols::clock);
+  lv_obj_align(alarmIcon, bleIcon, LV_ALIGN_OUT_LEFT_MID, -5, 0);
 
   notificationIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FF00));
@@ -110,8 +116,19 @@ void WatchFaceDigital::Refresh() {
   if (bleState.IsUpdated() || bleRadioEnabled.IsUpdated()) {
     lv_label_set_text_static(bleIcon, BleIcon::GetIcon(bleState.Get()));
   }
+
+  alarmEnabled = alarmController.State() == Controllers::AlarmController::AlarmState::Set;
+  if (alarmEnabled.IsUpdated()) {
+    if (alarmEnabled.Get()) {
+      lv_label_set_text_static(alarmIcon, Symbols::clock);
+    } else {
+      lv_label_set_text_static(alarmIcon, "");
+    }
+  }
+
   lv_obj_realign(batteryPlug);
   lv_obj_realign(bleIcon);
+  lv_obj_realign(alarmIcon);
 
   notificationState = notificatioManager.AreNewNotificationsAvailable();
   if (notificationState.IsUpdated()) {

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -6,8 +6,9 @@
 #include <cstdint>
 #include <memory>
 #include "displayapp/screens/Screen.h"
-#include "components/datetime/DateTimeController.h"
+#include "components/alarm/AlarmController.h"
 #include "components/ble/BleController.h"
+#include "components/datetime/DateTimeController.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -31,7 +32,8 @@ namespace Pinetime {
                          Controllers::NotificationManager& notificatioManager,
                          Controllers::Settings& settingsController,
                          Controllers::HeartRateController& heartRateController,
-                         Controllers::MotionController& motionController);
+                         Controllers::MotionController& motionController,
+                         Controllers::AlarmController& alarmController);
         ~WatchFaceDigital() override;
 
         void Refresh() override;
@@ -49,6 +51,7 @@ namespace Pinetime {
         DirtyValue<bool> powerPresent {};
         DirtyValue<bool> bleState {};
         DirtyValue<bool> bleRadioEnabled {};
+        DirtyValue<bool> alarmEnabled {};
         DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime {};
         DirtyValue<bool> motionSensorOk {};
         DirtyValue<uint32_t> stepCount {};
@@ -59,6 +62,7 @@ namespace Pinetime {
         lv_obj_t* label_time;
         lv_obj_t* label_time_ampm;
         lv_obj_t* label_date;
+        lv_obj_t* alarmIcon;
         lv_obj_t* bleIcon;
         lv_obj_t* batteryPlug;
         lv_obj_t* heartbeatIcon;
@@ -76,6 +80,7 @@ namespace Pinetime {
         Controllers::Settings& settingsController;
         Controllers::HeartRateController& heartRateController;
         Controllers::MotionController& motionController;
+        Controllers::AlarmController& alarmController;
 
         lv_task_t* taskRefresh;
       };

--- a/src/displayapp/screens/WatchFacePineTimeStyle.h
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.h
@@ -18,6 +18,7 @@ namespace Pinetime {
     class NotificationManager;
     class HeartRateController;
     class MotionController;
+    class AlarmController;
   }
 
   namespace Applications {
@@ -25,12 +26,13 @@ namespace Pinetime {
       class WatchFacePineTimeStyle : public Screen {
       public:
         WatchFacePineTimeStyle(DisplayApp* app,
-                      Controllers::DateTime& dateTimeController,
-                      Controllers::Battery& batteryController,
-                      Controllers::Ble& bleController,
-                      Controllers::NotificationManager& notificatioManager,
-                      Controllers::Settings& settingsController,
-                      Controllers::MotionController& motionController);
+                               Controllers::DateTime& dateTimeController,
+                               Controllers::Battery& batteryController,
+                               Controllers::Ble& bleController,
+                               Controllers::NotificationManager& notificatioManager,
+                               Controllers::Settings& settingsController,
+                               Controllers::MotionController& motionController,
+                               Controllers::AlarmController& alarmController);
         ~WatchFacePineTimeStyle() override;
 
         bool OnTouchEvent(TouchEvents event) override;
@@ -54,6 +56,7 @@ namespace Pinetime {
         DirtyValue<bool> isCharging {};
         DirtyValue<bool> bleState {};
         DirtyValue<bool> bleRadioEnabled {};
+        DirtyValue<bool> alarmEnabled {};
         DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime {};
         DirtyValue<bool> motionSensorOk {};
         DirtyValue<uint32_t> stepCount {};
@@ -81,6 +84,7 @@ namespace Pinetime {
         lv_obj_t* dateMonth;
         lv_obj_t* plugIcon;
         lv_obj_t* bleIcon;
+        lv_obj_t* alarmIcon;
         lv_obj_t* calendarOuter;
         lv_obj_t* calendarInner;
         lv_obj_t* calendarBar1;
@@ -101,6 +105,7 @@ namespace Pinetime {
         Controllers::NotificationManager& notificatioManager;
         Controllers::Settings& settingsController;
         Controllers::MotionController& motionController;
+        Controllers::AlarmController& alarmController;
 
         void SetBatteryIcon();
         void CloseMenu();


### PR DESCRIPTION
When using the device I am often uncertain if I did infact set the alarm.
This patch adds display of the clock icon for the DigitalWatchFace and WatchFacePineTimeStyle.

I decided not to add it to the other onces since:
- Terminal is already quite full and I did not want to clutter it further
- Analog: It did not fit the style, since the bleIcon is also not shown I assume this is meant to be more minimalistic.

Here are some screenshots:
![image](https://user-images.githubusercontent.com/5813055/168445855-b00c9bdb-06a9-4afe-b864-440dc89a4bda.png)
![image](https://user-images.githubusercontent.com/5813055/168445859-916656a5-f5df-4a34-8486-09942530a06b.png)
![image](https://user-images.githubusercontent.com/5813055/168445861-c54e8259-5758-47d9-ba4c-43f8f70cb3a3.png)
![image](https://user-images.githubusercontent.com/5813055/168445864-0c81688e-7689-48f6-aaab-bb462c5eeac7.png)
