### PR TITLE
Dismiss notifications in preview screen with SwipeRight

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -226,6 +226,10 @@ void DisplayApp::Refresh() {
               default:
                 break;
             }
+          } else if (currentApp == Apps::NotificationsPreview && gesture == TouchEvents::SwipeRight) {
+            auto currentId = notificationManager.GetLastNotification().id;
+            notificationManager.Dismiss(currentId);
+            LoadPreviousScreen();
           } else if (returnTouchEvent == gesture) {
             LoadPreviousScreen();
           }


### PR DESCRIPTION
I often found myself trying to swipe away a new notification, but in the preview this wasn't possible. This small change allows to swipe away notifications from the preview.

I'm not sure if there's a more elegant way to do it, but I think this is the simplest.

Fixes #1232 