### PR TITLE
Extend CTS Server

### DIFF
--- a/src/components/ble/CurrentTimeClient.cpp
+++ b/src/components/ble/CurrentTimeClient.cpp
@@ -85,21 +85,11 @@ int CurrentTimeClient::OnCurrentTimeReadResult(uint16_t conn_handle, const ble_g
     // TODO check that attribute->handle equals the handle discovered in OnCharacteristicDiscoveryEvent
     CtsData result;
     os_mbuf_copydata(attribute->om, 0, sizeof(CtsData), &result);
-    NRF_LOG_INFO("Received data: %d-%d-%d %d:%d:%d",
-                 result.year,
-                 result.month,
-                 result.dayofmonth,
-                 result.hour,
-                 result.minute,
-                 result.second);
-    dateTimeController.SetTime(result.year,
-                               result.month,
-                               result.dayofmonth,
-                               0,
-                               result.hour,
-                               result.minute,
-                               result.second,
-                               nrf_rtc_counter_get(portNRF_RTC_REG));
+    uint16_t year = ((uint16_t) result.year_MSO << 8) + result.year_LSO;
+
+    NRF_LOG_INFO("Received data: %d-%d-%d %d:%d:%d", year, result.month, result.dayofmonth, result.hour, result.minute, result.second);
+    dateTimeController
+      .SetTime(year, result.month, result.dayofmonth, 0, result.hour, result.minute, result.second, nrf_rtc_counter_get(portNRF_RTC_REG));
   } else {
     NRF_LOG_INFO("Error retrieving current time: %d", error->status);
   }

--- a/src/components/ble/CurrentTimeClient.h
+++ b/src/components/ble/CurrentTimeClient.h
@@ -29,14 +29,16 @@ namespace Pinetime {
 
     private:
       typedef struct __attribute__((packed)) {
-        uint16_t year;
+        uint8_t year_LSO; // explicit byte ordering to be independent of machine order
+        uint8_t year_MSO; // BLE GATT is little endian
         uint8_t month;
         uint8_t dayofmonth;
         uint8_t hour;
         uint8_t minute;
         uint8_t second;
-        uint8_t millis;
-        uint8_t reason;
+        uint8_t dayofweek;
+        uint8_t fractions256; // currently ignored
+        uint8_t reason;       // currently ignored, not that any host would set it anyway
       } CtsData;
 
       static constexpr uint16_t ctsServiceId {0x1805};

--- a/src/components/ble/CurrentTimeService.cpp
+++ b/src/components/ble/CurrentTimeService.cpp
@@ -5,11 +5,23 @@
 using namespace Pinetime::Controllers;
 
 constexpr ble_uuid16_t CurrentTimeService::ctsUuid;
-constexpr ble_uuid16_t CurrentTimeService::ctChrUuid;
+constexpr ble_uuid16_t CurrentTimeService::ctsCtChrUuid;
+constexpr ble_uuid16_t CurrentTimeService::ctsLtChrUuid;
 
 int CTSCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
   auto cts = static_cast<CurrentTimeService*>(arg);
-  return cts->OnTimeAccessed(conn_handle, attr_handle, ctxt);
+
+  return cts->OnCurrentTimeServiceAccessed(conn_handle, attr_handle, ctxt);
+}
+
+int CurrentTimeService::OnCurrentTimeServiceAccessed(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
+  switch (ble_uuid_u16(ctxt->chr->uuid)) {
+    case ctsCurrentTimeCharId:
+      return OnCurrentTimeAccessed(conn_handle, attr_handle, ctxt);
+    case ctsLocalTimeCharId:
+      return OnLocalTimeAccessed(conn_handle, attr_handle, ctxt);
+  }
+  return -1; // Unknown characteristic
 }
 
 void CurrentTimeService::Init() {
@@ -18,45 +30,69 @@ void CurrentTimeService::Init() {
   ASSERT(res == 0);
 
   res = ble_gatts_add_svcs(serviceDefinition);
+
   ASSERT(res == 0);
 }
 
-int CurrentTimeService::OnTimeAccessed(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
+int CurrentTimeService::OnCurrentTimeAccessed(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
 
   NRF_LOG_INFO("Setting time...");
 
   if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
-    CtsData result;
-    os_mbuf_copydata(ctxt->om, 0, sizeof(CtsData), &result);
+    CtsCurrentTimeData result;
+    int res = os_mbuf_copydata(ctxt->om, 0, sizeof(CtsCurrentTimeData), &result);
+    if (res < 0) {
+      NRF_LOG_ERROR("Error reading BLE Data writing to CTS Current Time (too little data)")
+      return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+    }
 
-    NRF_LOG_INFO("Received data: %d-%d-%d %d:%d:%d",
-                 result.year,
-                 result.month,
-                 result.dayofmonth,
-                 result.hour,
-                 result.minute,
-                 result.second);
+    uint16_t year = ((uint16_t) result.year_MSO << 8) + result.year_LSO;
 
-    m_dateTimeController.SetTime(result.year,
-                                 result.month,
-                                 result.dayofmonth,
-                                 0,
-                                 result.hour,
-                                 result.minute,
-                                 result.second,
-                                 nrf_rtc_counter_get(portNRF_RTC_REG));
+    NRF_LOG_INFO("Received data: %d-%d-%d %d:%d:%d", year, result.month, result.dayofmonth, result.hour, result.minute, result.second);
+
+    m_dateTimeController
+      .SetTime(year, result.month, result.dayofmonth, 0, result.hour, result.minute, result.second, nrf_rtc_counter_get(portNRF_RTC_REG));
 
   } else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
-    CtsData currentDateTime;
-    currentDateTime.year = m_dateTimeController.Year();
+    CtsCurrentTimeData currentDateTime;
+    currentDateTime.year_LSO = m_dateTimeController.Year() & 0xff;
+    currentDateTime.year_MSO = (m_dateTimeController.Year() >> 8) & 0xff;
     currentDateTime.month = static_cast<u_int8_t>(m_dateTimeController.Month());
     currentDateTime.dayofmonth = m_dateTimeController.Day();
     currentDateTime.hour = m_dateTimeController.Hours();
     currentDateTime.minute = m_dateTimeController.Minutes();
     currentDateTime.second = m_dateTimeController.Seconds();
-    currentDateTime.millis = 0;
+    currentDateTime.fractions256 = 0;
 
-    int res = os_mbuf_append(ctxt->om, &currentDateTime, sizeof(CtsData));
+    int res = os_mbuf_append(ctxt->om, &currentDateTime, sizeof(CtsCurrentTimeData));
+    return (res == 0) ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+  }
+
+  return 0;
+}
+
+int CurrentTimeService::OnLocalTimeAccessed(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
+  NRF_LOG_INFO("Setting timezone...");
+
+  if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
+    CtsLocalTimeData result;
+    int res = os_mbuf_copydata(ctxt->om, 0, sizeof(CtsLocalTimeData), &result);
+
+    if (res < 0) {
+      NRF_LOG_ERROR("Error reading BLE Data writing to CTS Local Time (too little data)")
+      return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+    }
+
+    NRF_LOG_INFO("Received data: %d %d", result.timezone, result.dst);
+
+    m_dateTimeController.SetTimeZone(result.timezone, result.dst);
+
+  } else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
+    CtsLocalTimeData currentTimezone;
+    currentTimezone.timezone = m_dateTimeController.TzOffset();
+    currentTimezone.dst = m_dateTimeController.DstOffset();
+
+    int res = os_mbuf_append(ctxt->om, &currentTimezone, sizeof(currentTimezone));
     return (res == 0) ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
   }
 
@@ -64,12 +100,19 @@ int CurrentTimeService::OnTimeAccessed(uint16_t conn_handle, uint16_t attr_handl
 }
 
 CurrentTimeService::CurrentTimeService(DateTime& dateTimeController)
-  : characteristicDefinition {{.uuid = &ctChrUuid.u,
-                               .access_cb = CTSCallback,
+  : characteristicDefinition {
 
+                              {.uuid = &ctsLtChrUuid.u,
+                               .access_cb = CTSCallback,
                                .arg = this,
                                .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ},
-                              {0}},
+
+                               {.uuid = &ctsCtChrUuid.u,
+                               .access_cb = CTSCallback,
+                               .arg = this,
+                               .flags = BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ},
+
+                               {0}},
     serviceDefinition {
       {/* Device Information Service */
        .type = BLE_GATT_SVC_TYPE_PRIMARY,

--- a/src/components/ble/CurrentTimeService.h
+++ b/src/components/ble/CurrentTimeService.h
@@ -16,29 +16,40 @@ namespace Pinetime {
       CurrentTimeService(DateTime& dateTimeController);
       void Init();
 
-      int OnTimeAccessed(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt);
+      int OnCurrentTimeServiceAccessed(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt);
+      int OnCurrentTimeAccessed(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt);
+      int OnLocalTimeAccessed(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt);
 
     private:
       static constexpr uint16_t ctsId {0x1805};
-      static constexpr uint16_t ctsCharId {0x2a2b};
+      static constexpr uint16_t ctsCurrentTimeCharId {0x2a2b};
+      static constexpr uint16_t ctsLocalTimeCharId {0x2a0f};
 
       static constexpr ble_uuid16_t ctsUuid {.u {.type = BLE_UUID_TYPE_16}, .value = ctsId};
 
-      static constexpr ble_uuid16_t ctChrUuid {.u {.type = BLE_UUID_TYPE_16}, .value = ctsCharId};
+      static constexpr ble_uuid16_t ctsCtChrUuid {.u {.type = BLE_UUID_TYPE_16}, .value = ctsCurrentTimeCharId};
+      static constexpr ble_uuid16_t ctsLtChrUuid {.u {.type = BLE_UUID_TYPE_16}, .value = ctsLocalTimeCharId};
 
-      struct ble_gatt_chr_def characteristicDefinition[2];
+      struct ble_gatt_chr_def characteristicDefinition[3];
       struct ble_gatt_svc_def serviceDefinition[2];
 
       typedef struct __attribute__((packed)) {
-        uint16_t year;
+        uint8_t year_LSO; // BLE GATT is little endian
+        uint8_t year_MSO;
         uint8_t month;
         uint8_t dayofmonth;
         uint8_t hour;
         uint8_t minute;
         uint8_t second;
-        uint8_t millis;
-        uint8_t reason;
-      } CtsData;
+        uint8_t dayofweek;
+        uint8_t fractions256; // currently ignored
+        uint8_t reason;       // currently ignored, not that any host would set it anyway
+      } CtsCurrentTimeData;
+
+      typedef struct __attribute__((packed)) {
+        uint8_t timezone;
+        uint8_t dst;
+      } CtsLocalTimeData;
 
       DateTime& m_dateTimeController;
     };

--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -35,6 +35,7 @@ void DateTime::SetTime(uint16_t year,
     /* .tm_mon  = */ month - 1,
     /* .tm_year = */ year - 1900,
   };
+
   tm.tm_isdst = -1; // Use DST value from local time zone
   currentDateTime = std::chrono::system_clock::from_time_t(std::mktime(&tm));
 
@@ -47,6 +48,11 @@ void DateTime::SetTime(uint16_t year,
   NRF_LOG_INFO("* %d %d %d ", this->day, this->month, this->year);
 
   systemTask->PushMessage(System::Messages::OnNewTime);
+}
+
+void DateTime::SetTimeZone(uint8_t timezone, uint8_t dst) {
+  tzOffset = timezone;
+  dstOffset = dst;
 }
 
 void DateTime::UpdateTime(uint32_t systickCounter) {

--- a/src/components/datetime/DateTimeController.h
+++ b/src/components/datetime/DateTimeController.h
@@ -38,6 +38,18 @@ namespace Pinetime {
                    uint8_t minute,
                    uint8_t second,
                    uint32_t systickCounter);
+
+      /*
+       * setter corresponding to the BLE Set Local Time characteristic.
+       *
+       * used to update difference between utc and local time (see UtcOffset())
+       *
+       * parameters are in quarters of an our. Following the BLE CTS specification,
+       * timezone is expected to be constant over DST which will be reported in
+       * dst field.
+       */
+      void SetTimeZone(uint8_t timezone, uint8_t dst);
+
       void UpdateTime(uint32_t systickCounter);
       uint16_t Year() const {
         return year;
@@ -61,12 +73,51 @@ namespace Pinetime {
         return second;
       }
 
+      /*
+       * returns the offset between local time and UTC in quarters of an hour
+       *
+       * Availability of this field depends on wether the companion app
+       * supports the BLE CTS Local Time Characteristic. Expect it to be 0
+       * if not.
+       */
+      uint8_t UtcOffset() const {
+        return tzOffset + dstOffset;
+      }
+
+      /*
+       * returns the offset between the (dst independent) local time zone and UTC
+       * in quarters of an hour
+       *
+       * Availability of this field depends on wether the companion app
+       * supports the BLE CTS Local Time Characteristic. Expect it to be 0
+       * if not.
+       */
+      uint8_t TzOffset() const {
+        return tzOffset;
+      }
+
+      /*
+       * returns the offset between the local time zone and local time
+       * in quarters of an hour
+       * if != 0, DST is in effect, if == 0 not.
+       *
+       * Availability of this field depends on wether the companion app
+       * supports the BLE CTS Local Time Characteristic. Expect it to be 0
+       * if not.
+       */
+      uint8_t DstOffset() const {
+        return dstOffset;
+      }
+
       const char* MonthShortToString() const;
       const char* DayOfWeekShortToString() const;
       static const char* MonthShortToStringLow(Months month);
 
       std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> CurrentDateTime() const {
         return currentDateTime;
+      }
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> UTCDateTime() const {
+        return currentDateTime - std::chrono::seconds((tzOffset + dstOffset) * 15 * 60);
       }
       std::chrono::seconds Uptime() const {
         return uptime;
@@ -84,6 +135,8 @@ namespace Pinetime {
       uint8_t hour = 0;
       uint8_t minute = 0;
       uint8_t second = 0;
+      uint8_t tzOffset = 0;
+      uint8_t dstOffset = 0;
 
       uint32_t previousSystickCounter = 0;
       std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> currentDateTime;


### PR DESCRIPTION
## Motivation

I implemented a small TOTP Screen for my watch and thus needed access to UTC. When checking on how to get this information from my phone to the watch, I found and implemented the Local Time Characteristic of the Current Time Service BLE specification. This allows the companion app to transmit information about the current timezone as well as dst in effect.
~~When checking for related PRs and Issues I found #365 and thought that I'd implement parts of it allowing to show UTC on the watch.~~

## Changes

### BLE

* implemented the Local Time Characteristic in `CurrentTimeService`
* added a check to both Local Time and Current Time to ignore too short data
* corrected the definition of the `CtsCurrentTimeData` struct in `CurrentTimeClient` as well as `CurrentTimeService` to match the specification

### `DateTimeController`

* added fields for timezone and dst offsets to store the values provided by the BLE characteristic
* added getter for UTC offset
* added getter for UTC


### ~~Settings~~

* ~~added UTC option to the clock formats
<img src="https://user-images.githubusercontent.com/106408965/170828357-dbe47c24-2331-41b4-8d9c-92f3c21b613c.png" width="50%">~~

### ~~WatchFaces~~

* ~~changed watch faces to respect UTC setting~~
* ~~UTC is always shown as 24h format (I do not think someone should display UTC in 12h format, change my mind ;)~~
* ~~WatchFace Analog: Found no good way to signal that UTC is active, did not want to impact the design~~
* ~~WatchFace Digital:  When displaying UTC the date is shown in ISO format (I guess whoever wants his watch to show UTC is also a big fan of ISO dates :)~~
<img src="https://user-images.githubusercontent.com/106408965/170828301-f34295e4-a8f8-49f6-83d0-0493fda62f8a.png" width="50%">

* ~~WatchFace Style: Found no good way to signal that UTC is active, did not want to impact the design~~
* ~~WatchFace Terminal: Shows trailing "Z" on the time if UTC is shown. Also, changed the date to use dashes instead of dots.~~
<img src="https://user-images.githubusercontent.com/106408965/170828305-965f0ced-1939-4def-b7c4-cdb193925fd8.png" width="50%">~~

## Tests


I tested my code on the InfiniSim as well as my actual (sealed) watch. I used a patched version of Gadgetbridge to send the added characteristic. So far, I could not observe any problems.


## Notes

I added a check for the returncode of the `os_mbuf_copydata()` function (may for-money job consists a lot of making people not ignore return values, so I am afraid I can not not do it). The question was what to do with invalid data. A) just set the received, potentially invalid, data and let the user see that there is something wrong. B) ignore the data, potentially having the watch not work at all. Seeing that the user can not really do something in any case, I chose B) as it just feels wrong to use invalid data.

I changed the 16bit year field into two 8 bit fields, assembling them manually and making the code more portable. The previous implementation relied on the machine order being little endian. While for now, this code is not very likely to end up on a big endian machine, I really think it is great and could/should end up on a different platform, where this might become an annoying bug.

I kept the separate timezone and dst fields, even if the might not be extremely useful uncombined, but maybe some wants to show if DST is active or something.

~~For WatchFaceAnalog, I had to pull in `<date/date.h>` to be able to convert from the chrono information returned by `dateTimeController.UTCDateTime()`. I could have added `UTCHour()` and other accessors to DateTimeController, but thought it was cleaner to do the conversion in the WatchFace, seeing the other WatchFaces do as well.~~

This all depends on a companion app supporting the newly implemented Local Time Characteristic. As I said before, I am using a patched version of Gadgetbridge for myself and I hope I can open a PR there soon (and then look into other companion apps). ~~The question here is, what to do if the companion app does not support it. A) Disable/Hide the UTC option in settings B) leave it, but without effect (all values are initialized to 0, making UTC and local time equivalent). I went with B as I am not a fan of the complexity added by having to check if there was a Local Time update or not, if was valid at some point, and so on. I just think that it is not worth it and a user should be able to tolerate that the setting does not chang anything. Maybe a note can be placed in some documentation (I actually found no in tree documentation on the 24h setting).~~