### PR TITLE
changed the alarm timeout to a saner value of 3 minutes

### DIFF
--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -253,7 +253,7 @@ void Alarm::UpdateAlarmTime() {
 void Alarm::SetAlerting() {
   lv_obj_set_hidden(enableSwitch, true);
   lv_obj_set_hidden(btnStop, false);
-  taskStopAlarm = lv_task_create(StopAlarmTaskCallback, pdMS_TO_TICKS(60 * 1000), LV_TASK_PRIO_MID, this);
+  taskStopAlarm = lv_task_create(StopAlarmTaskCallback, pdMS_TO_TICKS(180 * 1000), LV_TASK_PRIO_MID, this);
   systemTask.PushMessage(System::Messages::DisableSleeping);
 }
 


### PR DESCRIPTION
In pull #945 the alarm functionality got expanded by a auto-dismiss after 60 seconds. As others pointed out, this makes the alarm hardly usable for hard sleepers. Also in **very** loud environments, for example on stage, 60 seconds could be to short to notice the alarm. 
