### PR TITLE
Limit backlight brightness when flashlight is off

### DIFF
--- a/src/displayapp/screens/FlashLight.cpp
+++ b/src/displayapp/screens/FlashLight.cpp
@@ -18,17 +18,17 @@ FlashLight::FlashLight(Pinetime::Applications::DisplayApp* app,
                        Controllers::BrightnessController& brightnessController)
   : Screen(app), systemTask {systemTask}, brightnessController {brightnessController} {
 
-  brightnessController.Set(brightnessLevel);
+  brightnessController.Set(Controllers::BrightnessController::Levels::Low);
 
   flashLight = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_sys_48);
   lv_label_set_text_static(flashLight, Symbols::highlight);
   lv_obj_align(flashLight, nullptr, LV_ALIGN_CENTER, 0, 0);
 
-  for (auto& i : indicators) {
-    i = lv_obj_create(lv_scr_act(), nullptr);
-    lv_obj_set_size(i, 15, 10);
-    lv_obj_set_style_local_border_width(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, 2);
+  for (auto& indicator : indicators) {
+    indicator = lv_obj_create(lv_scr_act(), nullptr);
+    lv_obj_set_size(indicator, 15, 10);
+    lv_obj_set_style_local_border_width(indicator, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, 2);
   }
 
   lv_obj_align(indicators[1], flashLight, LV_ALIGN_OUT_BOTTOM_MID, 0, 5);
@@ -57,22 +57,15 @@ FlashLight::~FlashLight() {
 }
 
 void FlashLight::SetColors() {
-  if (isOn) {
-    lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-    lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0xb0, 0xb0, 0xb0));
-    for (auto& i : indicators) {
-      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0xb0, 0xb0, 0xb0));
-      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DISABLED, LV_COLOR_WHITE);
-      lv_obj_set_style_local_border_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0xb0, 0xb0, 0xb0));
-    }
-  } else {
-    lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-    lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-    for (auto& i : indicators) {
-      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-      lv_obj_set_style_local_bg_color(i, LV_OBJ_PART_MAIN, LV_STATE_DISABLED, LV_COLOR_BLACK);
-      lv_obj_set_style_local_border_color(i, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-    }
+  lv_color_t bgColor = isOn ? LV_COLOR_WHITE : LV_COLOR_BLACK;
+  lv_color_t fgColor = isOn ? LV_COLOR_MAKE(0xb0, 0xb0, 0xb0) : LV_COLOR_WHITE;
+
+  lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, bgColor);
+  lv_obj_set_style_local_text_color(flashLight, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, fgColor);
+  for (auto& indicator : indicators) {
+    lv_obj_set_style_local_bg_color(indicator, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, fgColor);
+    lv_obj_set_style_local_bg_color(indicator, LV_OBJ_PART_MAIN, LV_STATE_DISABLED, bgColor);
+    lv_obj_set_style_local_border_color(indicator, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, fgColor);
   }
 }
 
@@ -94,32 +87,40 @@ void FlashLight::SetIndicators() {
 void FlashLight::Toggle() {
   isOn = !isOn;
   SetColors();
+  if (isOn) {
+    brightnessController.Set(brightnessLevel);
+  } else {
+    brightnessController.Set(Controllers::BrightnessController::Levels::Low);
+  }
 }
 
 bool FlashLight::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
   using namespace Pinetime::Controllers;
 
+  auto SetState = [this]() {
+    if (isOn) {
+      brightnessController.Set(brightnessLevel);
+    }
+    SetIndicators();
+  };
+
   if (event == TouchEvents::SwipeLeft) {
     if (brightnessLevel == BrightnessController::Levels::High) {
       brightnessLevel = BrightnessController::Levels::Medium;
-      brightnessController.Set(brightnessLevel);
-      SetIndicators();
+      SetState();
     } else if (brightnessLevel == BrightnessController::Levels::Medium) {
       brightnessLevel = BrightnessController::Levels::Low;
-      brightnessController.Set(brightnessLevel);
-      SetIndicators();
+      SetState();
     }
     return true;
   }
   if (event == TouchEvents::SwipeRight) {
     if (brightnessLevel == BrightnessController::Levels::Low) {
       brightnessLevel = BrightnessController::Levels::Medium;
-      brightnessController.Set(brightnessLevel);
-      SetIndicators();
+      SetState();
     } else if (brightnessLevel == BrightnessController::Levels::Medium) {
       brightnessLevel = BrightnessController::Levels::High;
-      brightnessController.Set(brightnessLevel);
-      SetIndicators();
+      SetState();
     }
     return true;
   }


### PR DESCRIPTION
Backlight brightness is unlimited while the flashlight is on.
While it is off, the brightness is limited to the global backlight level.
Small code optimizations.

Fixes #1210