### PR TITLE
Always restore brightness on app switch

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -130,7 +130,6 @@ void DisplayApp::InitHw() {
 
 void DisplayApp::Refresh() {
   auto LoadPreviousScreen = [this]() {
-    brightnessController.Set(settingsController.GetBrightness());
     LoadApp(returnToApp, returnDirection);
   };
 
@@ -302,6 +301,8 @@ void DisplayApp::ReturnApp(Apps app, DisplayApp::FullRefreshDirections direction
 
 void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) {
   touchHandler.CancelTap();
+  brightnessController.Set(settingsController.GetBrightness());
+
   currentScreen.reset(nullptr);
   SetFullRefresh(direction);
 


### PR DESCRIPTION
Previously it was restored only when specifically returning to the previous app.

Fixes #1201