### PR TITLE
Remove backup brightness feature

### DIFF
--- a/src/components/brightness/BrightnessController.cpp
+++ b/src/components/brightness/BrightnessController.cpp
@@ -74,14 +74,6 @@ BrightnessController::Levels BrightnessController::Level() const {
   return level;
 }
 
-void BrightnessController::Backup() {
-  backupLevel = level;
-}
-
-void BrightnessController::Restore() {
-  Set(backupLevel);
-}
-
 void BrightnessController::Step() {
   switch (level) {
     case Levels::Low:

--- a/src/components/brightness/BrightnessController.h
+++ b/src/components/brightness/BrightnessController.h
@@ -15,15 +15,11 @@ namespace Pinetime {
       void Higher();
       void Step();
 
-      void Backup();
-      void Restore();
-
       const char* GetIcon();
       const char* ToString();
 
     private:
       Levels level = Levels::High;
-      Levels backupLevel = Levels::High;
     };
   }
 }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -129,7 +129,7 @@ void DisplayApp::InitHw() {
 }
 
 void DisplayApp::Refresh() {
-  auto Return = [this]() {
+  auto LoadPreviousScreen = [this]() {
     brightnessController.Set(settingsController.GetBrightness());
     LoadApp(returnToApp, returnDirection);
   };
@@ -141,7 +141,7 @@ void DisplayApp::Refresh() {
       break;
     case States::Running:
       if (!currentScreen->IsRunning()) {
-        Return();
+        LoadPreviousScreen();
       }
       queueTimeout = lv_task_handler();
       break;
@@ -227,7 +227,7 @@ void DisplayApp::Refresh() {
                 break;
             }
           } else if (returnTouchEvent == gesture) {
-            Return();
+            LoadPreviousScreen();
           }
         } else {
           touchHandler.CancelTap();
@@ -238,7 +238,7 @@ void DisplayApp::Refresh() {
           if (currentApp == Apps::Clock) {
             PushMessageToSystemTask(System::Messages::GoToSleep);
           } else {
-            Return();
+            LoadPreviousScreen();
           }
         }
         break;

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -129,6 +129,11 @@ void DisplayApp::InitHw() {
 }
 
 void DisplayApp::Refresh() {
+  auto Return = [this]() {
+    brightnessController.Set(settingsController.GetBrightness());
+    LoadApp(returnToApp, returnDirection);
+  };
+
   TickType_t queueTimeout;
   switch (state) {
     case States::Idle:
@@ -136,7 +141,7 @@ void DisplayApp::Refresh() {
       break;
     case States::Running:
       if (!currentScreen->IsRunning()) {
-        LoadApp(returnToApp, returnDirection);
+        Return();
       }
       queueTimeout = lv_task_handler();
       break;
@@ -149,12 +154,10 @@ void DisplayApp::Refresh() {
   if (xQueueReceive(msgQueue, &msg, queueTimeout)) {
     switch (msg) {
       case Messages::DimScreen:
-        // Backup brightness is the brightness to return to after dimming or sleeping
-        brightnessController.Backup();
         brightnessController.Set(Controllers::BrightnessController::Levels::Low);
         break;
       case Messages::RestoreBrightness:
-        brightnessController.Restore();
+        brightnessController.Set(settingsController.GetBrightness());
         break;
       case Messages::GoToSleep:
         while (brightnessController.Level() != Controllers::BrightnessController::Levels::Off) {
@@ -165,7 +168,7 @@ void DisplayApp::Refresh() {
         state = States::Idle;
         break;
       case Messages::GoToRunning:
-        brightnessController.Restore();
+        brightnessController.Set(settingsController.GetBrightness());
         state = States::Running;
         break;
       case Messages::UpdateTimeOut:
@@ -224,9 +227,7 @@ void DisplayApp::Refresh() {
                 break;
             }
           } else if (returnTouchEvent == gesture) {
-            LoadApp(returnToApp, returnDirection);
-            brightnessController.Set(settingsController.GetBrightness());
-            brightnessController.Backup();
+            Return();
           }
         } else {
           touchHandler.CancelTap();
@@ -237,9 +238,7 @@ void DisplayApp::Refresh() {
           if (currentApp == Apps::Clock) {
             PushMessageToSystemTask(System::Messages::GoToSleep);
           } else {
-            LoadApp(returnToApp, returnDirection);
-            brightnessController.Set(settingsController.GetBrightness());
-            brightnessController.Backup();
+            Return();
           }
         }
         break;

--- a/src/displayapp/screens/FlashLight.cpp
+++ b/src/displayapp/screens/FlashLight.cpp
@@ -14,12 +14,7 @@ namespace {
 FlashLight::FlashLight(Pinetime::Applications::DisplayApp* app,
                        System::SystemTask& systemTask,
                        Controllers::BrightnessController& brightnessController)
-  : Screen(app),
-    systemTask {systemTask},
-    brightnessController {brightnessController}
-
-{
-  brightnessController.Backup();
+  : Screen(app), systemTask {systemTask}, brightnessController {brightnessController} {
 
   brightnessLevel = brightnessController.Level();
 
@@ -56,7 +51,6 @@ FlashLight::FlashLight(Pinetime::Applications::DisplayApp* app,
 FlashLight::~FlashLight() {
   lv_obj_clean(lv_scr_act());
   lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-  brightnessController.Restore();
   systemTask.PushMessage(Pinetime::System::Messages::EnableSleeping);
 }
 


### PR DESCRIPTION
This feature is not needed and is probably more likely to cause issues. It's better to just use `brightnessController.Set(settingsController.GetBrightness());`