### PR TITLE
Simplified stopwatch lap buffer

### DIFF
--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -1,13 +1,11 @@
 #pragma once
 
 #include "displayapp/screens/Screen.h"
-#include "components/datetime/DateTimeController.h"
-#include "displayapp/LittleVgl.h"
+#include <lvgl/lvgl.h>
 
 #include <FreeRTOS.h>
 #include "portmacro_cmsis.h"
 
-#include <array>
 #include "systemtask/SystemTask.h"
 
 namespace Pinetime::Applications::Screens {
@@ -18,46 +16,6 @@ namespace Pinetime::Applications::Screens {
     int mins;
     int secs;
     int hundredths;
-  };
-
-  // A simple buffer to hold the latest two laps
-  template <int N> struct LapTextBuffer_t {
-    LapTextBuffer_t() : buffer {}, currentSize {}, capacity {N}, head {-1} {
-    }
-
-    void addLaps(const TimeSeparated_t& timeVal) {
-      head++;
-      head %= capacity;
-      buffer[head] = timeVal;
-
-      if (currentSize < capacity) {
-        currentSize++;
-      }
-    }
-
-    void clearBuffer() {
-      buffer = {};
-      currentSize = 0;
-      head = -1;
-    }
-
-    TimeSeparated_t* operator[](std::size_t idx) {
-      // Sanity check for out-of-bounds
-      if (idx >= 0 && idx < capacity) {
-        if (idx < currentSize) {
-          // This transformation is to ensure that head is always pointing to index 0.
-          const auto transformed_idx = (head - idx) % capacity;
-          return (&buffer[transformed_idx]);
-        }
-      }
-      return nullptr;
-    }
-
-  private:
-    std::array<TimeSeparated_t, N> buffer;
-    uint8_t currentSize;
-    uint8_t capacity;
-    int8_t head;
   };
 
   class StopWatch : public Screen {
@@ -76,15 +34,15 @@ namespace Pinetime::Applications::Screens {
 
   private:
     Pinetime::System::SystemTask& systemTask;
-    TickType_t timeElapsed;
-    States currentState;
+    States currentState = States::Init;
     TickType_t startTime;
-    TickType_t oldTimeElapsed;
-    TimeSeparated_t currentTimeSeparated; // Holds Mins, Secs, millisecs
-    LapTextBuffer_t<2> lapBuffer;
-    int lapNr = 0;
+    TickType_t oldTimeElapsed = 0;
+    static constexpr int maxLapCount = 20;
+    TickType_t laps[maxLapCount + 1];
+    static constexpr int displayedLaps = 2;
+    int lapsDone = 0;
     lv_obj_t *time, *msecTime, *btnPlayPause, *btnStopLap, *txtPlayPause, *txtStopLap;
-    lv_obj_t *lapOneText, *lapTwoText;
+    lv_obj_t* lapText;
 
     lv_task_t* taskRefresh;
   };


### PR DESCRIPTION
Overriding the earlier laps doesn't seem like a good idea when the intention is to make all of the saved laps accessible. Previous laps will be made accessible in another PR.

This is a part of #612 rewritten.