### PR TITLE
colored battery icon "juice"

### DIFF
--- a/src/displayapp/screens/BatteryIcon.cpp
+++ b/src/displayapp/screens/BatteryIcon.cpp
@@ -28,7 +28,7 @@ void BatteryIcon::SetBatteryPercentage(uint8_t percentage) {
   } else if (percentage > 40 && percentage < 60) {
     lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
   } else if (percentage >= 60) {
-    lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_LIGHT_GREEN);
+    lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_LIME);
   }
 }
 

--- a/src/displayapp/screens/BatteryIcon.cpp
+++ b/src/displayapp/screens/BatteryIcon.cpp
@@ -24,11 +24,11 @@ void BatteryIcon::SetBatteryPercentage(uint8_t percentage) {
   lv_obj_set_height(batteryJuice, percentage * 14 / 100);
   lv_obj_realign(batteryJuice);
   if (percentage <= 40) {
-    lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFF0000));
+    lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_RED);
   } else if (percentage > 40 && percentage < 60) {
-    lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFF8600));
+    lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
   } else if (percentage >= 60) {
-    lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
+    lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_LIGHT_GREEN);
   }
 }
 

--- a/src/displayapp/screens/BatteryIcon.cpp
+++ b/src/displayapp/screens/BatteryIcon.cpp
@@ -23,6 +23,13 @@ lv_obj_t* BatteryIcon::GetObject() {
 void BatteryIcon::SetBatteryPercentage(uint8_t percentage) {
   lv_obj_set_height(batteryJuice, percentage * 14 / 100);
   lv_obj_realign(batteryJuice);
+  if (percentage <= 40) {
+  lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFF0000));
+    } else if (percentage > 40 && percentage < 60) {
+  lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFF8600));
+    } else if (percentage >= 60) {
+  lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
+    }
 }
 
 void BatteryIcon::SetColor(lv_color_t color) {

--- a/src/displayapp/screens/BatteryIcon.cpp
+++ b/src/displayapp/screens/BatteryIcon.cpp
@@ -24,12 +24,12 @@ void BatteryIcon::SetBatteryPercentage(uint8_t percentage) {
   lv_obj_set_height(batteryJuice, percentage * 14 / 100);
   lv_obj_realign(batteryJuice);
   if (percentage <= 40) {
-  lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFF0000));
-    } else if (percentage > 40 && percentage < 60) {
-  lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFF8600));
-    } else if (percentage >= 60) {
-  lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
-    }
+    lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFF0000));
+  } else if (percentage > 40 && percentage < 60) {
+    lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xFF8600));
+  } else if (percentage >= 60) {
+    lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
+  }
 }
 
 void BatteryIcon::SetColor(lv_color_t color) {


### PR DESCRIPTION
Battery status icon "juice" colored depending on the reported battery percentage. 
This is a first attempt to introduce a few colored elements into the UI, in accordance with some of the reactions to #1265 

```
>=60 GREEN
>40 && <60 ORANGE
<=40 RED
```

![6pnwi3](https://user-images.githubusercontent.com/54219098/184242891-5fc81c6d-a5c4-49f0-b634-af8496d1dd29.gif)
