### PR TITLE
Create GH Actions workflow to build Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          username: infinitime
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up QEMU
@@ -37,6 +37,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           builder: ${{ steps.buildx.outputs.name }}
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/infinitime-build:latest
-          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/infinitime-build:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/infinitime-build:buildcache,mode=max
+          tags: infinitime/infinitime-build:latest
+          cache-from: type=registry,ref=infinitime/infinitime-build:buildcache
+          cache-to: type=registry,ref=infinitime/infinitime-build:buildcache,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,42 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches: [ master, develop ]
+    paths:
+      - 'docker/**'
+  pull_request:
+    branches: [ master, develop ]
+    paths:
+      - 'docker/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./docker/
+          file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          builder: ${{ steps.buildx.outputs.name }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/infinitime-build:latest
+          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/infinitime-build:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/infinitime-build:buildcache,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,13 +32,25 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v3
         with:
           context: ./docker/
           file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           builder: ${{ steps.buildx.outputs.name }}
-          push: ${{ github.event_name == 'push' }}
+          push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:latest
           cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:buildcache,mode=max
+
+      - name: Build
+        if: github.event_name != 'push'
+        uses: docker/build-push-action@v3
+        with:
+          context: ./docker/
+          file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          builder: ${{ steps.buildx.outputs.name }}
+          push: false
+          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:buildcache

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,11 +2,11 @@ name: Build and push Docker image
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ develop ]
     paths:
       - 'docker/**'
   pull_request:
-    branches: [ master, develop ]
+    branches: [ develop ]
     paths:
       - 'docker/**'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: docker/login-action@v2
         with:
           username: infinitime
@@ -36,7 +36,7 @@ jobs:
           file: ./docker/Dockerfile
           platforms: linux/amd64,linux/arm64
           builder: ${{ steps.buildx.outputs.name }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' }}
           tags: infinitime/infinitime-build:latest
           cache-from: type=registry,ref=infinitime/infinitime-build:buildcache
           cache-to: type=registry,ref=infinitime/infinitime-build:buildcache,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,10 +25,21 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Set up Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build
+          tags: |
+            type=sha
+            type=raw,value=latest
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push
@@ -40,7 +51,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:buildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:buildcache,mode=max
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      USERNAME: infinitime
     steps:
       - uses: actions/checkout@v3
 
@@ -20,7 +22,7 @@ jobs:
         if: github.event_name == 'push'
         uses: docker/login-action@v2
         with:
-          username: infinitime
+          username: ${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up QEMU
@@ -37,6 +39,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           builder: ${{ steps.buildx.outputs.name }}
           push: ${{ github.event_name == 'push' }}
-          tags: infinitime/infinitime-build:latest
-          cache-from: type=registry,ref=infinitime/infinitime-build:buildcache
-          cache-to: type=registry,ref=infinitime/infinitime-build:buildcache,mode=max
+          tags: ${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:latest
+          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:buildcache,mode=max


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that builds the Docker image and pushes it to Docker Hub whenever anything in the `docker/` directory is changed. I've tested it [here](https://github.com/FintasticMan/InfiniTime/actions/runs/2505633550), and the images have been pushed [here](https://hub.docker.com/r/fintasticman/infinitime/tags).

Any pull requests should just build the image, but not upload it to Docker Hub. It should also be possible to publish to different tags than just latest by using docker/metadata-action, I just haven't gotten around to that yet.

Before merging, the secret `DOCKER_HUB_ACCESS_TOKEN` will be needed to be added to this repository.