### PR TITLE
comment about common error "glyphs.map" in old nodejs

### DIFF
--- a/doc/buildAndProgram.md
+++ b/doc/buildAndProgram.md
@@ -14,7 +14,7 @@ To build this project, you'll need:
  - A reasonably recent version of CMake (I use 3.16.5)
  - lv_font_conv, to generate the font .c files
    - see [lv_font_conv](https://github.com/lvgl/lv_font_conv#install-the-script)
-   - install npm (commonly done via the package manager)
+   - install npm (commonly done via the package manager, might need to upgrade node if you get `TypeError: this.src.glyphs.map(...).flat is not a function`)
    - install lv_font_conv: `npm install lv_font_conv`
 
 ## Build steps 


### PR DESCRIPTION
Added a comment in doc/buildAndProgram.md about nodejs needing to be updated if the error 
> "TypeError: this.src.glyphs.map(...).flat is not a function"

 pops up.