### PR TITLE
Docker workflow use separate username for login

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,8 +13,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      USERNAME: infinitime
     steps:
       - uses: actions/checkout@v3
 
@@ -22,7 +20,7 @@ jobs:
         if: github.event_name == 'push'
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}
+          username: ${{ secrets.DOCKER_HUB_LOGIN_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Set up Docker metadata
@@ -30,7 +28,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build
+            ${{ secrets.DOCKER_HUB_IMAGE_USERNAME }}/infinitime-build
           tags: |
             type=sha
             type=raw,value=latest
@@ -53,8 +51,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:buildcache,mode=max
+          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_IMAGE_USERNAME }}/infinitime-build:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_IMAGE_USERNAME }}/infinitime-build:buildcache,mode=max
 
       - name: Build
         if: github.event_name != 'push'
@@ -65,4 +63,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           builder: ${{ steps.buildx.outputs.name }}
           push: false
-          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME || env.USERNAME }}/infinitime-build:buildcache
+          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_IMAGE_USERNAME }}/infinitime-build:buildcache


### PR DESCRIPTION
@JF002 This pull request fixes the issue mentioned [here](https://github.com/InfiniTimeOrg/InfiniTime/pull/1184#issuecomment-1179127636) about that the username used for logging in to Docker Hub is different than the one that actually has the images. This works around it by having 2 secrets: `DOCKER_HUB_LOGIN_USERNAME`, which should be set to (in this case) `jf002`, and `DOCKER_HUB_IMAGE_USERNAME`, which should be set to `infinitime`.

I don't have an organisation on Docker Hub to test it out on, but I have tested it on my personal repository, with both secrets set to `fintasticman`, and it works fine.