### PR TITLE
P8: Mirror display for P8b variant

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -804,6 +804,7 @@ elseif(TARGET_DEVICE STREQUAL "MOY-UNK") # P8b mirrored
   add_definitions(-DCLOCK_CONFIG_LF_SRC=0) # RC
   add_definitions(-DMYNEWT_VAL_BLE_LL_SCA=500)
   add_definitions(-DCLOCK_CONFIG_LF_CAL_ENABLED=1)
+  add_definitions(-DDRIVER_DISPLAY_MIRROR)
 else()
   message(FATAL_ERROR "Invalid TARGET_DEVICE")
 endif()

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -21,7 +21,10 @@ void St7789::Init() {
   MemoryDataAccessControl();
   ColumnAddressSet();
   RowAddressSet();
+// P8B Mirrored version does not need display inversion.
+#ifndef DRIVER_DISPLAY_MIRROR
   DisplayInversionOn();
+#endif
   NormalModeOn();
   SetVdv();
   DisplayOn();
@@ -62,7 +65,18 @@ void St7789::ColMod() {
 
 void St7789::MemoryDataAccessControl() {
   WriteCommand(static_cast<uint8_t>(Commands::MemoryDataAccessControl));
+#ifdef DRIVER_DISPLAY_MIRROR
+  // [7] = MY = Page Address Order, 0 = Top to bottom, 1 = Bottom to top
+  // [6] = MX = Column Address Order, 0 = Left to right, 1 = Right to left
+  // [5] = MV = Page/Column Order, 0 = Normal mode, 1 = Reverse mode
+  // [4] = ML = Line Address Order, 0 = LCD refresh from top to bottom, 1 = Bottom to top
+  // [3] = RGB = RGB/BGR Order, 0 = RGB, 1 = BGR
+  // [2] = MH = Display Data Latch Order, 0 = LCD refresh from left to right, 1 = Right to left
+  // [0 .. 1] = Unused
+  WriteData(0b01000000);
+#else
   WriteData(0x00);
+#endif
 }
 
 void St7789::ColumnAddressSet() {


### PR DESCRIPTION
This PR has been broken out of https://github.com/InfiniTimeOrg/InfiniTime/pull/1050, and depends on / includes https://github.com/InfiniTimeOrg/InfiniTime/pull/1128 .

A new P8b hardware variant requires the display to be mirrored, and the colors to be inverted. Patch provided by @izzeho .

Related: https://github.com/StarGate01/p8b-infinitime/issues/3