### PR TITLE
Counter: Determine the number of digits from the max value.

### DIFF
--- a/src/displayapp/widgets/Counter.cpp
+++ b/src/displayapp/widgets/Counter.cpp
@@ -17,9 +17,17 @@ namespace {
       widget->DownBtnPressed();
     }
   }
+  constexpr int digitCount(int number) {
+    int digitCount = 0;
+    while (number > 0) {
+      digitCount++;
+      number /= 10;
+    }
+    return digitCount;
+  }
 }
 
-Counter::Counter(int min, int max, lv_font_t& font) : min {min}, max {max}, value {min}, font {font} {
+Counter::Counter(int min, int max, lv_font_t& font) : min {min}, max {max}, value {min}, font {font}, leadingZeroCount {digitCount(max)} {
 }
 
 void Counter::UpBtnPressed() {
@@ -71,14 +79,14 @@ void Counter::UpdateLabel() {
     if (value == 0) {
       lv_label_set_text_static(number, "12");
     } else if (value <= 12) {
-      lv_label_set_text_fmt(number, "%.2i", value);
+      lv_label_set_text_fmt(number, "%.*i", leadingZeroCount, value);
     } else {
-      lv_label_set_text_fmt(number, "%.2i", value - 12);
+      lv_label_set_text_fmt(number, "%.*i", leadingZeroCount, value - 12);
     }
   } else if (monthMode) {
     lv_label_set_text(number, Controllers::DateTime::MonthShortToStringLow(static_cast<Controllers::DateTime::Months>(value)));
   } else {
-    lv_label_set_text_fmt(number, "%.2i", value);
+    lv_label_set_text_fmt(number, "%.*i", leadingZeroCount, value);
   }
 }
 
@@ -94,6 +102,8 @@ void Counter::EnableMonthMode() {
   monthMode = true;
 }
 
+// Counter cannot be resized after creation,
+// so the newMax value must have the same number of digits as the old one
 void Counter::SetMax(int newMax) {
   max = newMax;
   if (value > max) {

--- a/src/displayapp/widgets/Counter.h
+++ b/src/displayapp/widgets/Counter.h
@@ -41,6 +41,7 @@ namespace Pinetime {
         int min;
         int max;
         int value;
+        const int leadingZeroCount;
         bool twelveHourMode = false;
         bool monthMode = false;
         lv_font_t& font;


### PR DESCRIPTION
Previously the minimum number of digits was fixed at two, padded with leading zeros if necessary. Now it will be determined from the max value. 

Current:
`00, 01, 02 ... 99, 100, 101 ... 999, 1000 1001`

With this change:
`0000, 0001, 0002 ... 0099, 0100, 0101 ... 0999, 1000, 1001`

This issue doesn't happen with the current uses of the Counter.