### PR TITLE
Use Counter widget in SetDate

### DIFF
--- a/src/displayapp/screens/settings/SettingSetDate.cpp
+++ b/src/displayapp/screens/settings/SettingSetDate.cpp
@@ -11,13 +11,36 @@ namespace {
   constexpr int16_t POS_X_DAY = -72;
   constexpr int16_t POS_X_MONTH = 0;
   constexpr int16_t POS_X_YEAR = 72;
-  constexpr int16_t POS_Y_PLUS = -50;
   constexpr int16_t POS_Y_TEXT = -6;
-  constexpr int16_t POS_Y_MINUS = 40;
 
   void event_handler(lv_obj_t* obj, lv_event_t event) {
     auto* screen = static_cast<SettingSetDate*>(obj->user_data);
-    screen->HandleButtonPress(obj, event);
+    if (event == LV_EVENT_CLICKED) {
+      screen->HandleButtonPress();
+    }
+  }
+
+  void ValueChangedHandler(void* userData) {
+    auto* screen = static_cast<SettingSetDate*>(userData);
+    screen->CheckDay();
+  }
+
+  int MaximumDayOfMonth(uint8_t month, uint16_t year) {
+    switch (month) {
+      case 2: {
+        if ((((year % 4) == 0) && ((year % 100) != 0)) || ((year % 400) == 0)) {
+          return 29;
+        }
+        return 28;
+      }
+      case 4:
+      case 6:
+      case 9:
+      case 11:
+        return 30;
+      default:
+        return 31;
+    }
   }
 }
 
@@ -35,164 +58,54 @@ SettingSetDate::SettingSetDate(Pinetime::Applications::DisplayApp* app, Pinetime
   lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
-  dayValue = static_cast<int>(dateTimeController.Day());
-  lblDay = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_fmt(lblDay, "%d", dayValue);
-  lv_label_set_align(lblDay, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(lblDay, lv_scr_act(), LV_ALIGN_CENTER, POS_X_DAY, POS_Y_TEXT);
-  lv_obj_set_auto_realign(lblDay, true);
+  dayCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
+  dayCounter.Create();
+  dayCounter.SetValue(dateTimeController.Day());
+  lv_obj_align(dayCounter.GetObject(), nullptr, LV_ALIGN_CENTER, POS_X_DAY, POS_Y_TEXT);
 
-  monthValue = static_cast<int>(dateTimeController.Month());
-  lblMonth = lv_label_create(lv_scr_act(), nullptr);
-  UpdateMonthLabel();
-  lv_label_set_align(lblMonth, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(lblMonth, lv_scr_act(), LV_ALIGN_CENTER, POS_X_MONTH, POS_Y_TEXT);
-  lv_obj_set_auto_realign(lblMonth, true);
+  monthCounter.EnableMonthMode();
+  monthCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
+  monthCounter.Create();
+  monthCounter.SetValue(static_cast<int>(dateTimeController.Month()));
+  lv_obj_align(monthCounter.GetObject(), nullptr, LV_ALIGN_CENTER, POS_X_MONTH, POS_Y_TEXT);
 
-  yearValue = static_cast<int>(dateTimeController.Year());
-  if (yearValue < 2021)
-    yearValue = 2021;
-  lblYear = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_fmt(lblYear, "%d", yearValue);
-  lv_label_set_align(lblYear, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(lblYear, lv_scr_act(), LV_ALIGN_CENTER, POS_X_YEAR, POS_Y_TEXT);
-  lv_obj_set_auto_realign(lblYear, true);
-
-  btnDayPlus = lv_btn_create(lv_scr_act(), nullptr);
-  btnDayPlus->user_data = this;
-  lv_obj_set_size(btnDayPlus, 50, 40);
-  lv_obj_align(btnDayPlus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_DAY, POS_Y_PLUS);
-  lv_obj_set_style_local_value_str(btnDayPlus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "+");
-  lv_obj_set_event_cb(btnDayPlus, event_handler);
-
-  btnDayMinus = lv_btn_create(lv_scr_act(), nullptr);
-  btnDayMinus->user_data = this;
-  lv_obj_set_size(btnDayMinus, 50, 40);
-  lv_obj_align(btnDayMinus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_DAY, POS_Y_MINUS);
-  lv_obj_set_style_local_value_str(btnDayMinus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "-");
-  lv_obj_set_event_cb(btnDayMinus, event_handler);
-
-  btnMonthPlus = lv_btn_create(lv_scr_act(), nullptr);
-  btnMonthPlus->user_data = this;
-  lv_obj_set_size(btnMonthPlus, 50, 40);
-  lv_obj_align(btnMonthPlus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_MONTH, POS_Y_PLUS);
-  lv_obj_set_style_local_value_str(btnMonthPlus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "+");
-  lv_obj_set_event_cb(btnMonthPlus, event_handler);
-
-  btnMonthMinus = lv_btn_create(lv_scr_act(), nullptr);
-  btnMonthMinus->user_data = this;
-  lv_obj_set_size(btnMonthMinus, 50, 40);
-  lv_obj_align(btnMonthMinus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_MONTH, POS_Y_MINUS);
-  lv_obj_set_style_local_value_str(btnMonthMinus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "-");
-  lv_obj_set_event_cb(btnMonthMinus, event_handler);
-
-  btnYearPlus = lv_btn_create(lv_scr_act(), nullptr);
-  btnYearPlus->user_data = this;
-  lv_obj_set_size(btnYearPlus, 50, 40);
-  lv_obj_align(btnYearPlus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_YEAR, POS_Y_PLUS);
-  lv_obj_set_style_local_value_str(btnYearPlus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "+");
-  lv_obj_set_event_cb(btnYearPlus, event_handler);
-
-  btnYearMinus = lv_btn_create(lv_scr_act(), nullptr);
-  btnYearMinus->user_data = this;
-  lv_obj_set_size(btnYearMinus, 50, 40);
-  lv_obj_align(btnYearMinus, lv_scr_act(), LV_ALIGN_CENTER, POS_X_YEAR, POS_Y_MINUS);
-  lv_obj_set_style_local_value_str(btnYearMinus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "-");
-  lv_obj_set_event_cb(btnYearMinus, event_handler);
+  yearCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
+  yearCounter.Create();
+  yearCounter.SetValue(dateTimeController.Year());
+  lv_obj_align(yearCounter.GetObject(), nullptr, LV_ALIGN_CENTER, POS_X_YEAR, POS_Y_TEXT);
 
   btnSetTime = lv_btn_create(lv_scr_act(), nullptr);
   btnSetTime->user_data = this;
   lv_obj_set_size(btnSetTime, 120, 48);
   lv_obj_align(btnSetTime, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
+  lv_obj_set_style_local_bg_color(btnSetTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0x38, 0x38, 0x38));
   lv_obj_set_style_local_value_str(btnSetTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Set");
   lv_obj_set_event_cb(btnSetTime, event_handler);
+  lv_btn_set_state(btnSetTime, LV_BTN_STATE_DISABLED);
 }
 
 SettingSetDate::~SettingSetDate() {
   lv_obj_clean(lv_scr_act());
 }
 
-void SettingSetDate::HandleButtonPress(lv_obj_t* object, lv_event_t event) {
-  if (event != LV_EVENT_CLICKED)
-    return;
-
-  if (object == btnDayPlus) {
-    dayValue++;
-    if (dayValue > MaximumDayOfMonth())
-      dayValue = 1;
-    lv_label_set_text_fmt(lblDay, "%d", dayValue);
-    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
-  } else if (object == btnDayMinus) {
-    dayValue--;
-    if (dayValue < 1)
-      dayValue = MaximumDayOfMonth();
-    lv_label_set_text_fmt(lblDay, "%d", dayValue);
-    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
-  } else if (object == btnMonthPlus) {
-    monthValue++;
-    if (monthValue > 12)
-      monthValue = 1;
-    UpdateMonthLabel();
-    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
-    CheckDay();
-  } else if (object == btnMonthMinus) {
-    monthValue--;
-    if (monthValue < 1)
-      monthValue = 12;
-    UpdateMonthLabel();
-    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
-    CheckDay();
-  } else if (object == btnYearPlus) {
-    yearValue++;
-    lv_label_set_text_fmt(lblYear, "%d", yearValue);
-    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
-    CheckDay();
-  } else if (object == btnYearMinus) {
-    yearValue--;
-    lv_label_set_text_fmt(lblYear, "%d", yearValue);
-    lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
-    CheckDay();
-  } else if (object == btnSetTime) {
-    NRF_LOG_INFO("Setting date (manually) to %04d-%02d-%02d", yearValue, monthValue, dayValue);
-    dateTimeController.SetTime(static_cast<uint16_t>(yearValue),
-                               static_cast<uint8_t>(monthValue),
-                               static_cast<uint8_t>(dayValue),
-                               0,
-                               dateTimeController.Hours(),
-                               dateTimeController.Minutes(),
-                               dateTimeController.Seconds(),
-                               nrf_rtc_counter_get(portNRF_RTC_REG));
-    lv_btn_set_state(btnSetTime, LV_BTN_STATE_DISABLED);
-  }
-}
-
-int SettingSetDate::MaximumDayOfMonth() const {
-  switch (monthValue) {
-    case 2:
-      if ((((yearValue % 4) == 0) && ((yearValue % 100) != 0)) || ((yearValue % 400) == 0))
-        return 29;
-      return 28;
-    case 4:
-    case 6:
-    case 9:
-    case 11:
-      return 30;
-    default:
-      return 31;
-  }
+void SettingSetDate::HandleButtonPress() {
+  const uint16_t yearValue = yearCounter.GetValue();
+  const uint8_t monthValue = monthCounter.GetValue();
+  const uint8_t dayValue = dayCounter.GetValue();
+  NRF_LOG_INFO("Setting date (manually) to %04d-%02d-%02d", yearValue, monthValue, dayValue);
+  dateTimeController.SetTime(yearValue,
+                             monthValue,
+                             dayValue,
+                             0,
+                             dateTimeController.Hours(),
+                             dateTimeController.Minutes(),
+                             dateTimeController.Seconds(),
+                             nrf_rtc_counter_get(portNRF_RTC_REG));
+  lv_btn_set_state(btnSetTime, LV_BTN_STATE_DISABLED);
 }
 
 void SettingSetDate::CheckDay() {
-  int maxDay = MaximumDayOfMonth();
-  if (dayValue > maxDay) {
-    dayValue = maxDay;
-    lv_label_set_text_fmt(lblDay, "%d", dayValue);
-    lv_obj_align(lblDay, lv_scr_act(), LV_ALIGN_CENTER, POS_X_DAY, POS_Y_TEXT);
-  }
-}
-
-void SettingSetDate::UpdateMonthLabel() {
-  lv_label_set_text_static(
-    lblMonth,
-    Pinetime::Controllers::DateTime::MonthShortToStringLow(static_cast<Pinetime::Controllers::DateTime::Months>(monthValue)));
+  const int maxDay = MaximumDayOfMonth(monthCounter.GetValue(), yearCounter.GetValue());
+  dayCounter.SetMax(maxDay);
+  lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
 }

--- a/src/displayapp/screens/settings/SettingSetDate.h
+++ b/src/displayapp/screens/settings/SettingSetDate.h
@@ -4,6 +4,7 @@
 #include <lvgl/lvgl.h>
 #include "components/datetime/DateTimeController.h"
 #include "displayapp/screens/Screen.h"
+#include "displayapp/widgets/Counter.h"
 
 namespace Pinetime {
   namespace Applications {
@@ -13,28 +14,17 @@ namespace Pinetime {
         SettingSetDate(DisplayApp* app, Pinetime::Controllers::DateTime& dateTimeController);
         ~SettingSetDate() override;
 
-        void HandleButtonPress(lv_obj_t* object, lv_event_t event);
+        void HandleButtonPress();
+        void CheckDay();
 
       private:
         Controllers::DateTime& dateTimeController;
 
-        int dayValue;
-        int monthValue;
-        int yearValue;
-        lv_obj_t* lblDay;
-        lv_obj_t* lblMonth;
-        lv_obj_t* lblYear;
-        lv_obj_t* btnDayPlus;
-        lv_obj_t* btnDayMinus;
-        lv_obj_t* btnMonthPlus;
-        lv_obj_t* btnMonthMinus;
-        lv_obj_t* btnYearPlus;
-        lv_obj_t* btnYearMinus;
         lv_obj_t* btnSetTime;
 
-        int MaximumDayOfMonth() const;
-        void CheckDay();
-        void UpdateMonthLabel();
+        Widgets::Counter dayCounter = Widgets::Counter(1, 31, jetbrains_mono_bold_20);
+        Widgets::Counter monthCounter = Widgets::Counter(1, 12, jetbrains_mono_bold_20);
+        Widgets::Counter yearCounter = Widgets::Counter(1970, 9999, jetbrains_mono_bold_20);
       };
     }
   }

--- a/src/displayapp/widgets/Counter.h
+++ b/src/displayapp/widgets/Counter.h
@@ -15,6 +15,8 @@ namespace Pinetime {
         void HideControls();
         void ShowControls();
         void EnableTwelveHourMode();
+        void EnableMonthMode();
+        void SetMax(int newMax);
         void SetValueChangedEventCallback(void* userData, void (*handler)(void* userData));
 
         int GetValue() const {
@@ -36,10 +38,11 @@ namespace Pinetime {
         lv_obj_t* upperLine;
         lv_obj_t* lowerLine;
         lv_point_t linePoints[2];
-        int value = 0;
         int min;
         int max;
+        int value;
         bool twelveHourMode = false;
+        bool monthMode = false;
         lv_font_t& font;
 
         void* userData = nullptr;


### PR DESCRIPTION
Counter was expanded with month mode, variable digit count and a minimum width.

The counter will always show at least two digits with leading zeroes if necessary. This doesn't impact anything currently, but it's worth considering and I'll see if I can find a neat solution to this.

![InfiniSim_2022-08-01_182556](https://user-images.githubusercontent.com/37774658/182218547-8aab48ec-8344-45de-838a-8c101c453750.png)