### PR TITLE
Add find phone feature

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -448,6 +448,7 @@ list(APPEND SOURCE_FILES
         components/brightness/BrightnessController.cpp
         components/motion/MotionController.cpp
         components/ble/NimbleController.cpp
+        components/ble/InfinitimeService.cpp
         components/ble/DeviceInformationService.cpp
         components/ble/CurrentTimeClient.cpp
         components/ble/AlertNotificationClient.cpp
@@ -517,6 +518,7 @@ list(APPEND RECOVERY_SOURCE_FILES
         components/ble/NimbleController.cpp
         components/ble/DeviceInformationService.cpp
         components/ble/CurrentTimeClient.cpp
+        components/ble/InfinitimeService.cpp
         components/ble/AlertNotificationClient.cpp
         components/ble/DfuService.cpp
         components/ble/CurrentTimeService.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -448,13 +448,13 @@ list(APPEND SOURCE_FILES
         components/brightness/BrightnessController.cpp
         components/motion/MotionController.cpp
         components/ble/NimbleController.cpp
-        components/ble/InfinitimeService.cpp
         components/ble/DeviceInformationService.cpp
         components/ble/CurrentTimeClient.cpp
         components/ble/AlertNotificationClient.cpp
         components/ble/DfuService.cpp
         components/ble/CurrentTimeService.cpp
         components/ble/AlertNotificationService.cpp
+        components/ble/InfinitimeService.cpp
         components/ble/MusicService.cpp
         components/ble/weather/WeatherService.cpp
         components/ble/NavigationService.cpp
@@ -518,11 +518,11 @@ list(APPEND RECOVERY_SOURCE_FILES
         components/ble/NimbleController.cpp
         components/ble/DeviceInformationService.cpp
         components/ble/CurrentTimeClient.cpp
-        components/ble/InfinitimeService.cpp
         components/ble/AlertNotificationClient.cpp
         components/ble/DfuService.cpp
         components/ble/CurrentTimeService.cpp
         components/ble/AlertNotificationService.cpp
+        components/ble/InfinitimeService.cpp
         components/ble/MusicService.cpp
         components/ble/weather/WeatherService.cpp
         components/ble/BatteryInformationService.cpp
@@ -643,6 +643,7 @@ set(INCLUDE_FILES
         components/ble/ImmediateAlertService.h
         components/ble/ServiceDiscovery.h
         components/ble/BleClient.h
+        components/ble/InfinitimeService.h
         components/ble/HeartRateService.h
         components/ble/MotionService.h
         components/ble/weather/WeatherService.h

--- a/src/components/ble/InfinitimeService.cpp
+++ b/src/components/ble/InfinitimeService.cpp
@@ -1,0 +1,100 @@
+/*  Copyright (C) 2020-2022 JF, Adam Pigg, Avamander, devnoname120
+
+    This file is part of InfiniTime.
+
+    InfiniTime is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    InfiniTime is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#include "components/ble/InfinitimeService.h"
+#include "systemtask/SystemTask.h"
+#include <cstring>
+
+namespace {
+  // 0001yyxx-b5e2-40c4-b1d5-2c5c48529c84
+  constexpr ble_uuid128_t CharUuid(uint8_t x, uint8_t y) {
+    return ble_uuid128_t {.u = {.type = BLE_UUID_TYPE_128},
+                          .value = {0x84, 0x9c, 0x52, 0x48, 0x5c, 0x2c, 0xd5, 0xb1, 0xc4, 0x40, 0xe2, 0xb5, x, y, 0x01, 0x00}};
+  }
+
+  // 00010000-b5e2-40c4-b1d5-2c5c48529c84
+  constexpr ble_uuid128_t BaseUuid() {
+    return CharUuid(0x00, 0x00);
+  }
+
+  constexpr ble_uuid128_t infUuid {BaseUuid()};
+  constexpr ble_uuid128_t infFindPhoneCharUuid {CharUuid(0x01, 0x00)};
+
+  constexpr size_t MaxNotifSize {1024};
+
+  int InfinitimeCallback(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
+    return static_cast<Pinetime::Controllers::InfinitimeService*>(arg)->OnCommand(conn_handle, attr_handle, ctxt);
+  }
+}
+
+Pinetime::Controllers::InfinitimeService::InfinitimeService(Pinetime::System::SystemTask& system) : m_system(system) {
+  characteristicDefinition[0] = {.uuid = &infFindPhoneCharUuid.u,
+                                 .access_cb = InfinitimeCallback,
+                                 .arg = this,
+                                 .flags = BLE_GATT_CHR_F_NOTIFY | BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_READ,
+                                 .val_handle = &phoneFindingHandle};
+  characteristicDefinition[1] = {0};
+
+  serviceDefinition[0] = {.type = BLE_GATT_SVC_TYPE_PRIMARY, .uuid = &infUuid.u, .characteristics = characteristicDefinition};
+  serviceDefinition[1] = {0};
+}
+
+void Pinetime::Controllers::InfinitimeService::Init() {
+  uint8_t res = 0;
+  res = ble_gatts_count_cfg(serviceDefinition);
+  ASSERT(res == 0);
+
+  res = ble_gatts_add_svcs(serviceDefinition);
+  ASSERT(res == 0);
+}
+
+int Pinetime::Controllers::InfinitimeService::OnCommand(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
+  if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
+    size_t notifSize = OS_MBUF_PKTLEN(ctxt->om);
+    size_t bufferSize = notifSize;
+    bool isNotifTruncated = false;
+
+    if (notifSize > MaxNotifSize) {
+      bufferSize = MaxNotifSize;
+      isNotifTruncated = true;
+    }
+
+    char data[bufferSize + 1];
+    os_mbuf_copydata(ctxt->om, 0, bufferSize, data);
+
+    if (ble_uuid_cmp(ctxt->chr->uuid, &infFindPhoneCharUuid.u) == 0) {
+      m_isPhoneFinding = static_cast<bool>(data[0]);
+    }
+  }
+  return 0;
+}
+
+bool Pinetime::Controllers::InfinitimeService::isPhoneFinding() const {
+  return m_isPhoneFinding;
+}
+
+void Pinetime::Controllers::InfinitimeService::event(char event) {
+  auto* om = ble_hs_mbuf_from_flat(&event, 1);
+
+  uint16_t connectionHandle = m_system.nimble().connHandle();
+
+  if (connectionHandle == 0 || connectionHandle == BLE_HS_CONN_HANDLE_NONE) {
+    return;
+  }
+
+  ble_gattc_notify_custom(connectionHandle, phoneFindingHandle, om);
+}

--- a/src/components/ble/InfinitimeService.h
+++ b/src/components/ble/InfinitimeService.h
@@ -1,0 +1,61 @@
+/*  Copyright (C) 2020-2022 JF, Adam Pigg, Avamander, devnoname120
+
+    This file is part of InfiniTime.
+
+    InfiniTime is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    InfiniTime is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include <cstdint>
+#include <string>
+#define min // workaround: nimble's min/max macros conflict with libstdc++
+#define max
+#include <host/ble_gap.h>
+#include <host/ble_uuid.h>
+#undef max
+#undef min
+
+namespace Pinetime {
+  namespace System {
+    class SystemTask;
+  }
+  namespace Controllers {
+    class InfinitimeService {
+    public:
+      explicit InfinitimeService(Pinetime::System::SystemTask& system);
+
+      void Init();
+
+      int OnCommand(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt);
+
+      void event(char event);
+
+      bool isPhoneFinding() const;
+
+      static const char EVENT_PHONE_FIND_START = 0x00;
+      static const char EVENT_PHONE_FIND_STOP = 0x01;
+
+      enum FindPhone { FindPhoneRunning = 0x00, FindPhoneStopped = 0x01 };
+
+    private:
+      struct ble_gatt_chr_def characteristicDefinition[2];
+      struct ble_gatt_svc_def serviceDefinition[2];
+
+      uint16_t phoneFindingHandle {};
+      bool m_isPhoneFinding {false};
+
+      Pinetime::System::SystemTask& m_system;
+    };
+  }
+}

--- a/src/components/ble/InfinitimeService.h
+++ b/src/components/ble/InfinitimeService.h
@@ -43,8 +43,8 @@ namespace Pinetime {
 
       bool isPhoneFinding() const;
 
-      static const char EVENT_PHONE_FIND_START = 0x00;
-      static const char EVENT_PHONE_FIND_STOP = 0x01;
+      static const char EVENT_PHONE_FIND_STOP = 0x00;
+      static const char EVENT_PHONE_FIND_START = 0x01;
 
       enum FindPhone { FindPhoneRunning = 0x00, FindPhoneStopped = 0x01 };
 

--- a/src/components/ble/InfinitimeService.h
+++ b/src/components/ble/InfinitimeService.h
@@ -46,7 +46,7 @@ namespace Pinetime {
       static const char EVENT_PHONE_FIND_STOP = 0x00;
       static const char EVENT_PHONE_FIND_START = 0x01;
 
-      enum FindPhone { FindPhoneRunning = 0x00, FindPhoneStopped = 0x01 };
+      enum FindPhone { FindPhoneStopped = 0x00, FindPhoneRunning = 0x01 };
 
     private:
       struct ble_gatt_chr_def characteristicDefinition[2];

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -40,6 +40,7 @@ NimbleController::NimbleController(Pinetime::System::SystemTask& systemTask,
     dfuService {systemTask, bleController, spiNorFlash},
 
     currentTimeClient {dateTimeController},
+    infinitimeService {systemTask},
     anService {systemTask, notificationManager},
     alertNotificationClient {systemTask, notificationManager},
     currentTimeService {dateTimeController},
@@ -90,6 +91,7 @@ void NimbleController::Init() {
   deviceInformationService.Init();
   currentTimeClient.Init();
   currentTimeService.Init();
+  infinitimeService.Init();
   musicService.Init();
   weatherService.Init();
   navService.Init();

--- a/src/components/ble/NimbleController.h
+++ b/src/components/ble/NimbleController.h
@@ -7,6 +7,7 @@
 #include <host/ble_gap.h>
 #undef max
 #undef min
+#include "components/ble/InfinitimeService.h"
 #include "components/ble/AlertNotificationClient.h"
 #include "components/ble/AlertNotificationService.h"
 #include "components/ble/BatteryInformationService.h"
@@ -55,6 +56,10 @@ namespace Pinetime {
       int OnGAPEvent(ble_gap_event* event);
       void StartDiscovery();
 
+      Pinetime::Controllers::InfinitimeService& infinitime() {
+        return infinitimeService;
+      };
+
       Pinetime::Controllers::MusicService& music() {
         return musicService;
       };
@@ -92,6 +97,7 @@ namespace Pinetime {
 
       DeviceInformationService deviceInformationService;
       CurrentTimeClient currentTimeClient;
+      InfinitimeService infinitimeService;
       AlertNotificationService anService;
       AlertNotificationClient alertNotificationClient;
       CurrentTimeService currentTimeService;

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -90,6 +90,7 @@ DisplayApp::DisplayApp(Drivers::St7789& lcd,
     motionController {motionController},
     timerController {timerController},
     alarmController {alarmController},
+    //    infinitimeService {infinitimeService},
     brightnessController {brightnessController},
     touchHandler {touchHandler} {
 }
@@ -439,7 +440,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::FlashLight:
-      currentScreen = std::make_unique<Screens::FlashLight>(this, *systemTask, brightnessController);
+      currentScreen = std::make_unique<Screens::FlashLight>(this, *systemTask, brightnessController, systemTask->nimble().infinitime());
       ReturnApp(Apps::QuickSettings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::StopWatch:

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -8,6 +8,7 @@
 #include "displayapp/Apps.h"
 #include "displayapp/LittleVgl.h"
 #include "displayapp/TouchEvents.h"
+#include "components/ble/infinitimeService.h"
 #include "components/brightness/BrightnessController.h"
 #include "components/motor/MotorController.h"
 #include "components/firmwarevalidator/FirmwareValidator.h"

--- a/src/displayapp/screens/FlashLight.cpp
+++ b/src/displayapp/screens/FlashLight.cpp
@@ -93,13 +93,13 @@ void FlashLight::SetIndicators() {
 }
 
 void FlashLight::Toggle() {
+  isOn = !isOn;
+
   if (isOn) {
     infinitimeService.event(Controllers::InfinitimeService::EVENT_PHONE_FIND_START);
   } else {
     infinitimeService.event(Controllers::InfinitimeService::EVENT_PHONE_FIND_STOP);
   }
-
-  isOn = !isOn;
 
   SetColors();
 }

--- a/src/displayapp/screens/FlashLight.cpp
+++ b/src/displayapp/screens/FlashLight.cpp
@@ -13,10 +13,11 @@ namespace {
   }
 }
 
-FlashLight::FlashLight(Pinetime::Applications::DisplayApp* app,
+FlashLight::FlashLight(DisplayApp* app,
                        System::SystemTask& systemTask,
-                       Controllers::BrightnessController& brightnessController)
-  : Screen(app), systemTask {systemTask}, brightnessController {brightnessController} {
+                       Controllers::BrightnessController& brightness,
+                       Pinetime::Controllers::InfinitimeService& infinitime)
+  : Screen(app), systemTask {systemTask}, brightnessController {brightnessController}, infinitimeService {infinitime} {
 
   brightnessController.Set(brightnessLevel);
 
@@ -92,7 +93,14 @@ void FlashLight::SetIndicators() {
 }
 
 void FlashLight::Toggle() {
+  if (isOn) {
+    infinitimeService.event(Controllers::InfinitimeService::EVENT_PHONE_FIND_START);
+  } else {
+    infinitimeService.event(Controllers::InfinitimeService::EVENT_PHONE_FIND_STOP);
+  }
+
   isOn = !isOn;
+
   SetColors();
 }
 

--- a/src/displayapp/screens/FlashLight.h
+++ b/src/displayapp/screens/FlashLight.h
@@ -7,13 +7,19 @@
 #include <lvgl/lvgl.h>
 
 namespace Pinetime {
+  namespace Controllers {
+    class InfinitimeService;
+  }
 
   namespace Applications {
     namespace Screens {
 
       class FlashLight : public Screen {
       public:
-        FlashLight(DisplayApp* app, System::SystemTask& systemTask, Controllers::BrightnessController& brightness);
+        FlashLight(DisplayApp* app,
+                   System::SystemTask& systemTask,
+                   Controllers::BrightnessController& brightness,
+                   Pinetime::Controllers::InfinitimeService& infinitime);
         ~FlashLight() override;
 
         bool OnTouchEvent(Pinetime::Applications::TouchEvents event) override;
@@ -25,6 +31,7 @@ namespace Pinetime {
 
         Pinetime::System::SystemTask& systemTask;
         Controllers::BrightnessController& brightnessController;
+        Pinetime::Controllers::InfinitimeService& infinitimeService;
 
         Controllers::BrightnessController::Levels brightnessLevel = Controllers::BrightnessController::Levels::High;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,7 @@
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
 #include "components/ble/NotificationManager.h"
+#include "components/ble/InfinitimeService.h"
 #include "components/brightness/BrightnessController.h"
 #include "components/motor/MotorController.h"
 #include "components/datetime/DateTimeController.h"
@@ -114,6 +115,7 @@ Pinetime::Controllers::TimerController timerController;
 Pinetime::Controllers::AlarmController alarmController {dateTimeController};
 Pinetime::Controllers::TouchHandler touchHandler(touchPanel, lvgl);
 Pinetime::Controllers::ButtonHandler buttonHandler;
+//Pinetime::Controllers::InfinitimeService infinitimeService;
 Pinetime::Controllers::BrightnessController brightnessController {};
 
 Pinetime::Applications::DisplayApp displayApp(lcd,
@@ -130,6 +132,7 @@ Pinetime::Applications::DisplayApp displayApp(lcd,
                                               motionController,
                                               timerController,
                                               alarmController,
+//                                              infinitimeService,
                                               brightnessController,
                                               touchHandler);
 


### PR DESCRIPTION
Close https://github.com/InfiniTimeOrg/InfiniTime/issues/343.

- Add new `infinitime` service to make it much easier and noob-friendly to add new features both on GadgetBridge's side and InfiniTime's side. This is the approach used by many devices in GadgetBridge (e.g. [WASP-OS](https://codeberg.org/Freeyourgadget/Gadgetbridge/src/commit/0349b2530fd29c02ad4d7fa85c4144b8cf7c1457/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/waspos/WaspOSDeviceSupport.java#L145-L195), [Bangle.js](https://codeberg.org/Freeyourgadget/Gadgetbridge/src/commit/0349b2530fd29c02ad4d7fa85c4144b8cf7c1457/app/src/main/java/nodomain/freeyourgadget/gadgetbridge/service/devices/banglejs/BangleJSDeviceSupport.java#L414-L605), etc etc.)
- Change flashlight app button to trigger the find phone feature.
- Forked GadgetBridge to add support for this new feature. See [Freeyourgadget/Gadgetbridge#2737](https://codeberg.org/Freeyourgadget/Gadgetbridge/pulls/2737)

https://user-images.githubusercontent.com/2824100/175046440-97b1e8ad-67b9-4cf7-a338-0f54e1b6c2d0.mp4

**TODO**:
- Make the brightness/dnd/etc quick toggles vertically scrollable and add a toggle for finding the phone.
- Rely on `Pinetime::Controllers::InfinitimeService::isPhoneFinding()` to show the find phone toggle status in InfiniTime.
- Implement `Immediate Alert Service 1.0 revision V10r00` and remove the added service
  - Investigate possible blockers/pitfalls for implementing
  - Set-up an implementation plan (get UIDs, failure modes, etc.)
  - Implement in GadgetBridge
  - Implement in InfiniTime
  - Test feature on my dev PineTime
- Document this feature (README + wiki + in-code doc) 