### PR TITLE
Disable LVGL value_str

### DIFF
--- a/src/displayapp/screens/Error.cpp
+++ b/src/displayapp/screens/Error.cpp
@@ -36,7 +36,8 @@ Error::Error(Pinetime::Applications::DisplayApp* app, System::BootErrors error) 
   lv_obj_set_event_cb(btnOk, ButtonEventCallback);
   lv_obj_set_size(btnOk, LV_HOR_RES, 50);
   lv_obj_align(btnOk, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
-  lv_obj_set_style_local_value_str(btnOk, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Proceed");
+  lv_obj_t* lblOk = lv_label_create(btnOk, nullptr);
+  lv_label_set_text_static(lblOk, "Proceed");
   lv_obj_set_style_local_bg_color(btnOk, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
 }
 

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -64,7 +64,8 @@ Metronome::Metronome(DisplayApp* app, Controllers::MotorController& motorControl
   lv_obj_set_event_cb(playPause, eventHandler);
   lv_obj_set_size(playPause, 115, 50);
   lv_obj_align(playPause, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
-  lv_obj_set_style_local_value_str(playPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Symbols::play);
+  lblPlayPause = lv_label_create(playPause, nullptr);
+  lv_label_set_text_static(lblPlayPause, Symbols::play);
 
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
 }
@@ -126,12 +127,12 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
       if (obj == playPause) {
         metronomeStarted = !metronomeStarted;
         if (metronomeStarted) {
-          lv_obj_set_style_local_value_str(playPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Symbols::pause);
+          lv_label_set_text_static(lblPlayPause, Symbols::pause);
           systemTask.PushMessage(System::Messages::DisableSleeping);
           startTime = xTaskGetTickCount();
           counter = 1;
         } else {
-          lv_obj_set_style_local_value_str(playPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Symbols::play);
+          lv_label_set_text_static(lblPlayPause, Symbols::play);
           systemTask.PushMessage(System::Messages::EnableSleeping);
         }
       }

--- a/src/displayapp/screens/Metronome.h
+++ b/src/displayapp/screens/Metronome.h
@@ -31,6 +31,7 @@ namespace Pinetime {
         lv_obj_t *bpmArc, *bpmTap, *bpmValue;
         lv_obj_t *bpbDropdown, *currentBpbText;
         lv_obj_t* playPause;
+        lv_obj_t* lblPlayPause;
 
         lv_task_t* taskRefresh;
       };

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -196,7 +196,8 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_obj_set_size(btnNextTime, 60, 60);
   lv_obj_align(btnNextTime, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -15, -80);
   lv_obj_set_style_local_bg_opa(btnNextTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_set_style_local_value_str(btnNextTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, ">");
+  lv_obj_t* lblNextTime = lv_label_create(btnNextTime, nullptr);
+  lv_label_set_text_static(lblNextTime, ">");
   lv_obj_set_event_cb(btnNextTime, event_handler);
   lv_obj_set_hidden(btnNextTime, true);
 
@@ -205,7 +206,8 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_obj_set_size(btnPrevTime, 60, 60);
   lv_obj_align(btnPrevTime, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 15, -80);
   lv_obj_set_style_local_bg_opa(btnPrevTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_set_style_local_value_str(btnPrevTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "<");
+  lv_obj_t* lblPrevTime = lv_label_create(btnPrevTime, nullptr);
+  lv_label_set_text_static(lblPrevTime, "<");
   lv_obj_set_event_cb(btnPrevTime, event_handler);
   lv_obj_set_hidden(btnPrevTime, true);
 
@@ -214,7 +216,8 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_obj_set_size(btnNextBar, 60, 60);
   lv_obj_align(btnNextBar, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -15, 0);
   lv_obj_set_style_local_bg_opa(btnNextBar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_set_style_local_value_str(btnNextBar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, ">");
+  lv_obj_t* lblNextBar = lv_label_create(btnNextBar, nullptr);
+  lv_label_set_text_static(lblNextBar, ">");
   lv_obj_set_event_cb(btnNextBar, event_handler);
   lv_obj_set_hidden(btnNextBar, true);
 
@@ -223,7 +226,8 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_obj_set_size(btnPrevBar, 60, 60);
   lv_obj_align(btnPrevBar, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 15, 0);
   lv_obj_set_style_local_bg_opa(btnPrevBar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_set_style_local_value_str(btnPrevBar, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "<");
+  lv_obj_t* lblPrevBar = lv_label_create(btnPrevBar, nullptr);
+  lv_label_set_text_static(lblPrevBar, "<");
   lv_obj_set_event_cb(btnPrevBar, event_handler);
   lv_obj_set_hidden(btnPrevBar, true);
 
@@ -232,7 +236,8 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_obj_set_size(btnNextBG, 60, 60);
   lv_obj_align(btnNextBG, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -15, 80);
   lv_obj_set_style_local_bg_opa(btnNextBG, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_set_style_local_value_str(btnNextBG, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, ">");
+  lv_obj_t* lblNextBG = lv_label_create(btnNextBG, nullptr);
+  lv_label_set_text_static(lblNextBG, ">");
   lv_obj_set_event_cb(btnNextBG, event_handler);
   lv_obj_set_hidden(btnNextBG, true);
 
@@ -241,7 +246,8 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_obj_set_size(btnPrevBG, 60, 60);
   lv_obj_align(btnPrevBG, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 15, 80);
   lv_obj_set_style_local_bg_opa(btnPrevBG, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_set_style_local_value_str(btnPrevBG, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "<");
+  lv_obj_t* lblPrevBG = lv_label_create(btnPrevBG, nullptr);
+  lv_label_set_text_static(lblPrevBG, "<");
   lv_obj_set_event_cb(btnPrevBG, event_handler);
   lv_obj_set_hidden(btnPrevBG, true);
 
@@ -250,7 +256,8 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_obj_set_size(btnReset, 60, 60);
   lv_obj_align(btnReset, lv_scr_act(), LV_ALIGN_CENTER, 0, 80);
   lv_obj_set_style_local_bg_opa(btnReset, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_set_style_local_value_str(btnReset, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Rst");
+  lv_obj_t* lblReset = lv_label_create(btnReset, nullptr);
+  lv_label_set_text_static(lblReset, "Rst");
   lv_obj_set_event_cb(btnReset, event_handler);
   lv_obj_set_hidden(btnReset, true);
 
@@ -259,7 +266,8 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_obj_set_size(btnRandom, 60, 60);
   lv_obj_align(btnRandom, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_local_bg_opa(btnRandom, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_set_style_local_value_str(btnRandom, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Rnd");
+  lv_obj_t* lblRandom = lv_label_create(btnRandom, nullptr);
+  lv_label_set_text_static(lblRandom, "Rnd");
   lv_obj_set_event_cb(btnRandom, event_handler);
   lv_obj_set_hidden(btnRandom, true);
 
@@ -268,7 +276,8 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_obj_set_size(btnClose, 60, 60);
   lv_obj_align(btnClose, lv_scr_act(), LV_ALIGN_CENTER, 0, -80);
   lv_obj_set_style_local_bg_opa(btnClose, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_set_style_local_value_str(btnClose, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "X");
+  lv_obj_t* lblClose = lv_label_create(btnClose, nullptr);
+  lv_label_set_text_static(lblClose, "X");
   lv_obj_set_event_cb(btnClose, event_handler);
   lv_obj_set_hidden(btnClose, true);
 

--- a/src/displayapp/screens/settings/SettingSetDate.cpp
+++ b/src/displayapp/screens/settings/SettingSetDate.cpp
@@ -79,9 +79,11 @@ SettingSetDate::SettingSetDate(Pinetime::Applications::DisplayApp* app, Pinetime
   lv_obj_set_size(btnSetTime, 120, 48);
   lv_obj_align(btnSetTime, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
   lv_obj_set_style_local_bg_color(btnSetTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0x38, 0x38, 0x38));
-  lv_obj_set_style_local_value_str(btnSetTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Set");
+  lblSetTime = lv_label_create(btnSetTime, nullptr);
+  lv_label_set_text_static(lblSetTime, "Set");
   lv_obj_set_event_cb(btnSetTime, event_handler);
   lv_btn_set_state(btnSetTime, LV_BTN_STATE_DISABLED);
+  lv_obj_set_state(lblSetTime, LV_STATE_DISABLED);
 }
 
 SettingSetDate::~SettingSetDate() {
@@ -102,10 +104,12 @@ void SettingSetDate::HandleButtonPress() {
                              dateTimeController.Seconds(),
                              nrf_rtc_counter_get(portNRF_RTC_REG));
   lv_btn_set_state(btnSetTime, LV_BTN_STATE_DISABLED);
+  lv_obj_set_state(lblSetTime, LV_STATE_DISABLED);
 }
 
 void SettingSetDate::CheckDay() {
   const int maxDay = MaximumDayOfMonth(monthCounter.GetValue(), yearCounter.GetValue());
   dayCounter.SetMax(maxDay);
   lv_btn_set_state(btnSetTime, LV_BTN_STATE_RELEASED);
+  lv_obj_set_state(lblSetTime, LV_STATE_DEFAULT);
 }

--- a/src/displayapp/screens/settings/SettingSetDate.h
+++ b/src/displayapp/screens/settings/SettingSetDate.h
@@ -21,6 +21,7 @@ namespace Pinetime {
         Controllers::DateTime& dateTimeController;
 
         lv_obj_t* btnSetTime;
+        lv_obj_t* lblSetTime;
 
         Widgets::Counter dayCounter = Widgets::Counter(1, 31, jetbrains_mono_bold_20);
         Widgets::Counter monthCounter = Widgets::Counter(1, 12, jetbrains_mono_bold_20);

--- a/src/displayapp/screens/settings/SettingSetTime.cpp
+++ b/src/displayapp/screens/settings/SettingSetTime.cpp
@@ -67,13 +67,15 @@ SettingSetTime::SettingSetTime(Pinetime::Applications::DisplayApp* app,
   btnSetTime->user_data = this;
   lv_obj_set_size(btnSetTime, 120, 50);
   lv_obj_align(btnSetTime, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
-  lv_obj_set_style_local_value_str(btnSetTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Set");
+  lblSetTime = lv_label_create(btnSetTime, nullptr);
+  lv_label_set_text_static(lblSetTime, "Set");
   lv_obj_set_style_local_bg_color(btnSetTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Colors::bgAlt);
-  lv_obj_set_style_local_value_color(btnSetTime, LV_BTN_PART_MAIN, LV_STATE_DISABLED, LV_COLOR_GRAY);
+  lv_obj_set_style_local_text_color(lblSetTime, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, LV_COLOR_GRAY);
   lv_obj_set_event_cb(btnSetTime, SetTimeEventHandler);
 
   UpdateScreen();
   lv_obj_set_state(btnSetTime, LV_STATE_DISABLED);
+  lv_obj_set_state(lblSetTime, LV_STATE_DISABLED);
 }
 
 SettingSetTime::~SettingSetTime() {
@@ -89,6 +91,7 @@ void SettingSetTime::UpdateScreen() {
     }
   }
   lv_obj_set_state(btnSetTime, LV_STATE_DEFAULT);
+  lv_obj_set_state(lblSetTime, LV_STATE_DEFAULT);
 }
 
 void SettingSetTime::SetTime() {
@@ -104,4 +107,5 @@ void SettingSetTime::SetTime() {
                              0,
                              nrf_rtc_counter_get(portNRF_RTC_REG));
   lv_obj_set_state(btnSetTime, LV_STATE_DISABLED);
+  lv_obj_set_state(lblSetTime, LV_STATE_DISABLED);
 }

--- a/src/displayapp/screens/settings/SettingSetTime.h
+++ b/src/displayapp/screens/settings/SettingSetTime.h
@@ -26,6 +26,7 @@ namespace Pinetime {
 
         lv_obj_t* lblampm;
         lv_obj_t* btnSetTime;
+        lv_obj_t* lblSetTime;
         Widgets::Counter hourCounter = Widgets::Counter(0, 23, jetbrains_mono_42);
         Widgets::Counter minuteCounter = Widgets::Counter(0, 59, jetbrains_mono_42);
       };

--- a/src/displayapp/screens/settings/SettingSteps.cpp
+++ b/src/displayapp/screens/settings/SettingSteps.cpp
@@ -48,7 +48,8 @@ SettingSteps::SettingSteps(Pinetime::Applications::DisplayApp* app, Pinetime::Co
   btnPlus->user_data = this;
   lv_obj_set_size(btnPlus, 80, 50);
   lv_obj_align(btnPlus, lv_scr_act(), LV_ALIGN_CENTER, 55, 80);
-  lv_obj_set_style_local_value_str(btnPlus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "+");
+  lv_obj_t* lblPlus = lv_label_create(btnPlus, nullptr);
+  lv_label_set_text_static(lblPlus, "+");
   lv_obj_set_event_cb(btnPlus, event_handler);
 
   btnMinus = lv_btn_create(lv_scr_act(), nullptr);
@@ -56,7 +57,8 @@ SettingSteps::SettingSteps(Pinetime::Applications::DisplayApp* app, Pinetime::Co
   lv_obj_set_size(btnMinus, 80, 50);
   lv_obj_set_event_cb(btnMinus, event_handler);
   lv_obj_align(btnMinus, lv_scr_act(), LV_ALIGN_CENTER, -55, 80);
-  lv_obj_set_style_local_value_str(btnMinus, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "-");
+  lv_obj_t* lblMinus = lv_label_create(btnMinus, nullptr);
+  lv_label_set_text_static(lblMinus, "-");
 }
 
 SettingSteps::~SettingSteps() {

--- a/src/libs/lv_conf.h
+++ b/src/libs/lv_conf.h
@@ -164,7 +164,7 @@ typedef void* lv_anim_user_data_t;
 #define LV_USE_PATTERN  1
 
 /*1: enable value string drawing on rectangles*/
-#define LV_USE_VALUE_STR    1
+#define LV_USE_VALUE_STR    0
 
 /* 1: Use other blend modes than normal (`LV_BLEND_MODE_...`)*/
 #define LV_USE_BLEND_MODES      0


### PR DESCRIPTION
value_str is a way to add text on a button without a separate label.
This saves having an extra label object, but I believe it's removed in LVGL8.
Disabling this saves some memory, but using value_str everywhere would probably also save some memory. value_str can make slightly cleaner code, but isn't good for future proofing. Thoughts?