### PR TITLE
Fix various typos

### DIFF
--- a/bootloader/README.md
+++ b/bootloader/README.md
@@ -9,14 +9,14 @@ Integrating a BLE stack for the OTA functionality would have used to much memory
 
 When it is run, this bootloader looks in the SPI flash memory if a new firmware is available. It there is one, it *swaps* the current firmware with the new one (the new one is copied in the main flash memory, and the current one is copied in the SPI flash memory) and run the new one. If the new one fails to run properly, the bootloader is able to revert to the old one and mark the new one as not working.
 
-As this bootloader does not provide any OTA capability, it is not able to actually download a new version of the application. Providing OTA functionality is thus the responsability of the application firmware.
+As this bootloader does not provide any OTA capability, it is not able to actually download a new version of the application. Providing OTA functionality is thus the responsibility of the application firmware.
 
 # About MCUBoot
 MCUBoot is run at boot time. In normal operation, it just jumps to the reset handler of the application firmware to run it. Once the application firmware is running, MCUBoot does not run at all.
 
 ![MCUBoot boot sequence diagram](../doc/bootloader/boot.png "MCUBoot boot sequence diagram")
 
-But MCUBoot does much more than that : it can upgrade the firmware that is currently running by a new one, and it is also able to revert to the previous version of the firmware in case the new one does not run propertly.
+But MCUBoot does much more than that : it can upgrade the firmware that is currently running by a new one, and it is also able to revert to the previous version of the firmware in case the new one does not run properly.
 
 To do this, it uses 2 memory 'slots' :
  - **The primary slot** : it contains the current firmware, the one that will be executed by MCUBoot
@@ -40,7 +40,7 @@ This chapter describes degraded cases that are handled by our bootloader and tho
 Case | Current bootloader | Solution
 -----|--------------------|----------------------------------------------
 Data got corrupted during file transfer | [OK] Application firmware does a CRC check before applying the update, and does not proceed if it fails. | N/A
-New firmware does not run at all (bad file) (1) | [NOK] MCU executes unknown instructions and will most likely end up in an infinite loop or freeze in an error handler. The bootloader does not run, it can do nothing, the MCU is stucked until next reset | [OK] The bootloader starts the watchdog just before running the new firmware. This way, the watchdog will reset the MCU after ~7s because the firmware does not refresh it. Bootloader reverts to the previous version of the firmware during the reset.
+New firmware does not run at all (bad file) (1) | [NOK] MCU executes unknown instructions and will most likely end up in an infinite loop or freeze in an error handler. The bootloader does not run, it can do nothing, the MCU is stuck until next reset | [OK] The bootloader starts the watchdog just before running the new firmware. This way, the watchdog will reset the MCU after ~7s because the firmware does not refresh it. Bootloader reverts to the previous version of the firmware during the reset.
 New firmware runs, does not set the valid bit and does not refresh the watchdog | [NOK] The new firmware runs until the next reset. The bootloader will be able to revert to the previous firmware only during the next reset. If the new firmware does not run properly and does not reset, the bootloader can do nothing until the next reset | [OK] The bootloader starts the watchdog just before running the new firmware. This way, the watchdog will reset the MCU after ~7s because the firmware does not refresh it. Bootloader reverts to the previous version of the firmware during the reset.
 New firmware does not run properly, does not set the valid bit but refreshes the watchdog | [NOK] The bootloader will be able to revert to the previous firmware only during the next reset. If the new firmware does not run properly and does not reset, the bootloader can do nothing until the next reset | [~] Wait for the battery to drain. The CPU will reset the next time the device is charged and will be able to rollback to the previous version.
 New firmware does not run properly but sets the valid bit and refreshes the watchdog | [NOK] The bootloader won't revert to the previous version because the valid flag is set | [~] Wait for the battery to drain. The CPU will reset the next time the device is charged. Then, the bootloader must provide a way for the user to force the rollback to the previous version

--- a/bootloader/ota-dfu-python/ble_secure_dfu_controller.py
+++ b/bootloader/ota-dfu-python/ble_secure_dfu_controller.py
@@ -236,7 +236,7 @@ class BleDfuControllerSecure(NrfBleDfuController):
         self._dfu_send_command(Procedures.EXECUTE)
         self._wait_and_parse_notify()
 
-        print("Init packet successfully transfered")
+        print("Init packet successfully transferred")
 
     # --------------------------------------------------------------------------
     #  Send the Firmware image to peripheral device.
@@ -319,5 +319,5 @@ class BleDfuControllerSecure(NrfBleDfuController):
         self._dfu_send_command(Procedures.EXECUTE)
         self._wait_and_parse_notify()
 
-        # If everything executed correctly, return amount of bytes transfered
+        # If everything executed correctly, return amount of bytes transferred
         return obj_max_size

--- a/cmake-nRF5x/readme.md
+++ b/cmake-nRF5x/readme.md
@@ -7,7 +7,7 @@ Cmake script for projects targeting Nordic Semiconductor nRF5x series devices us
 The script makes use of the following tools:
 
 - nRF5x SDK by Nordic Semiconductor - SoC specific drivers and libraries (also includes a lot of examples)
-- JLink by Segger - interface software for the JLink familiy of programmers
+- JLink by Segger - interface software for the JLink family of programmers
 - nrfjprog by Nordic Semiconductor - Wrapper utility around JLink
 - arm-non-eabi-gcc by ARM and the GCC Team - compiler toolchain for embedded (= bare metal) ARM chips
 
@@ -15,11 +15,11 @@ The script makes use of the following tools:
 
 1. Download this repo (or add as submodule) to the directory `cmake-nRF5x` in your project
 
-1. Search the SDK `example` directory for a `sdk_config.h`, `main.c` and a linker script (normally named `<project_name>_gcc_<chip familly>.ld`) that fits your chip and project needs.
+1. Search the SDK `example` directory for a `sdk_config.h`, `main.c` and a linker script (normally named `<project_name>_gcc_<chip family>.ld`) that fits your chip and project needs.
 
 1. Copy the `sdk_config.h` and the project `main.c` into a new directory `src`. Modify them as required for your project.
 
-1. Copy the linker script into the root of your project. Rename it to just `gcc_<chip familly>.ld` For example:
+1. Copy the linker script into the root of your project. Rename it to just `gcc_<chip family>.ld` For example:
 	
 	```
 	gcc_nrf51.ld

--- a/doc/MemoryAnalysis.md
+++ b/doc/MemoryAnalysis.md
@@ -60,7 +60,7 @@ Puncover is really easy to install:
  - Launch a browser at http://localhost:5000/
 
 ### Analysis
-Using the MAP file and tools, we can easily see what symbols are using most of the flash memory. In this case, unsuprisingly, fonts and graphics are the largest use of flash memory.
+Using the MAP file and tools, we can easily see what symbols are using most of the flash memory. In this case, unsurprisingly, fonts and graphics are the largest use of flash memory.
 
 ![Puncover](./memoryAnalysis/puncover-all-symbols.png)
 
@@ -150,7 +150,7 @@ You can then display the file using objdump:
 hexdump ram.bin -v  | less
 ```
 
-The stack is positionned at the end of the RAM -> 0xFFFF. Its size is 8192 bytes, so the end of the stack is at 0xE000.
+The stack is positioned at the end of the RAM -> 0xFFFF. Its size is 8192 bytes, so the end of the stack is at 0xE000.
 On the following dump, the maximum stack usage is 520 bytes (0xFFFF - 0xFDF8):
 
 ```

--- a/doc/NavigationService.md
+++ b/doc/NavigationService.md
@@ -13,7 +13,7 @@ The service UUID is 00010000-78fc-48fe-8e23-433b3a1942d0
 
 ## Characteristics
 ## Flags (UUID 00010001-78fc-48fe-8e23-433b3a1942d0)
-All included icons are from pure-maps, which provides the actual routing from the client. The icon names ultimately come from the mapbox project "direction-icons", See https://github.com/rinigus/pure-maps/tree/master/qml/icons/navigation See the end of this document for the full lsit of supported icon names.
+All included icons are from pure-maps, which provides the actual routing from the client. The icon names ultimately come from the mapbox project "direction-icons", See https://github.com/rinigus/pure-maps/tree/master/qml/icons/navigation See the end of this document for the full list of supported icon names.
 
 ## Narrative (UUID 00010002-78fc-48fe-8e23-433b3a1942d0)
 This is a client supplied string describing the upcoming instruction such as "At the roundabout take the first exit".

--- a/doc/PinetimeStubWithNrf52DK.md
+++ b/doc/PinetimeStubWithNrf52DK.md
@@ -1,5 +1,5 @@
 # Build a stub for PineTime using NRF52-DK
-[NRF52-DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52-DK) is the official developpment kit for the NRF52832 SoC from Nordic Semiconductor used in the PineTime.
+[NRF52-DK](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52-DK) is the official development kit for the NRF52832 SoC from Nordic Semiconductor used in the PineTime.
 
 This development kit can be very useful for PineTime development:
  * You can use its embedded JLink SWD programmer/debugger to program and debug your code on the PineTime

--- a/doc/ble.md
+++ b/doc/ble.md
@@ -44,7 +44,7 @@ When starting, the firmware starts BLE advertising. It sends small messages that
 
 A companion application (running on a PC, Raspberry Pi, smartphone, etc.) which receives this advertising packet can request a connection to the device. This connection procedure allows the 2 devices to negotiate communication parameters, security keys, etc.
 
-When the connection is established, the PineTime will try to discover services running on the companion application. For now **CTS** (**C**urrent **T**ime **S**ervice) and **ANS** (**A**lert **N**otification **S**ervice) are supported.
+When the connection is established, the PineTime will try to discover services running on the companion application. For now **CTS** (**C**urrent **T**ime **S**ervice) and **ANS** (**A**lert **N**notification **S**ervice) are supported.
 
 If **CTS** is detected, it'll request the current time to the companion application. If **ANS** is detected, it will listen to new notifications coming from the companion application.
 
@@ -146,14 +146,14 @@ The new alert characteristic allows sending new notifications to InfiniTime. It 
 For example, here is what a normal notification looks like in Golang (language of `itd`):
 
 ```go
-// \x00 is the category for simple alert, and there is one new notifcation, hence \x01.
+// \x00 is the category for simple alert, and there is one new notification, hence \x01.
 "\x00\x01\x00Test Title\x00Test Body"
 ```
 
 A call notification looks like so:
 
 ```go
-// \x03 is the category for calls, and there is one new call notifcation, hence \x01.
+// \x03 is the category for calls, and there is one new call notification, hence \x01.
 "\x03\x01\x00Mary"
 ```
 

--- a/doc/ble.md
+++ b/doc/ble.md
@@ -44,7 +44,7 @@ When starting, the firmware starts BLE advertising. It sends small messages that
 
 A companion application (running on a PC, Raspberry Pi, smartphone, etc.) which receives this advertising packet can request a connection to the device. This connection procedure allows the 2 devices to negotiate communication parameters, security keys, etc.
 
-When the connection is established, the PineTime will try to discover services running on the companion application. For now **CTS** (**C**urrent **T**ime **S**ervice) and **ANS** (**A**lert **N**notification **S**ervice) are supported.
+When the connection is established, the PineTime will try to discover services running on the companion application. For now **CTS** (**C**urrent **T**ime **S**ervice) and **ANS** (**A**lert **N**otification **S**ervice) are supported.
 
 If **CTS** is detected, it'll request the current time to the companion application. If **ANS** is detected, it will listen to new notifications coming from the companion application.
 

--- a/doc/ble/connection_sequence.puml
+++ b/doc/ble/connection_sequence.puml
@@ -3,7 +3,7 @@ Pinetime --> CompanionApp: Start advertising
 
 group BLE Connection
 CompanionApp -> Pinetime: Connection request
-CompanionApp <-> Pinetime: Connection parameters negociation, security procedure,...
+CompanionApp <-> Pinetime: Connection parameters negotiation, security procedure,...
 end
 
 group Service Discovery

--- a/doc/branches.md
+++ b/doc/branches.md
@@ -5,7 +5,7 @@ The project is based on 2 main branches:
  - **master** : this branch is always ready to be deployed. It means that at any time, we should be able to build the branch and release a new version of the application.
  - **develop** : this branch contains the latest development that will be integrated in the next release once it's considered as stable.
 
-New features should be implemented in **feature branches** created from **develop**. When the feature is ready, a pull-request is created and it'll be merge into **develop** when it is succesfully reviewed and accepted.
+New features should be implemented in **feature branches** created from **develop**. When the feature is ready, a pull-request is created and it'll be merge into **develop** when it is successfully reviewed and accepted.
 
 To release a new version of the application, when develop is considered stable, a **release** branch is created from **develop**. This can be considered as a *release candidate* branch. When everything is OK, this release branch is merged into **master** and the release is generated (a tag is applied to git, the release note is finalized, binaries are built,...) from **master**.
 

--- a/doc/buildAndProgram.md
+++ b/doc/buildAndProgram.md
@@ -47,7 +47,7 @@ By default, this variable is set to *Release*. It compiles the code with size an
 The *Debug* mode disables all optimizations, which makes the code easier to debug. However, the binary size will likely be too big to fit in the internal flash memory. If you want to build and debug a *Debug* binary, you'll need to disable some parts of the code. For example, the icons for the **Navigation** app use a lot of memory space. You can comment the content of `m_iconMap` in the [Navigation](https://github.com/InfiniTimeOrg/InfiniTime/blob/develop/src/displayapp/screens/Navigation.h#L148) application to free some memory.
 
 ####(**) Note about **BUILD_DFU**:
-DFU files are the files you'll need to install your build of InfiniTime using OTA (over-the-air) mecanism. To generate the DFU file, the Python tool [adafruit-nrfutil](https://github.com/adafruit/Adafruit_nRF52_nrfutil) is needed on your system. Check that this tool is properly installed before enabling this option.
+DFU files are the files you'll need to install your build of InfiniTime using OTA (over-the-air) mechanism. To generate the DFU file, the Python tool [adafruit-nrfutil](https://github.com/adafruit/Adafruit_nRF52_nrfutil) is needed on your system. Check that this tool is properly installed before enabling this option.
 
 #### CMake command line for JLink
 ```

--- a/nrf52.svd
+++ b/nrf52.svd
@@ -13659,12 +13659,12 @@ POSSIBILITY OF SUCH DAMAGE.\n
                 <usage>read</usage>
                 <enumeratedValue>
                   <name>NotPresent</name>
-                  <description>Read: no overrun occured</description>
+                  <description>Read: no overrun occurred</description>
                   <value>0</value>
                 </enumeratedValue>
                 <enumeratedValue>
                   <name>Present</name>
-                  <description>Read: overrun occured</description>
+                  <description>Read: overrun occurred</description>
                   <value>1</value>
                 </enumeratedValue>
               </enumeratedValues>

--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -244,7 +244,7 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
         NRF_LOG_INFO("[DFU] -> Receive firmware image requested, but we are not in Start Init");
         return 0;
       }
-      // TODO the chunk size is dependant of the implementation of the host application...
+      // TODO the chunk size is dependent of the implementation of the host application...
       dfuImage.Init(20, applicationSize, expectedCrc);
       NRF_LOG_INFO("[DFU] -> Starting receive firmware");
       state = States::Data;

--- a/src/components/ble/FSService.cpp
+++ b/src/components/ble/FSService.cpp
@@ -81,7 +81,7 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
         return -1;
       }
       memcpy(filepath, header->pathstr, plen);
-      filepath[plen] = 0; // Copy and null teminate string
+      filepath[plen] = 0; // Copy and null terminate string
       ReadResponse resp;
       os_mbuf* om;
       resp.command = commands::READ_DATA;
@@ -148,7 +148,7 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
         return -1;             // TODO make this actually return a BLE notif
       }
       memcpy(filepath, header->pathstr, plen);
-      filepath[plen] = 0; // Copy and null teminate string
+      filepath[plen] = 0; // Copy and null terminate string
       fileSize = header->totalSize;
       WriteResponse resp;
       resp.command = commands::WRITE_PACING;
@@ -193,7 +193,7 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
       uint16_t plen = header->pathlen;
       char path[plen + 1] = {0};
       memcpy(path, header->pathstr, plen);
-      path[plen] = 0; // Copy and null teminate string
+      path[plen] = 0; // Copy and null terminate string
       DelResponse resp {};
       resp.command = commands::DELETE_STATUS;
       int res = fs.FileDelete(path);
@@ -208,7 +208,7 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
       uint16_t plen = header->pathlen;
       char path[plen + 1] = {0};
       memcpy(path, header->pathstr, plen);
-      path[plen] = 0; // Copy and null teminate string
+      path[plen] = 0; // Copy and null terminate string
       MKDirResponse resp {};
       resp.command = commands::MKDIR_STATUS;
       resp.modification_time = 0;
@@ -223,7 +223,7 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
       ListDirHeader* header = (ListDirHeader*) om->om_data;
       uint16_t plen = header->pathlen;
       char path[plen + 1] = {0};
-      path[plen] = 0; // Copy and null teminate string
+      path[plen] = 0; // Copy and null terminate string
       memcpy(path, header->pathstr, plen);
 
       ListDirResponse resp {};
@@ -290,7 +290,7 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
       header->pathstr[plen] = 0;
       char path[header->NewPathLength + 1] = {0};
       memcpy(path, &header->pathstr[plen + 1], header->NewPathLength);
-      path[header->NewPathLength] = 0; // Copy and null teminate string
+      path[header->NewPathLength] = 0; // Copy and null terminate string
       MoveResponse resp {};
       resp.command = commands::MOVE_STATUS;
       int8_t res = (int8_t) fs.Rename(header->pathstr, path);

--- a/src/displayapp/LittleVgl.cpp
+++ b/src/displayapp/LittleVgl.cpp
@@ -94,8 +94,8 @@ void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
   uint16_t y1, y2, width, height = 0;
 
   ulTaskNotifyTake(pdTRUE, 200);
-  // NOtification is still needed (even if there is a mutex on SPI) because of the DataCommand pin
-  // which cannot be set/clear during a transfert.
+  // Notification is still needed (even if there is a mutex on SPI) because of the DataCommand pin
+  // which cannot be set/clear during a transfer.
 
   if ((scrollDirection == LittleVgl::FullRefreshDirections::Down) && (area->y2 == visibleNbLines - 1)) {
     writeOffset = ((writeOffset + totalNbLines) - visibleNbLines) % totalNbLines;

--- a/src/displayapp/fonts/generate.py
+++ b/src/displayapp/fonts/generate.py
@@ -43,7 +43,7 @@ def main():
     if not os.path.exists(args.config):
         sys.exit(f'Error: the config file {args.config} does not exist.')
     if not os.access(args.config, os.R_OK):
-        sys.exit(f'Error: the config file {args.config} is not accessable (permissions?).')
+        sys.exit(f'Error: the config file {args.config} is not accessible (permissions?).')
     with open(args.config, 'r') as fd:
         data = json.load(fd)
 

--- a/src/displayapp/screens/Screen.h
+++ b/src/displayapp/screens/Screen.h
@@ -35,7 +35,7 @@ namespace Pinetime {
 
       private:
         T value {};            // NSDMI - default initialise type
-        bool isUpdated {true}; // NSDMI - use brace initilisation
+        bool isUpdated {true}; // NSDMI - use brace initialisation
       };
 
       class Screen {

--- a/src/drivers/Bma421_C/bma4.c
+++ b/src/drivers/Bma421_C/bma4.c
@@ -621,7 +621,7 @@ static int8_t get_average_of_sensor_data(uint8_t accel_en,
  *
  * @param[in] accel_en : Variable to store status of accel
  * @param[in] accel_g_axis : Accel axis to FOC
- * @param[in] avg_foc_data : Average value of sensor sample datas
+ * @param[in] avg_foc_data : Average value of sensor sample data
  * @param[in] dev : Structure instance of bma4_dev.
  *
  * @return Result of API execution status
@@ -637,7 +637,7 @@ static int8_t validate_foc_position(uint8_t accel_en,
 /*!
  * @brief This internal API validates accel FOC axis given as input
  *
- * @param[in] avg_foc_data : Average value of sensor sample datas
+ * @param[in] avg_foc_data : Average value of sensor sample data
  * @param[in] dev : Structure instance of bma4_dev.
  *
  * @return Result of API execution status

--- a/src/drivers/Bma421_C/bma4_defs.h
+++ b/src/drivers/Bma421_C/bma4_defs.h
@@ -259,7 +259,7 @@
 #define BMA4_ACCEL_RANGE_8G                       UINT8_C(2)
 #define BMA4_ACCEL_RANGE_16G                      UINT8_C(3)
 
-/**\name  CONDITION CHECK FOR READING AND WRTING DATA*/
+/**\name  CONDITION CHECK FOR READING AND WRITING DATA*/
 #define BMA4_MAX_VALUE_FIFO_FILTER                UINT8_C(1)
 #define BMA4_MAX_VALUE_SPI3                       UINT8_C(1)
 #define BMA4_MAX_VALUE_SELFTEST_AMP               UINT8_C(1)

--- a/src/sdk_config.h
+++ b/src/sdk_config.h
@@ -1224,7 +1224,7 @@
 
 // <q> PM_SERVICE_CHANGED_ENABLED  - Enable/disable the service changed management for GATT server in Peer Manager.
 
-// <i> If not using a GATT server, or using a server wihout a service changed characteristic,
+// <i> If not using a GATT server, or using a server without a service changed characteristic,
 // <i> disable this to save code space.
 
 #ifndef PM_SERVICE_CHANGED_ENABLED
@@ -7667,7 +7667,7 @@
 #endif
 // <e> USE_COMP - Use the comparator to implement the capacitive sensor driver.
 
-// <i> Due to Anomaly 84, COMP I_SOURCE is not functional. It has too high a varation.
+// <i> Due to Anomaly 84, COMP I_SOURCE is not functional. It has too high a variation.
 //==========================================================
 #ifndef USE_COMP
   #define USE_COMP 0
@@ -8200,7 +8200,7 @@
   #define NRF_LOG_DEFAULT_LEVEL 3
 #endif
 
-// <q> NRF_LOG_DEFERRED  - Enable deffered logger.
+// <q> NRF_LOG_DEFERRED  - Enable deferred logger.
 
 // <i> Log data is buffered and can be processed in idle.
 
@@ -11620,7 +11620,7 @@
   #define NRF_SDH_ANT_OBSERVER_PRIO_LEVELS 2
 #endif
 
-// <h> ANT Observers priorities - Invididual priorities
+// <h> ANT Observers priorities - Individual priorities
 
 //==========================================================
 // <o> ANT_BPWR_ANT_OBSERVER_PRIO
@@ -11696,7 +11696,7 @@
 // <h> BLE Stack configuration - Stack configuration parameters
 
 // <i> The SoftDevice handler will configure the stack with these parameters when calling @ref nrf_sdh_ble_default_cfg_set.
-// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitely calling @ref
+// <i> Other libraries might depend on these values; keep them up-to-date even if you are not explicitly calling @ref
 // nrf_sdh_ble_default_cfg_set.
 //==========================================================
 // <o> NRF_SDH_BLE_GAP_DATA_LENGTH   <27-251>
@@ -11766,7 +11766,7 @@
   #define NRF_SDH_BLE_OBSERVER_PRIO_LEVELS 4
 #endif
 
-// <h> BLE Observers priorities - Invididual priorities
+// <h> BLE Observers priorities - Individual priorities
 
 //==========================================================
 // <o> BLE_ADV_BLE_OBSERVER_PRIO
@@ -12302,7 +12302,7 @@
   #define NRF_SDH_STACK_OBSERVER_PRIO_LEVELS 2
 #endif
 
-// <h> State Observers priorities - Invididual priorities
+// <h> State Observers priorities - Individual priorities
 
 //==========================================================
 // <o> CLOCK_CONFIG_STATE_OBSERVER_PRIO
@@ -12329,7 +12329,7 @@
 // </h>
 //==========================================================
 
-// <h> Stack Event Observers priorities - Invididual priorities
+// <h> Stack Event Observers priorities - Individual priorities
 
 //==========================================================
 // <o> NRF_SDH_ANT_STACK_OBSERVER_PRIO
@@ -12383,7 +12383,7 @@
   #define NRF_SDH_SOC_OBSERVER_PRIO_LEVELS 2
 #endif
 
-// <h> SoC Observers priorities - Invididual priorities
+// <h> SoC Observers priorities - Individual priorities
 
 //==========================================================
 // <o> BLE_ADV_SOC_OBSERVER_PRIO

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -456,7 +456,7 @@ void SystemTask::Work() {
     if (isBleDiscoveryTimerRunning) {
       if (bleDiscoveryTimer == 0) {
         isBleDiscoveryTimerRunning = false;
-        // Services discovery is deffered from 3 seconds to avoid the conflicts between the host communicating with the
+        // Services discovery is deferred from 3 seconds to avoid the conflicts between the host communicating with the
         // target and vice-versa. I'm not sure if this is the right way to handle this...
         nimbleController.StartDiscovery();
       } else {

--- a/tools/rle_encode.py
+++ b/tools/rle_encode.py
@@ -101,7 +101,7 @@ class ReverseCLUT:
             rd = r - (candidate >> 16)
             gd = g - ((candidate >> 8) & 0xff)
             bd = b - (candidate & 0xff)
-            # This is the Euclidian distance (squared)
+            # This is the Euclidean distance (squared)
             distance = rd * rd + gd * gd + bd * bd
             if distance < best:
                 best = distance


### PR DESCRIPTION
Found via `codespell -q 3 -S ./src/libs -L ans,doubleclick,trough`
