### PR TITLE
Add InfiniTime Vision document

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Fast open-source firmware for the [PineTime smartwatch](https://www.pine64.org/p
 
 ## Development
 
+ - [InfiniTime Vision](doc/InfiniTimeVision.md)
  - [Rough structure of the code](doc/code/Intro.md)
  - [How to implement an application](doc/code/Apps.md)
  - [Generate the fonts and symbols](src/displayapp/fonts/README.md)

--- a/doc/InfiniTimeVision.md
+++ b/doc/InfiniTimeVision.md
@@ -25,7 +25,7 @@ InfiniTime is not to be used for medical or other health tracking purposes.
 
 The perfect version of InfiniTime would include:
 
-- Capability to upload apps and watchfaces from a phone
+- Capability to sideload apps and watchfaces
 - Only a minimal feature set in the flashed firmware.
   Users would add the features they want.
 - Ports to other devices

--- a/doc/InfiniTimeVision.md
+++ b/doc/InfiniTimeVision.md
@@ -4,7 +4,7 @@ The purpose of this document is to steer efforts towards a common goal, and as s
 
 ## InfiniTime
 
-InfiniTime is a community built smartwatch firmware, providing freedom and privacy that's usually insufficient in wearable technology.
+InfiniTime is a community-built smartwatch firmware, providing freedom and privacy that's usually insufficient in wearable technology.
 
 InfiniTime is not to be used for medical or other health tracking purposes.
 
@@ -17,7 +17,7 @@ InfiniTime is not to be used for medical or other health tracking purposes.
 - Behaviour should be predictable and easy to understand
 - Prefer solid default experience over customization
 - Personalization is achieved through custom watchfaces.
-More options may be available through a companion app.
+  More options may be available through a companion app.
 - Use standard protocols and methods
 
 ## Long term vision
@@ -25,8 +25,8 @@ More options may be available through a companion app.
 The perfect version of InfiniTime would include:
 
 - Capability to upload apps and watchfaces from a phone
-- Only minimal features.
-Users would add the features they want.
+- Only a minimal feature set in the flashed firmware.
+  Users would add the features they want.
 - Ports to other devices
 - Translations
-- Great documentation
+- Great user documentation

--- a/doc/InfiniTimeVision.md
+++ b/doc/InfiniTimeVision.md
@@ -4,13 +4,14 @@ The purpose of this document is to steer efforts towards a common goal, and as s
 
 ## InfiniTime
 
-InfiniTime is a community-built smartwatch firmware, providing freedom and privacy that's usually insufficient in wearable technology.
+InfiniTime is a community-built smartwatch firmware.
+It offers freedom and privacy advantages unavailable to users of proprietary wearable technology.
 
 InfiniTime is not to be used for medical or other health tracking purposes.
 
 ## Core Principles
 
-- KISS (Keep It Short and Simple)
+- Keep It Simple
 - Reliability
 - Battery efficiency
 - Easy and simple navigation

--- a/doc/InfiniTimeVision.md
+++ b/doc/InfiniTimeVision.md
@@ -1,0 +1,28 @@
+The purpose of this document is to steer efforts towards a common goal, and as such should be taken into consideration with all developments.
+
+# InfiniTime
+
+InfiniTime is a community built smartwatch firmware, providing freedom and privacy that's usually insufficient in wearable technology.
+
+InfiniTime is not to be used for medical or other health tracking purposes.
+
+# Core Principles
+
+- KISS
+- Reliability
+- Battery efficiency
+- Easy and simple navigation
+- Behaviour should be predictable and easy to understand
+- Prefer solid default experience over customization
+- Personalization is achieved through custom watchfaces. More options may be available through a companion app.
+- Use standard protocols and methods
+
+# Long term vision
+
+The perfect version of InfiniTime would include:
+
+- Capability to upload apps and watchfaces from a phone
+- Only minimal features. Users would add the features they want.
+- Ports to other devices
+- Translations
+- Great documentation

--- a/doc/InfiniTimeVision.md
+++ b/doc/InfiniTimeVision.md
@@ -1,28 +1,32 @@
+# InfiniTime Vision
+
 The purpose of this document is to steer efforts towards a common goal, and as such should be taken into consideration with all developments.
 
-# InfiniTime
+## InfiniTime
 
 InfiniTime is a community built smartwatch firmware, providing freedom and privacy that's usually insufficient in wearable technology.
 
 InfiniTime is not to be used for medical or other health tracking purposes.
 
-# Core Principles
+## Core Principles
 
-- KISS
+- KISS (Keep It Short and Simple)
 - Reliability
 - Battery efficiency
 - Easy and simple navigation
 - Behaviour should be predictable and easy to understand
 - Prefer solid default experience over customization
-- Personalization is achieved through custom watchfaces. More options may be available through a companion app.
+- Personalization is achieved through custom watchfaces.
+More options may be available through a companion app.
 - Use standard protocols and methods
 
-# Long term vision
+## Long term vision
 
 The perfect version of InfiniTime would include:
 
 - Capability to upload apps and watchfaces from a phone
-- Only minimal features. Users would add the features they want.
+- Only minimal features.
+Users would add the features they want.
 - Ports to other devices
 - Translations
 - Great documentation


### PR DESCRIPTION
Add the initial InfiniTIme Vision document that has been written in collaboration with the core developers. This document will help steer efforts towards a common goal by having the goals of the project written down and visible to everyone.

Since the last draft I added some context to the top of the document and using standard protocols as a core principle.