### PR TITLE
Bluetooth interface to control heart rate measurement

### DIFF
--- a/doc/ble.md
+++ b/doc/ble.md
@@ -91,6 +91,9 @@ The following custom services are implemented in InfiniTime:
 - Since InfiniTime 1.8:
     * [Weather Service](/src/components/ble/weather/WeatherService.h): 00040000-78fc-48fe-8e23-433b3a1942d0
 
+
+- Development:
+    * Running characteristic (extension to Heart Rate Service): 00050001-78fc-48fe-8e23-433b3a1942d0
 ---
 
 ## BLE services

--- a/src/components/ble/HeartRateService.h
+++ b/src/components/ble/HeartRateService.h
@@ -16,7 +16,7 @@ namespace Pinetime {
     public:
       HeartRateService(Pinetime::System::SystemTask& system, Controllers::HeartRateController& heartRateController);
       void Init();
-      int OnHeartRateRequested(uint16_t connectionHandle, uint16_t attributeHandle, ble_gatt_access_ctxt* context);
+      int OnAtributeRequested(uint16_t connectionHandle, uint16_t attributeHandle, ble_gatt_access_ctxt* context);
       void OnNewHeartRateValue(uint8_t hearRateValue);
 
       void SubscribeNotification(uint16_t connectionHandle, uint16_t attributeHandle);
@@ -31,11 +31,15 @@ namespace Pinetime {
       static constexpr ble_uuid16_t heartRateServiceUuid {.u {.type = BLE_UUID_TYPE_16}, .value = heartRateServiceId};
 
       static constexpr ble_uuid16_t heartRateMeasurementUuid {.u {.type = BLE_UUID_TYPE_16}, .value = heartRateMeasurementId};
+      static constexpr ble_uuid128_t runningCharUuid {
+        .u = {.type = BLE_UUID_TYPE_128},
+        .value = {0xd0, 0x42, 0x19, 0x3a, 0x3b, 0x43, 0x23, 0x8e, 0xfe, 0x48, 0xfc, 0x78, 0x01, 0x00, 0x05, 0x00}};
 
-      struct ble_gatt_chr_def characteristicDefinition[2];
+      struct ble_gatt_chr_def characteristicDefinition[3];
       struct ble_gatt_svc_def serviceDefinition[2];
 
       uint16_t heartRateMeasurementHandle;
+      uint16_t runningCharHandle;
       std::atomic_bool heartRateMeasurementNotificationEnable {false};
     };
   }


### PR DESCRIPTION
Adds a bluetooth characteristic (`00050001-78fc-48fe-8e23-433b3a1942d0`) to read the state of the heart rate sensor and turn it on/off. This will be useful for companion apps that want to take periodic heart rate measurements.
It might be worth requiring that the watch is paired before being able to use this, but I'm not experienced enough with Bluetooth to do that.

I'm not sure what `HeartRateController::States::NoTouch` represents, but I've assumed the sensor is not running at this point.