### PR TITLE
Add sleep mode

### DIFF
--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -9,7 +9,7 @@ namespace Pinetime {
     class Settings {
     public:
       enum class ClockType : uint8_t { H24, H12 };
-      enum class Notification : uint8_t { ON, OFF };
+      enum class Notification : uint8_t { On, Off, Sleep };
       enum class ChimesOption : uint8_t { None, Hours, HalfHours };
       enum class WakeUpMode : uint8_t {
         SingleTap = 0,
@@ -219,7 +219,7 @@ namespace Pinetime {
         uint32_t screenTimeOut = 15000;
 
         ClockType clockType = ClockType::H24;
-        Notification notificationStatus = Notification::ON;
+        Notification notificationStatus = Notification::On;
 
         uint8_t clockFace = 0;
         ChimesOption chimesOption = ChimesOption::None;

--- a/src/displayapp/fonts/fonts.json
+++ b/src/displayapp/fonts/fonts.json
@@ -58,7 +58,7 @@
       "sources": [
          {
             "file": "material-design-icons/MaterialIcons-Regular.ttf",
-            "range": "0xf00b, 0xe3aa-0xe3ac, 0xe7f6-0xe7f7, 0xe8b8"
+            "range": "0xf00b, 0xe3aa-0xe3ac, 0xe7f6-0xe7f7, 0xe8b8, 0xef44"
          }
       ],
       "bpp": 1,

--- a/src/displayapp/screens/Symbols.h
+++ b/src/displayapp/screens/Symbols.h
@@ -37,6 +37,7 @@ namespace Pinetime {
         static constexpr const char* chartLine = "\xEF\x88\x81";
         static constexpr const char* eye = "\xEF\x81\xAE";
         static constexpr const char* home = "\xEF\x80\x95";
+        static constexpr const char* sleep = "\xEE\xBD\x84";
 
         // lv_font_sys_48.c
         static constexpr const char* settings = "\xEE\xA2\xB8";

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -9,13 +9,21 @@ using namespace Pinetime::Applications::Screens;
 namespace {
   void ButtonEventHandler(lv_obj_t* obj, lv_event_t event) {
     auto* screen = static_cast<QuickSettings*>(obj->user_data);
-    screen->OnButtonEvent(obj, event);
+    if (event == LV_EVENT_CLICKED) {
+      screen->OnButtonEvent(obj);
+    }
   }
 
   void lv_update_task(struct _lv_task_t* task) {
     auto* user_data = static_cast<QuickSettings*>(task->user_data);
     user_data->UpdateScreen();
   }
+
+  enum class ButtonState : lv_state_t {
+    NotificationsOn = LV_STATE_CHECKED,
+    NotificationsOff = LV_STATE_DEFAULT,
+    Sleep = 0x40,
+  };
 }
 
 QuickSettings::QuickSettings(Pinetime::Applications::DisplayApp* app,
@@ -78,19 +86,24 @@ QuickSettings::QuickSettings(Pinetime::Applications::DisplayApp* app,
   btn3 = lv_btn_create(lv_scr_act(), nullptr);
   btn3->user_data = this;
   lv_obj_set_event_cb(btn3, ButtonEventHandler);
-  lv_btn_set_checkable(btn3, true);
   lv_obj_add_style(btn3, LV_BTN_PART_MAIN, &btn_style);
+  lv_obj_set_style_local_bg_color(btn3, LV_BTN_PART_MAIN, static_cast<lv_state_t>(ButtonState::NotificationsOff), LV_COLOR_RED);
+  static constexpr lv_color_t violet = LV_COLOR_MAKE(0x60, 0x00, 0xff);
+  lv_obj_set_style_local_bg_color(btn3, LV_BTN_PART_MAIN, static_cast<lv_state_t>(ButtonState::Sleep), violet);
   lv_obj_set_size(btn3, buttonWidth, buttonHeight);
   lv_obj_align(btn3, nullptr, LV_ALIGN_IN_BOTTOM_LEFT, buttonXOffset, 0);
 
   btn3_lvl = lv_label_create(btn3, nullptr);
   lv_obj_set_style_local_text_font(btn3_lvl, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &lv_font_sys_48);
 
-  if (settingsController.GetNotificationStatus() == Controllers::Settings::Notification::ON) {
-    lv_obj_add_state(btn3, LV_STATE_CHECKED);
+  if (settingsController.GetNotificationStatus() == Controllers::Settings::Notification::On) {
     lv_label_set_text_static(btn3_lvl, Symbols::notificationsOn);
-  } else {
+    lv_obj_set_state(btn3, static_cast<lv_state_t>(ButtonState::NotificationsOn));
+  } else if (settingsController.GetNotificationStatus() == Controllers::Settings::Notification::Off) {
     lv_label_set_text_static(btn3_lvl, Symbols::notificationsOff);
+  } else {
+    lv_label_set_text_static(btn3_lvl, Symbols::sleep);
+    lv_obj_set_state(btn3, static_cast<lv_state_t>(ButtonState::Sleep));
   }
 
   btn4 = lv_btn_create(lv_scr_act(), nullptr);
@@ -121,31 +134,33 @@ void QuickSettings::UpdateScreen() {
   statusIcons.Update();
 }
 
-void QuickSettings::OnButtonEvent(lv_obj_t* object, lv_event_t event) {
-  if (object == btn2 && event == LV_EVENT_CLICKED) {
-
-    running = false;
+void QuickSettings::OnButtonEvent(lv_obj_t* object) {
+  if (object == btn2) {
     app->StartApp(Apps::FlashLight, DisplayApp::FullRefreshDirections::Up);
-
-  } else if (object == btn1 && event == LV_EVENT_CLICKED) {
+  } else if (object == btn1) {
 
     brightness.Step();
     lv_label_set_text_static(btn1_lvl, brightness.GetIcon());
     settingsController.SetBrightness(brightness.Level());
 
-  } else if (object == btn3 && event == LV_EVENT_VALUE_CHANGED) {
+  } else if (object == btn3) {
 
-    if (lv_obj_get_state(btn3, LV_BTN_PART_MAIN) & LV_STATE_CHECKED) {
-      settingsController.SetNotificationStatus(Controllers::Settings::Notification::ON);
-      motorController.RunForDuration(35);
-      lv_label_set_text_static(btn3_lvl, Symbols::notificationsOn);
-    } else {
-      settingsController.SetNotificationStatus(Controllers::Settings::Notification::OFF);
+    if (settingsController.GetNotificationStatus() == Controllers::Settings::Notification::On) {
+      settingsController.SetNotificationStatus(Controllers::Settings::Notification::Off);
       lv_label_set_text_static(btn3_lvl, Symbols::notificationsOff);
+      lv_obj_set_state(btn3, static_cast<lv_state_t>(ButtonState::NotificationsOff));
+    } else if (settingsController.GetNotificationStatus() == Controllers::Settings::Notification::Off) {
+      settingsController.SetNotificationStatus(Controllers::Settings::Notification::Sleep);
+      lv_label_set_text_static(btn3_lvl, Symbols::sleep);
+      lv_obj_set_state(btn3, static_cast<lv_state_t>(ButtonState::Sleep));
+    } else {
+      settingsController.SetNotificationStatus(Controllers::Settings::Notification::On);
+      lv_label_set_text_static(btn3_lvl, Symbols::notificationsOn);
+      lv_obj_set_state(btn3, static_cast<lv_state_t>(ButtonState::NotificationsOn));
+      motorController.RunForDuration(35);
     }
 
-  } else if (object == btn4 && event == LV_EVENT_CLICKED) {
-    running = false;
+  } else if (object == btn4) {
     settingsController.SetSettingsMenu(0);
     app->StartApp(Apps::Settings, DisplayApp::FullRefreshDirections::Up);
   }

--- a/src/displayapp/screens/settings/QuickSettings.h
+++ b/src/displayapp/screens/settings/QuickSettings.h
@@ -27,7 +27,7 @@ namespace Pinetime {
 
         ~QuickSettings() override;
 
-        void OnButtonEvent(lv_obj_t* object, lv_event_t event);
+        void OnButtonEvent(lv_obj_t* object);
 
         void UpdateScreen();
 

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -251,7 +251,8 @@ void SystemTask::Work() {
         case Messages::TouchWakeUp: {
           if (touchHandler.GetNewTouchInfo()) {
             auto gesture = touchHandler.GestureGet();
-            if (gesture != Pinetime::Applications::TouchEvents::None &&
+            if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep &&
+                gesture != Pinetime::Applications::TouchEvents::None &&
                 ((gesture == Pinetime::Applications::TouchEvents::DoubleTap &&
                   settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::DoubleTap)) ||
                  (gesture == Pinetime::Applications::TouchEvents::Tap &&
@@ -280,7 +281,7 @@ void SystemTask::Work() {
           }
           break;
         case Messages::OnNewNotification:
-          if (settingsController.GetNotificationStatus() == Pinetime::Controllers::Settings::Notification::ON) {
+          if (settingsController.GetNotificationStatus() == Pinetime::Controllers::Settings::Notification::On) {
             if (state == SystemTaskState::Sleeping) {
               GoToRunning();
             } else {
@@ -388,7 +389,8 @@ void SystemTask::Work() {
           break;
         case Messages::OnNewHour:
           using Pinetime::Controllers::AlarmController;
-          if (settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::Hours &&
+          if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep &&
+              settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::Hours &&
               alarmController.State() != AlarmController::AlarmState::Alerting) {
             if (state == SystemTaskState::Sleeping) {
               GoToRunning();
@@ -399,7 +401,8 @@ void SystemTask::Work() {
           break;
         case Messages::OnNewHalfHour:
           using Pinetime::Controllers::AlarmController;
-          if (settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::HalfHours &&
+          if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep &&
+              settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::HalfHours &&
               alarmController.State() != AlarmController::AlarmState::Alerting) {
             if (state == SystemTaskState::Sleeping) {
               GoToRunning();
@@ -483,13 +486,13 @@ void SystemTask::UpdateMotion() {
   motionController.IsSensorOk(motionSensor.IsOk());
   motionController.Update(motionValues.x, motionValues.y, motionValues.z, motionValues.steps);
 
-  if (settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist) &&
-      motionController.Should_RaiseWake(state == SystemTaskState::Sleeping)) {
-    GoToRunning();
-  }
-  if (settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::Shake) &&
-      motionController.Should_ShakeWake(settingsController.GetShakeThreshold())) {
-    GoToRunning();
+  if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep) {
+    if ((settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist) &&
+         motionController.Should_RaiseWake(state == SystemTaskState::Sleeping)) ||
+        (settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::Shake) &&
+         motionController.Should_ShakeWake(settingsController.GetShakeThreshold()))) {
+      GoToRunning();
+    }
   }
 }
 


### PR DESCRIPTION
A sleep mode is needed so the watch can be worn during the night without causing the menus to activate.

Sleep mode disables notifications, touch wakeup, motion wakeup and chimes.

![InfiniSim_2022-08-02_105252](https://user-images.githubusercontent.com/37774658/182357972-52497dd3-2e59-4289-913d-484d67ce6644.gif)

Fixes #689