### PR TITLE
feature: add battery percentage display

### DIFF
--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -209,10 +209,18 @@ namespace Pinetime {
         return bleRadioEnabled;
       };
 
+      void SetShowBatteryPercentage(bool enabled) {
+        settings.showBatteryPercentage = enabled;
+      }
+
+      bool GetShowBatteryPercentage() {
+        return settings.showBatteryPercentage;
+      }
+
     private:
       Pinetime::Controllers::FS& fs;
 
-      static constexpr uint32_t settingsVersion = 0x0003;
+      static constexpr uint32_t settingsVersion = 0x0004;
       struct SettingsData {
         uint32_t version = settingsVersion;
         uint32_t stepsGoal = 10000;
@@ -229,6 +237,7 @@ namespace Pinetime {
         std::bitset<4> wakeUpMode {0};
         uint16_t shakeWakeThreshold = 150;
         Controllers::BrightnessController::Levels brightLevel = Controllers::BrightnessController::Levels::Medium;
+        bool showBatteryPercentage = false;
       };
 
       SettingsData settings;

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -424,7 +424,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::BatteryInfo:
-      currentScreen = std::make_unique<Screens::BatteryInfo>(this, batteryController);
+      currentScreen = std::make_unique<Screens::BatteryInfo>(this, batteryController, settingsController);
       ReturnApp(Apps::Settings, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
     case Apps::SysInfo:

--- a/src/displayapp/screens/BatteryIcon.cpp
+++ b/src/displayapp/screens/BatteryIcon.cpp
@@ -6,7 +6,15 @@
 using namespace Pinetime::Applications::Screens;
 
 void BatteryIcon::Create(lv_obj_t* parent) {
-  batteryImg = lv_img_create(parent, nullptr);
+
+  batteryContainer = lv_cont_create(parent, nullptr);
+  lv_cont_set_layout(batteryContainer, LV_LAYOUT_ROW_MID);
+  lv_cont_set_fit(batteryContainer, LV_FIT_TIGHT);
+  lv_obj_set_style_local_bg_color(batteryContainer, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_pad_inner(batteryContainer, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
+  lv_obj_set_style_local_pad_hor(batteryContainer, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
+
+  batteryImg = lv_img_create(batteryContainer, nullptr);
   lv_img_set_src(batteryImg, &batteryicon);
   lv_obj_set_style_local_image_recolor(batteryImg, LV_IMG_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
 
@@ -14,15 +22,26 @@ void BatteryIcon::Create(lv_obj_t* parent) {
   lv_obj_set_width(batteryJuice, 8);
   lv_obj_align(batteryJuice, nullptr, LV_ALIGN_IN_BOTTOM_RIGHT, -2, -2);
   lv_obj_set_style_local_radius(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, 0);
+
+  batteryPercentageText = lv_label_create(batteryContainer, nullptr);
+  lv_label_set_text(batteryPercentageText, "");
+  lv_obj_align(batteryPercentageText, batteryContainer, LV_ALIGN_IN_RIGHT_MID, 0, 0);
 }
 
 lv_obj_t* BatteryIcon::GetObject() {
-  return batteryImg;
+  return batteryContainer;
 }
 
-void BatteryIcon::SetBatteryPercentage(uint8_t percentage) {
+void BatteryIcon::SetBatteryPercentage(uint8_t percentage, bool show_percentage) {
   lv_obj_set_height(batteryJuice, percentage * 14 / 100);
   lv_obj_realign(batteryJuice);
+  if (show_percentage) {
+    lv_label_set_text_fmt(batteryPercentageText, "%02i%%", percentage);
+  } else {
+    lv_label_set_text(batteryPercentageText, "");
+  }
+  lv_obj_realign(batteryPercentageText);
+  lv_obj_realign(batteryContainer);
 }
 
 void BatteryIcon::SetColor(lv_color_t color) {
@@ -32,8 +51,8 @@ void BatteryIcon::SetColor(lv_color_t color) {
 }
 
 const char* BatteryIcon::GetPlugIcon(bool isCharging) {
-  if (isCharging)
+  if (isCharging) {
     return Symbols::plug;
-  else
-    return "";
+  }
+  return "";
 }

--- a/src/displayapp/screens/BatteryIcon.h
+++ b/src/displayapp/screens/BatteryIcon.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <lvgl/src/lv_core/lv_obj.h>
+#include "components/settings/Settings.h"
 
 namespace Pinetime {
   namespace Applications {
@@ -10,15 +11,17 @@ namespace Pinetime {
         void Create(lv_obj_t* parent);
 
         void SetColor(lv_color_t);
-        void SetBatteryPercentage(uint8_t percentage);
+        void SetBatteryPercentage(uint8_t percentage, bool show_percentage);
         lv_obj_t* GetObject();
 
         static const char* GetUnknownIcon();
         static const char* GetPlugIcon(bool isCharging);
 
       private:
+        lv_obj_t* batteryContainer;
         lv_obj_t* batteryImg;
         lv_obj_t* batteryJuice;
+        lv_obj_t* batteryPercentageText;
       };
     }
   }

--- a/src/displayapp/screens/BatteryInfo.cpp
+++ b/src/displayapp/screens/BatteryInfo.cpp
@@ -4,8 +4,19 @@
 
 using namespace Pinetime::Applications::Screens;
 
-BatteryInfo::BatteryInfo(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Battery& batteryController)
-  : Screen(app), batteryController {batteryController} {
+namespace {
+  void event_handler(lv_obj_t* obj, lv_event_t event) {
+    if (event == LV_EVENT_VALUE_CHANGED) {
+      auto* battery = static_cast<BatteryInfo*>(obj->user_data);
+      battery->ToggleBatteryPercentState();
+    }
+  }
+}
+
+BatteryInfo::BatteryInfo(Pinetime::Applications::DisplayApp* app,
+                         Pinetime::Controllers::Battery& batteryController,
+                         Pinetime::Controllers::Settings& settingsController)
+  : Screen(app), batteryController {batteryController}, settingsController {settingsController} {
 
   batteryPercent = batteryController.PercentRemaining();
   batteryVoltage = batteryController.Voltage();
@@ -13,7 +24,7 @@ BatteryInfo::BatteryInfo(Pinetime::Applications::DisplayApp* app, Pinetime::Cont
   charging_bar = lv_bar_create(lv_scr_act(), nullptr);
   lv_obj_set_size(charging_bar, 200, 15);
   lv_bar_set_range(charging_bar, 0, 100);
-  lv_obj_align(charging_bar, nullptr, LV_ALIGN_CENTER, 0, 10);
+  lv_obj_align(charging_bar, nullptr, LV_ALIGN_CENTER, 0, -30);
   lv_bar_set_anim_time(charging_bar, 1000);
   lv_obj_set_style_local_radius(charging_bar, LV_BAR_PART_BG, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
   lv_obj_set_style_local_bg_color(charging_bar, LV_BAR_PART_BG, LV_STATE_DEFAULT, lv_color_hex(0x222222));
@@ -27,22 +38,31 @@ BatteryInfo::BatteryInfo(Pinetime::Applications::DisplayApp* app, Pinetime::Cont
   lv_obj_align(status, charging_bar, LV_ALIGN_OUT_BOTTOM_MID, 0, 20);
 
   percent = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(percent, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
+  lv_obj_set_style_local_text_font(percent, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
   lv_label_set_text_fmt(percent, "%02i%%", batteryPercent);
   lv_label_set_align(percent, LV_LABEL_ALIGN_LEFT);
-  lv_obj_align(percent, nullptr, LV_ALIGN_CENTER, 0, -60);
+  lv_obj_align(percent, nullptr, LV_ALIGN_CENTER, 0, -70);
 
   voltage = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(voltage, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0xff, 0xb0, 0x0));
   lv_label_set_text_fmt(voltage, "%1i.%02i volts", batteryVoltage / 1000, batteryVoltage % 1000 / 10);
   lv_label_set_align(voltage, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(voltage, nullptr, LV_ALIGN_CENTER, 0, 95);
+  lv_obj_align(voltage, nullptr, LV_ALIGN_CENTER, 0, 55);
+
+  show_percentage_checkbox = lv_checkbox_create(lv_scr_act(), nullptr);
+  lv_checkbox_set_text(show_percentage_checkbox, "Show %");
+  lv_obj_align(show_percentage_checkbox, nullptr, LV_ALIGN_IN_BOTTOM_MID, 0, -5);
+  lv_obj_add_state(show_percentage_checkbox, LV_STATE_DEFAULT);
+  lv_checkbox_set_checked(show_percentage_checkbox, settingsController.GetShowBatteryPercentage());
+  show_percentage_checkbox->user_data = this;
+  lv_obj_set_event_cb(show_percentage_checkbox, event_handler);
 
   taskRefresh = lv_task_create(RefreshTaskCallback, 5000, LV_TASK_PRIO_MID, this);
   Refresh();
 }
 
 BatteryInfo::~BatteryInfo() {
+  settingsController.SaveSettings();
   lv_task_del(taskRefresh);
   lv_obj_clean(lv_scr_act());
 }
@@ -71,4 +91,9 @@ void BatteryInfo::Refresh() {
   lv_obj_align(status, charging_bar, LV_ALIGN_OUT_BOTTOM_MID, 0, 20);
   lv_label_set_text_fmt(voltage, "%1i.%02i volts", batteryVoltage / 1000, batteryVoltage % 1000 / 10);
   lv_bar_set_value(charging_bar, batteryPercent, LV_ANIM_ON);
+}
+
+void BatteryInfo::ToggleBatteryPercentState() {
+  settingsController.SetShowBatteryPercentage(!settingsController.GetShowBatteryPercentage());
+  lv_checkbox_set_checked(show_percentage_checkbox, settingsController.GetShowBatteryPercentage());
 }

--- a/src/displayapp/screens/BatteryInfo.h
+++ b/src/displayapp/screens/BatteryInfo.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include "displayapp/screens/Screen.h"
+#include "components/settings/Settings.h"
 #include <lvgl/lvgl.h>
 
 namespace Pinetime {
@@ -14,14 +15,19 @@ namespace Pinetime {
 
       class BatteryInfo : public Screen {
       public:
-        BatteryInfo(DisplayApp* app, Pinetime::Controllers::Battery& batteryController);
+        BatteryInfo(DisplayApp* app,
+                    Pinetime::Controllers::Battery& batteryController,
+                    Pinetime::Controllers::Settings& settingsController);
         ~BatteryInfo() override;
 
         void Refresh() override;
+        void ToggleBatteryPercentState();
 
       private:
         Pinetime::Controllers::Battery& batteryController;
+        Pinetime::Controllers::Settings& settingsController;
 
+        lv_obj_t* show_percentage_checkbox;
         lv_obj_t* voltage;
         lv_obj_t* percent;
         lv_obj_t* charging_bar;

--- a/src/displayapp/screens/Tile.cpp
+++ b/src/displayapp/screens/Tile.cpp
@@ -29,7 +29,11 @@ Tile::Tile(uint8_t screenID,
            Pinetime::Controllers::Battery& batteryController,
            Controllers::DateTime& dateTimeController,
            std::array<Applications, 6>& applications)
-  : Screen(app), batteryController {batteryController}, dateTimeController {dateTimeController}, pageIndicator(screenID, numScreens) {
+  : Screen(app),
+    batteryController {batteryController},
+    settingsController(settingsController),
+    dateTimeController {dateTimeController},
+    pageIndicator(screenID, numScreens) {
 
   settingsController.SetAppMenu(screenID);
 
@@ -93,7 +97,7 @@ Tile::~Tile() {
 
 void Tile::UpdateScreen() {
   lv_label_set_text(label_time, dateTimeController.FormattedTime().c_str());
-  batteryIcon.SetBatteryPercentage(batteryController.PercentRemaining());
+  batteryIcon.SetBatteryPercentage(batteryController.PercentRemaining(), settingsController.GetShowBatteryPercentage());
 }
 
 void Tile::OnValueChangedEvent(lv_obj_t* obj, uint32_t buttonId) {

--- a/src/displayapp/screens/Tile.h
+++ b/src/displayapp/screens/Tile.h
@@ -37,6 +37,7 @@ namespace Pinetime {
 
       private:
         Pinetime::Controllers::Battery& batteryController;
+        Pinetime::Controllers::Settings& settingsController;
         Controllers::DateTime& dateTimeController;
 
         lv_task_t* taskUpdate;

--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -182,7 +182,7 @@ void WatchFaceAnalog::UpdateClock() {
 
 void WatchFaceAnalog::SetBatteryIcon() {
   auto batteryPercent = batteryPercentRemaining.Get();
-  batteryIcon.SetBatteryPercentage(batteryPercent);
+  batteryIcon.SetBatteryPercentage(batteryPercent, settingsController.GetShowBatteryPercentage());
 }
 
 void WatchFaceAnalog::Refresh() {

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -102,7 +102,7 @@ void WatchFaceDigital::Refresh() {
   batteryPercentRemaining = batteryController.PercentRemaining();
   if (batteryPercentRemaining.IsUpdated()) {
     auto batteryPercent = batteryPercentRemaining.Get();
-    batteryIcon.SetBatteryPercentage(batteryPercent);
+    batteryIcon.SetBatteryPercentage(batteryPercent, settingsController.GetShowBatteryPercentage());
   }
 
   bleState = bleController.IsConnected();

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -329,7 +329,7 @@ bool WatchFacePineTimeStyle::OnButtonPushed() {
 
 void WatchFacePineTimeStyle::SetBatteryIcon() {
   auto batteryPercent = batteryPercentRemaining.Get();
-  batteryIcon.SetBatteryPercentage(batteryPercent);
+  batteryIcon.SetBatteryPercentage(batteryPercent, settingsController.GetShowBatteryPercentage());
 }
 
 void WatchFacePineTimeStyle::AlignIcons() {

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -118,7 +118,7 @@ QuickSettings::~QuickSettings() {
 
 void QuickSettings::UpdateScreen() {
   lv_label_set_text(label_time, dateTimeController.FormattedTime().c_str());
-  batteryIcon.SetBatteryPercentage(batteryController.PercentRemaining());
+  batteryIcon.SetBatteryPercentage(batteryController.PercentRemaining(), settingsController.GetShowBatteryPercentage());
 }
 
 void QuickSettings::OnButtonEvent(lv_obj_t* object, lv_event_t event) {


### PR DESCRIPTION
This commit adds the option to display
battery percentage in the top of the
screen, next to the battery icon.

The toggle for this option is in the
battery info screen.

![Option](https://i.ibb.co/YQYNjzS/Infini-Sim-2022-06-28-093631.png)

![Active](https://i.ibb.co/bdY4Rr0/Infini-Sim-2022-06-28-093832.png)

**Please be aware that I only have a sealed watch. It works fine on the simulator, but please test this on real hardware**