### PR TITLE
Improve status icon visibility

### DIFF
--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -70,7 +70,6 @@ WatchFaceAnalog::WatchFaceAnalog(Pinetime::Applications::DisplayApp* app,
 
   plugIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_static(plugIcon, Symbols::plug);
-  lv_obj_set_style_local_text_color(plugIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_RED);
   lv_obj_align(plugIcon, nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
 
   notificationIcon = lv_label_create(lv_scr_act(), NULL);

--- a/src/displayapp/widgets/StatusIcons.cpp
+++ b/src/displayapp/widgets/StatusIcons.cpp
@@ -15,11 +15,9 @@ void StatusIcons::Create() {
   lv_obj_set_style_local_bg_opa(container, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
 
   bleIcon = lv_label_create(container, nullptr);
-  lv_obj_set_style_local_text_color(bleIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x0082FC));
   lv_label_set_text_static(bleIcon, Screens::Symbols::bluetooth);
 
   batteryPlug = lv_label_create(container, nullptr);
-  lv_obj_set_style_local_text_color(batteryPlug, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_RED);
   lv_label_set_text_static(batteryPlug, Screens::Symbols::plug);
 
   batteryIcon.Create(container);


### PR DESCRIPTION
Making the icons white Improves the visibility, but also makes them more subdued instead of attention grabbing. I was planning on making this change regardless of #1263.

Relates to #958. One of the necessary changes for #1263.

![InfiniSim_2022-08-03_092844](https://user-images.githubusercontent.com/37774658/182575510-0809130d-e544-4565-a8fe-93c2bca45b42.png)
![InfiniSim_2022-08-03_092845](https://user-images.githubusercontent.com/37774658/182575516-39c287c0-b948-4fdd-a6e0-9b4f195441ab.png)
![InfiniSim_2022-08-03_092847](https://user-images.githubusercontent.com/37774658/182575517-b0f3367f-8f9a-4f4b-af0f-92e078dea636.png)
![InfiniSim_2022-08-03_092851](https://user-images.githubusercontent.com/37774658/182575518-6ece33ac-dc78-4879-8223-955c044bb4f0.png)