### PR TITLE
Font generation: Fix patch binary path

### DIFF
--- a/src/displayapp/fonts/generate.py
+++ b/src/displayapp/fonts/generate.py
@@ -67,7 +67,7 @@ def main():
         subprocess.check_call(line)
         if patches:
             for patch in patches:
-                subprocess.check_call(['/usr/bin/patch', name+'.c', patch])
+                subprocess.check_call(['/usr/bin/env', 'patch', name+'.c', patch])
 
 
 


### PR DESCRIPTION
In some Linux distributions, binaries are not necessarily stored in `/usr/bin/` (e.g. NixOS).

This PR changes the call to `patch` in `displayapp/fonts/generate.py` to use the `env` tool in order to determine the location of the `patch` tool.