### PR TITLE
Move basic apps to the top of the app list

### DIFF
--- a/src/displayapp/screens/ApplicationList.cpp
+++ b/src/displayapp/screens/ApplicationList.cpp
@@ -41,11 +41,11 @@ bool ApplicationList::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
 std::unique_ptr<Screen> ApplicationList::CreateScreen1() {
   std::array<Screens::Tile::Applications, 6> applications {{
     {Symbols::stopWatch, Apps::StopWatch},
-    {Symbols::music, Apps::Music},
-    {Symbols::map, Apps::Navigation},
+    {Symbols::clock, Apps::Alarm},
+    {Symbols::hourGlass, Apps::Timer},
     {Symbols::shoe, Apps::Steps},
     {Symbols::heartBeat, Apps::HeartRate},
-    {Symbols::hourGlass, Apps::Timer},
+    {Symbols::music, Apps::Music},
   }};
 
   return std::make_unique<Screens::Tile>(0, 2, app, settingsController, batteryController, dateTimeController, applications);
@@ -58,7 +58,7 @@ std::unique_ptr<Screen> ApplicationList::CreateScreen2() {
     {"2", Apps::Twos},
     {Symbols::chartLine, Apps::Motion},
     {Symbols::drum, Apps::Metronome},
-    {Symbols::clock, Apps::Alarm},
+    {Symbols::map, Apps::Navigation},
   }};
 
   return std::make_unique<Screens::Tile>(1, 2, app, settingsController, batteryController, dateTimeController, applications);


### PR DESCRIPTION
Moved timer and alarm next to the stopwatch on the first row. Music was moved to where timer was and navigation was moved to where alarm was.

![InfiniSim_2022-06-05_060759](https://user-images.githubusercontent.com/37774658/172037803-f26211b7-cb66-40aa-a726-a3dcf6bc7e9b.png)
![InfiniSim_2022-06-05_060800](https://user-images.githubusercontent.com/37774658/172037805-27d54f9e-3b79-46b5-8d54-1e844f859471.png)

Closes #696