### PR TITLE
SystemInfo: Display target build variant

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -785,6 +785,7 @@ add_definitions(-D__HEAP_SIZE=4096)
 
 # Target hardware configuration options
 add_definitions(-DTARGET_DEVICE_${TARGET_DEVICE})
+add_definitions(-DTARGET_DEVICE_NAME="${TARGET_DEVICE}")
 if(TARGET_DEVICE STREQUAL "PINETIME")
   add_definitions(-DDRIVER_PINMAP_PINETIME)
   add_definitions(-DCLOCK_CONFIG_LF_SRC=1) # XTAL

--- a/src/displayapp/screens/SystemInfo.cpp
+++ b/src/displayapp/screens/SystemInfo.cpp
@@ -136,6 +136,10 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen2() {
   uptimeSeconds = uptimeSeconds % secondsInAMinute;
   // TODO handle more than 100 days of uptime
 
+#ifndef TARGET_DEVICE_NAME
+  #define TARGET_DEVICE_NAME "UNKNOWN"
+#endif
+
   lv_obj_t* label = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_recolor(label, true);
   lv_label_set_text_fmt(label,
@@ -146,7 +150,8 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen2() {
                         "#808080 Backlight# %s\n"
                         "#808080 Last reset# %s\n"
                         "#808080 Accel.# %s\n"
-                        "#808080 Touch.# %x.%x.%x\n",
+                        "#808080 Touch.# %x.%x.%x\n"
+                        "#808080 Model# %s",
                         dateTimeController.Day(),
                         static_cast<uint8_t>(dateTimeController.Month()),
                         dateTimeController.Year(),
@@ -164,7 +169,8 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen2() {
                         ToString(motionController.DeviceType()),
                         touchPanel.GetChipId(),
                         touchPanel.GetVendorId(),
-                        touchPanel.GetFwVersion());
+                        touchPanel.GetFwVersion(),
+                        TARGET_DEVICE_NAME);
   lv_obj_align(label, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
   return std::make_unique<Screens::Label>(1, 5, app, label);
 }


### PR DESCRIPTION
This PR has been broken out of https://github.com/InfiniTimeOrg/InfiniTime/pull/1050, and depends on / includes https://github.com/InfiniTimeOrg/InfiniTime/pull/1128 .

This PR uses the last line on the second screen in the system information to display the target build variant, i.e. which device the firmware was compiled for. This is very useful to know which updates to download, once you have forgotten which variant your device is.

![signal-2022-06-27-083124](https://user-images.githubusercontent.com/6362238/175875343-245edbf2-2b09-498e-a8e4-7438ad5a1e6b.jpeg)


