### PR TITLE
Analog Face: Add stepmeter indicators around watch face, add missing icons, restyling

### DIFF
--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -75,8 +75,14 @@ std::unique_ptr<Screen> Clock::WatchFaceDigitalScreen() {
 }
 
 std::unique_ptr<Screen> Clock::WatchFaceAnalogScreen() {
-  return std::make_unique<Screens::WatchFaceAnalog>(
-    app, dateTimeController, batteryController, bleController, notificatioManager, settingsController);
+  return std::make_unique<Screens::WatchFaceAnalog>(app, 
+                                                    dateTimeController, 
+                                                    batteryController, 
+                                                    bleController, 
+                                                    notificatioManager, 
+                                                    settingsController,
+                                                    heartRateController,
+                                                    motionController);
 }
 
 std::unique_ptr<Screen> Clock::WatchFacePineTimeStyleScreen() {

--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -5,16 +5,16 @@
 #include "displayapp/screens/BleIcon.h"
 #include "displayapp/screens/Symbols.h"
 #include "displayapp/screens/NotificationIcon.h"
+#include "components/heartrate/HeartRateController.h"
+#include "components/motion/MotionController.h"
 #include "components/settings/Settings.h"
-
-LV_IMG_DECLARE(bg_clock);
 
 using namespace Pinetime::Applications::Screens;
 
 namespace {
-constexpr int16_t HourLength = 70;
-constexpr int16_t MinuteLength = 90;
-constexpr int16_t SecondLength = 110;
+constexpr int16_t HourLength = 60;
+constexpr int16_t MinuteLength = 80;
+constexpr int16_t SecondLength = 90;
 
 // sin(90) = 1 so the value of _lv_trigo_sin(90) is the scaling factor
 const auto LV_TRIG_SCALE = _lv_trigo_sin(90);
@@ -49,22 +49,28 @@ WatchFaceAnalog::WatchFaceAnalog(Pinetime::Applications::DisplayApp* app,
                                  Controllers::Battery& batteryController,
                                  Controllers::Ble& bleController,
                                  Controllers::NotificationManager& notificationManager,
-                                 Controllers::Settings& settingsController)
+                                 Controllers::Settings& settingsController,
+                                 Controllers::HeartRateController& heartRateController,
+                                 Controllers::MotionController& motionController)
   : Screen(app),
     currentDateTime {{}},
     dateTimeController {dateTimeController},
     batteryController {batteryController},
     bleController {bleController},
     notificationManager {notificationManager},
-    settingsController {settingsController} {
+    settingsController {settingsController},
+    heartRateController {heartRateController},
+    motionController {motionController} {
 
   sHour = 99;
   sMinute = 99;
   sSecond = 99;
 
-  lv_obj_t* bg_clock_img = lv_img_create(lv_scr_act(), NULL);
-  lv_img_set_src(bg_clock_img, &bg_clock);
-  lv_obj_align(bg_clock_img, NULL, LV_ALIGN_CENTER, 0, 0);
+  stepsMeter = lv_linemeter_create(lv_scr_act(), NULL);
+  lv_linemeter_set_range(stepsMeter, 0, 12);
+  lv_linemeter_set_scale(stepsMeter, 360, 13);
+  lv_obj_set_size(stepsMeter, 250, 250);
+  lv_obj_align(stepsMeter, NULL, LV_ALIGN_CENTER, 0, 0);
 
   batteryIcon.Create(lv_scr_act());
   lv_obj_align(batteryIcon.GetObject(), nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
@@ -73,31 +79,38 @@ WatchFaceAnalog::WatchFaceAnalog(Pinetime::Applications::DisplayApp* app,
   lv_label_set_text_static(plugIcon, Symbols::plug);
   lv_obj_set_style_local_text_color(plugIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_RED);
   lv_obj_align(plugIcon, nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
+  
+  bleIcon = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(bleIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x0082FC));
+  lv_label_set_text_static(bleIcon, Symbols::bluetooth);
+  lv_obj_align(bleIcon, plugIcon, LV_ALIGN_OUT_LEFT_MID, -5, 0);
 
   notificationIcon = lv_label_create(lv_scr_act(), NULL);
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FF00));
   lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(false));
   lv_obj_align(notificationIcon, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 0);
 
+  heartbeatIcon = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(heartbeatIcon, Symbols::heartBeat);
+  lv_obj_set_style_local_text_color(heartbeatIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xCE1B1B));
+  lv_obj_align(heartbeatIcon, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
+
+  heartbeatValue = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(heartbeatValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xCE1B1B));
+  lv_label_set_text_static(heartbeatValue, "");
+  lv_obj_align(heartbeatValue, heartbeatIcon, LV_ALIGN_OUT_RIGHT_MID, 5, 0);
+
   // Date - Day / Week day
 
   label_date_day = lv_label_create(lv_scr_act(), NULL);
-  lv_obj_set_style_local_text_color(label_date_day, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0xff, 0xb0, 0x0));
-  lv_label_set_text_fmt(label_date_day, "%s\n%02i", dateTimeController.DayOfWeekShortToString(), dateTimeController.Day());
+  lv_obj_set_style_local_text_color(label_date_day, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0x90, 0x90, 0x90));
+  lv_label_set_text_fmt(label_date_day, "%s %02i", dateTimeController.DayOfWeekShortToString(), dateTimeController.Day());
   lv_label_set_align(label_date_day, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(label_date_day, NULL, LV_ALIGN_CENTER, 50, 0);
+  lv_obj_align(label_date_day, NULL, LV_ALIGN_CENTER, 55, -2);
 
   minute_body = lv_line_create(lv_scr_act(), NULL);
-  minute_body_trace = lv_line_create(lv_scr_act(), NULL);
   hour_body = lv_line_create(lv_scr_act(), NULL);
-  hour_body_trace = lv_line_create(lv_scr_act(), NULL);
   second_body = lv_line_create(lv_scr_act(), NULL);
-
-  lv_style_init(&second_line_style);
-  lv_style_set_line_width(&second_line_style, LV_STATE_DEFAULT, 3);
-  lv_style_set_line_color(&second_line_style, LV_STATE_DEFAULT, LV_COLOR_RED);
-  lv_style_set_line_rounded(&second_line_style, LV_STATE_DEFAULT, true);
-  lv_obj_add_style(second_body, LV_LINE_PART_MAIN, &second_line_style);
 
   lv_style_init(&minute_line_style);
   lv_style_set_line_width(&minute_line_style, LV_STATE_DEFAULT, 7);
@@ -105,23 +118,24 @@ WatchFaceAnalog::WatchFaceAnalog(Pinetime::Applications::DisplayApp* app,
   lv_style_set_line_rounded(&minute_line_style, LV_STATE_DEFAULT, true);
   lv_obj_add_style(minute_body, LV_LINE_PART_MAIN, &minute_line_style);
 
-  lv_style_init(&minute_line_style_trace);
-  lv_style_set_line_width(&minute_line_style_trace, LV_STATE_DEFAULT, 3);
-  lv_style_set_line_color(&minute_line_style_trace, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-  lv_style_set_line_rounded(&minute_line_style_trace, LV_STATE_DEFAULT, false);
-  lv_obj_add_style(minute_body_trace, LV_LINE_PART_MAIN, &minute_line_style_trace);
-
   lv_style_init(&hour_line_style);
   lv_style_set_line_width(&hour_line_style, LV_STATE_DEFAULT, 7);
   lv_style_set_line_color(&hour_line_style, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   lv_style_set_line_rounded(&hour_line_style, LV_STATE_DEFAULT, true);
   lv_obj_add_style(hour_body, LV_LINE_PART_MAIN, &hour_line_style);
 
-  lv_style_init(&hour_line_style_trace);
-  lv_style_set_line_width(&hour_line_style_trace, LV_STATE_DEFAULT, 3);
-  lv_style_set_line_color(&hour_line_style_trace, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-  lv_style_set_line_rounded(&hour_line_style_trace, LV_STATE_DEFAULT, false);
-  lv_obj_add_style(hour_body_trace, LV_LINE_PART_MAIN, &hour_line_style_trace);
+  lv_style_init(&second_line_style);
+  lv_style_set_line_width(&second_line_style, LV_STATE_DEFAULT, 3);
+  lv_style_set_line_color(&second_line_style, LV_STATE_DEFAULT, LV_COLOR_RED);
+  lv_style_set_line_rounded(&second_line_style, LV_STATE_DEFAULT, true);
+  lv_obj_add_style(second_body, LV_LINE_PART_MAIN, &second_line_style);
+  
+  dot = lv_line_create(lv_scr_act(), NULL);
+  lv_style_init(&dot_style);
+  lv_style_set_line_width(&dot_style, LV_STATE_DEFAULT, 10);
+  lv_style_set_line_color(&dot_style, LV_STATE_DEFAULT, LV_COLOR_RED);
+  lv_style_set_line_rounded(&dot_style, LV_STATE_DEFAULT, true);
+  lv_obj_add_style(dot, LV_LINE_PART_MAIN, &dot_style);
 
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
 
@@ -132,9 +146,7 @@ WatchFaceAnalog::~WatchFaceAnalog() {
   lv_task_del(taskRefresh);
 
   lv_style_reset(&hour_line_style);
-  lv_style_reset(&hour_line_style_trace);
   lv_style_reset(&minute_line_style);
-  lv_style_reset(&minute_line_style_trace);
   lv_style_reset(&second_line_style);
 
   lv_obj_clean(lv_scr_act());
@@ -147,14 +159,10 @@ void WatchFaceAnalog::UpdateClock() {
 
   if (sMinute != minute) {
     auto const angle = minute * 6;
-    minute_point[0] = CoordinateRelocate(30, angle);
+    minute_point[0] = CoordinateRelocate(0, angle);
     minute_point[1] = CoordinateRelocate(MinuteLength, angle);
 
-    minute_point_trace[0] = CoordinateRelocate(5, angle);
-    minute_point_trace[1] = CoordinateRelocate(31, angle);
-
     lv_line_set_points(minute_body, minute_point, 2);
-    lv_line_set_points(minute_body_trace, minute_point_trace, 2);
   }
 
   if (sHour != hour || sMinute != minute) {
@@ -162,14 +170,10 @@ void WatchFaceAnalog::UpdateClock() {
     sMinute = minute;
     auto const angle = (hour * 30 + minute / 2);
 
-    hour_point[0] = CoordinateRelocate(30, angle);
+    hour_point[0] = CoordinateRelocate(0, angle);
     hour_point[1] = CoordinateRelocate(HourLength, angle);
 
-    hour_point_trace[0] = CoordinateRelocate(5, angle);
-    hour_point_trace[1] = CoordinateRelocate(31, angle);
-
     lv_line_set_points(hour_body, hour_point, 2);
-    lv_line_set_points(hour_body_trace, hour_point_trace, 2);
   }
 
   if (sSecond != second) {
@@ -178,7 +182,12 @@ void WatchFaceAnalog::UpdateClock() {
 
     second_point[0] = CoordinateRelocate(-20, angle);
     second_point[1] = CoordinateRelocate(SecondLength, angle);
+
+    dot_point[0] = lv_point_t{ 119, 120 };
+    dot_point[1] = lv_point_t{ 120, 120 };;
+
     lv_line_set_points(second_body, second_point, 2);
+    lv_line_set_points(dot, dot_point, 2);
   }
 }
 
@@ -206,6 +215,14 @@ void WatchFaceAnalog::Refresh() {
     }
   }
 
+  bleState = bleController.IsConnected();
+  bleRadioEnabled = bleController.IsRadioEnabled();
+  if (bleState.IsUpdated() || bleRadioEnabled.IsUpdated()) {
+    lv_label_set_text_static(bleIcon, BleIcon::GetIcon(bleState.Get()));
+  }
+  lv_obj_realign(plugIcon);
+  lv_obj_realign(bleIcon);
+
   notificationState = notificationManager.AreNewNotificationsAvailable();
 
   if (notificationState.IsUpdated()) {
@@ -222,11 +239,40 @@ void WatchFaceAnalog::Refresh() {
     UpdateClock();
 
     if ((month != currentMonth) || (dayOfWeek != currentDayOfWeek) || (day != currentDay)) {
-      lv_label_set_text_fmt(label_date_day, "%s\n%02i", dateTimeController.DayOfWeekShortToString(), day);
+      lv_label_set_text_fmt(label_date_day, "%s %02i", dateTimeController.DayOfWeekShortToString(), day);
 
       currentMonth = month;
       currentDayOfWeek = dayOfWeek;
       currentDay = day;
     }
+  }
+  
+  heartbeat = heartRateController.HeartRate();
+  heartbeatRunning = heartRateController.State() != Controllers::HeartRateController::States::Stopped;
+  if (heartbeat.IsUpdated() || heartbeatRunning.IsUpdated()) {
+    if (heartbeatRunning.Get()) {
+      lv_obj_set_style_local_text_color(heartbeatIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xCE1B1B));
+      lv_label_set_text_fmt(heartbeatValue, "%d", heartbeat.Get());
+    } else {
+      lv_obj_set_style_local_text_color(heartbeatIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x1B1B1B));
+      lv_label_set_text_static(heartbeatValue, "");
+    }
+
+    lv_obj_realign(heartbeatIcon);
+    lv_obj_realign(heartbeatValue);
+  }
+
+  stepCount = motionController.NbSteps();
+  motionSensorOk = motionController.IsSensorOk();
+  if (stepCount.IsUpdated() || motionSensorOk.IsUpdated()) {
+    uint32_t goal = settingsController.GetStepsGoal();
+    uint32_t steps = stepCount.Get();
+    int32_t steps_value;
+    if(steps > goal)
+      steps_value = 12; 
+    else
+      steps_value = ((float)steps / goal) * 12;
+
+    lv_linemeter_set_value(stepsMeter, steps_value);
   }
 }

--- a/src/displayapp/screens/WatchFaceAnalog.h
+++ b/src/displayapp/screens/WatchFaceAnalog.h
@@ -17,6 +17,8 @@ namespace Pinetime {
     class Battery;
     class Ble;
     class NotificationManager;
+    class HeartRateController;
+    class MotionController;
   }
   namespace Applications {
     namespace Screens {
@@ -28,7 +30,9 @@ namespace Pinetime {
                         Controllers::Battery& batteryController,
                         Controllers::Ble& bleController,
                         Controllers::NotificationManager& notificationManager,
-                        Controllers::Settings& settingsController);
+                        Controllers::Settings& settingsController,
+                        Controllers::HeartRateController& heartRateController,
+                        Controllers::MotionController& motionController);
 
         ~WatchFaceAnalog() override;
 
@@ -45,28 +49,35 @@ namespace Pinetime {
         DirtyValue<bool> isCharging {};
         DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime;
         DirtyValue<bool> notificationState {false};
+        DirtyValue<bool> bleState {};
+        DirtyValue<bool> bleRadioEnabled {};
+        DirtyValue<bool> motionSensorOk {};
+        DirtyValue<uint32_t> stepCount {};
+        DirtyValue<uint8_t> heartbeat {};
+        DirtyValue<bool> heartbeatRunning {};
 
+        lv_obj_t* dot;
         lv_obj_t* hour_body;
-        lv_obj_t* hour_body_trace;
         lv_obj_t* minute_body;
-        lv_obj_t* minute_body_trace;
         lv_obj_t* second_body;
 
         lv_point_t hour_point[2];
-        lv_point_t hour_point_trace[2];
         lv_point_t minute_point[2];
-        lv_point_t minute_point_trace[2];
         lv_point_t second_point[2];
+        lv_point_t dot_point[2];
 
+        lv_style_t dot_style;
         lv_style_t hour_line_style;
-        lv_style_t hour_line_style_trace;
         lv_style_t minute_line_style;
-        lv_style_t minute_line_style_trace;
         lv_style_t second_line_style;
 
         lv_obj_t* label_date_day;
         lv_obj_t* plugIcon;
+        lv_obj_t* bleIcon;
         lv_obj_t* notificationIcon;
+        lv_obj_t* heartbeatIcon;
+        lv_obj_t* heartbeatValue;
+        lv_obj_t* stepsMeter;
 
         BatteryIcon batteryIcon;
 
@@ -75,6 +86,8 @@ namespace Pinetime {
         Controllers::Ble& bleController;
         Controllers::NotificationManager& notificationManager;
         Controllers::Settings& settingsController;
+        Controllers::HeartRateController& heartRateController;
+        Controllers::MotionController& motionController;
 
         void UpdateClock();
         void SetBatteryIcon();


### PR DESCRIPTION
Hey all,

I've revamped the analogue watch face and would like to discuss what people think.
Here is a screenshot:
![screenshot](https://i.imgur.com/2T7kDwL.png)


More detailed changes:
- Removed rendering of background image.
- Step meter uses lv_linemeter with 12 indicator lines (one for each hour). So for instance you have 10000 steps goal, and have walked 5000, 6 hour indicator lines will be highlighted. Once you go above the goal, the indicator lines will remain highlighting all 12.
- Add missing icons for bluetooth and heartrate (as in Digital watchface)
- Re-style face and hands (lovely red dot).
- Day of week and date now render on a single line (like a lot of analogue watches out there!)

Open to discussion, like the ideas? I am fond of making the face minimal (no second indicators between the hours), and simple single lines for each hand - but obviously this is just my opinion...  