### PR TITLE
Minor changes to clang-format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,6 +7,7 @@ on:
       - '**.cpp'
       - '**.h'
       - '!src/libs/**'
+      - '!src/FreeRTOS/**'
 
 jobs:
   test-format:
@@ -18,8 +19,6 @@ jobs:
 
       - name: Configure git
         run: |
-          git config --global user.email "-"
-          git config --global user.name "Autoformatter"
           git fetch origin "$GITHUB_BASE_REF":"$GITHUB_BASE_REF" --depth=1000
 
       - name: Install clang-format

--- a/tests/test-format.sh
+++ b/tests/test-format.sh
@@ -16,18 +16,17 @@ for file in $CHANGED_FILES
 do
   [ -e "$file" ] || continue
   case "$file" in
-  src/libs/*) continue ;;
+  src/libs/*|src/FreeRTOS/*) continue ;;
   *.cpp|*.h)
     echo Checking "$file"
-    clang-format -i "$file"
-    if ! git diff --quiet
+    PATCH="$(basename "$file").patch"
+    git clang-format-12 -q --style file --diff "$GITHUB_BASE_REF" "$file" > "$PATCH"
+    if [ -s "$PATCH" ]
     then
       printf "\033[31mError:\033[0m Formatting error in %s\n" "$file"
       CHANGED=1
-      git add "$file"
-      git commit -q -m "Apply clang-format to $(basename "$file")"
-      printf "Creating patch "
-      git format-patch HEAD~
+    else
+      rm "$PATCH"
     fi
   esac
 done


### PR DESCRIPTION
Excludes `src/FreeRTOS` as well, and only formats lines that have been changed. Supersedes #1176. Testing is in FintasticMan#3 and FintasticMan#4 again.