### PR TITLE
Fix InfiniTime compiler warnings

### DIFF
--- a/src/BootloaderVersion.cpp
+++ b/src/BootloaderVersion.cpp
@@ -9,15 +9,15 @@ using namespace Pinetime;
 uint32_t BootloaderVersion::version = 0;
 char BootloaderVersion::versionString[BootloaderVersion::VERSION_STR_LEN] = "0.0.0";
 
-const uint32_t BootloaderVersion::Major() {
+uint32_t BootloaderVersion::Major() {
   return (BootloaderVersion::version >> 16u) & 0xff;
 }
 
-const uint32_t BootloaderVersion::Minor() {
+uint32_t BootloaderVersion::Minor() {
   return (BootloaderVersion::version >> 8u) & 0xff;
 }
 
-const uint32_t BootloaderVersion::Patch() {
+uint32_t BootloaderVersion::Patch() {
   return BootloaderVersion::version & 0xff;
 }
 
@@ -25,7 +25,7 @@ const char* BootloaderVersion::VersionString() {
   return BootloaderVersion::versionString;
 }
 
-const bool BootloaderVersion::IsValid() {
+bool BootloaderVersion::IsValid() {
   return BootloaderVersion::version >= 0x00010000;
 }
 

--- a/src/BootloaderVersion.h
+++ b/src/BootloaderVersion.h
@@ -6,11 +6,11 @@
 namespace Pinetime {
   class BootloaderVersion {
   public:
-    static const uint32_t Major();
-    static const uint32_t Minor();
-    static const uint32_t Patch();
+    static uint32_t Major();
+    static uint32_t Minor();
+    static uint32_t Patch();
     static const char* VersionString();
-    static const bool IsValid();
+    static bool IsValid();
     static void SetVersion(uint32_t v);
 
   private:

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -42,13 +42,6 @@ namespace {
     auto* screen = static_cast<WatchFacePineTimeStyle*>(obj->user_data);
     screen->UpdateSelected(obj, event);
   }
-
-  bool IsBleIconVisible(bool isRadioEnabled, bool isConnected) {
-    if (!isRadioEnabled) {
-      return true;
-    }
-    return isConnected;
-  }
 }
 
 WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,


### PR DESCRIPTION
`const` return type doesn't make sense.
~~Weather wasn't handled in LoadApp switch. Added default.~~
Removed unused function.

This doesn't fix warnings generated by nimble and QCBOR