### PR TITLE
Remove leftover debugging logs

### DIFF
--- a/src/components/ble/AlertNotificationClient.cpp
+++ b/src/components/ble/AlertNotificationClient.cpp
@@ -2,7 +2,6 @@
 #include <algorithm>
 #include "components/ble/NotificationManager.h"
 #include "systemtask/SystemTask.h"
-#include <nrf_log.h>
 
 using namespace Pinetime::Controllers;
 constexpr ble_uuid16_t AlertNotificationClient::ansServiceUuid;

--- a/src/components/ble/BatteryInformationService.cpp
+++ b/src/components/ble/BatteryInformationService.cpp
@@ -42,7 +42,6 @@ int BatteryInformationService::OnBatteryServiceRequested(uint16_t connectionHand
                                                          uint16_t attributeHandle,
                                                          ble_gatt_access_ctxt* context) {
   if (attributeHandle == batteryLevelHandle) {
-    NRF_LOG_INFO("BATTERY : handle = %d", batteryLevelHandle);
     uint8_t batteryValue = batteryController.PercentRemaining();
     int res = os_mbuf_append(context->om, &batteryValue, 1);
     return (res == 0) ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;

--- a/src/components/ble/BatteryInformationService.cpp
+++ b/src/components/ble/BatteryInformationService.cpp
@@ -1,5 +1,4 @@
 #include "components/ble/BatteryInformationService.h"
-#include <nrf_log.h>
 #include "components/battery/BatteryController.h"
 
 using namespace Pinetime::Controllers;

--- a/src/components/ble/CurrentTimeClient.cpp
+++ b/src/components/ble/CurrentTimeClient.cpp
@@ -37,18 +37,14 @@ void CurrentTimeClient::Init() {
 bool CurrentTimeClient::OnDiscoveryEvent(uint16_t connectionHandle, const ble_gatt_error* error, const ble_gatt_svc* service) {
   if (service == nullptr && error->status == BLE_HS_EDONE) {
     if (isDiscovered) {
-      NRF_LOG_INFO("CTS found, starting characteristics discovery");
-
       ble_gattc_disc_all_chrs(connectionHandle, ctsStartHandle, ctsEndHandle, OnCurrentTimeCharacteristicDiscoveredCallback, this);
     } else {
-      NRF_LOG_INFO("CTS not found");
       onServiceDiscovered(connectionHandle);
     }
     return true;
   }
 
   if (service != nullptr && ble_uuid_cmp(&ctsServiceUuid.u, &service->uuid.u) == 0) {
-    NRF_LOG_INFO("CTS discovered : 0x%x - 0x%x", service->start_handle, service->end_handle);
     isDiscovered = true;
     ctsStartHandle = service->start_handle;
     ctsEndHandle = service->end_handle;
@@ -62,10 +58,8 @@ int CurrentTimeClient::OnCharacteristicDiscoveryEvent(uint16_t conn_handle,
                                                       const ble_gatt_chr* characteristic) {
   if (characteristic == nullptr && error->status == BLE_HS_EDONE) {
     if (isCharacteristicDiscovered) {
-      NRF_LOG_INFO("CTS Characteristic discovery complete, fetching time");
       ble_gattc_read(conn_handle, currentTimeHandle, CurrentTimeReadCallback, this);
     } else {
-      NRF_LOG_INFO("CTS Characteristic discovery unsuccessful");
       onServiceDiscovered(conn_handle);
     }
 
@@ -73,7 +67,6 @@ int CurrentTimeClient::OnCharacteristicDiscoveryEvent(uint16_t conn_handle,
   }
 
   if (characteristic != nullptr && ble_uuid_cmp(&currentTimeCharacteristicUuid.u, &characteristic->uuid.u) == 0) {
-    NRF_LOG_INFO("CTS Characteristic discovered : 0x%x", characteristic->val_handle);
     isCharacteristicDiscovered = true;
     currentTimeHandle = characteristic->val_handle;
   }
@@ -85,13 +78,6 @@ int CurrentTimeClient::OnCurrentTimeReadResult(uint16_t conn_handle, const ble_g
     // TODO check that attribute->handle equals the handle discovered in OnCharacteristicDiscoveryEvent
     CtsData result;
     os_mbuf_copydata(attribute->om, 0, sizeof(CtsData), &result);
-    NRF_LOG_INFO("Received data: %d-%d-%d %d:%d:%d",
-                 result.year,
-                 result.month,
-                 result.dayofmonth,
-                 result.hour,
-                 result.minute,
-                 result.second);
     dateTimeController.SetTime(result.year,
                                result.month,
                                result.dayofmonth,
@@ -100,8 +86,6 @@ int CurrentTimeClient::OnCurrentTimeReadResult(uint16_t conn_handle, const ble_g
                                result.minute,
                                result.second,
                                nrf_rtc_counter_get(portNRF_RTC_REG));
-  } else {
-    NRF_LOG_INFO("Error retrieving current time: %d", error->status);
   }
 
   onServiceDiscovered(conn_handle);
@@ -114,7 +98,6 @@ void CurrentTimeClient::Reset() {
 }
 
 void CurrentTimeClient::Discover(uint16_t connectionHandle, std::function<void(uint16_t)> onServiceDiscovered) {
-  NRF_LOG_INFO("[CTS] Starting discovery");
   this->onServiceDiscovered = onServiceDiscovered;
   ble_gattc_disc_svc_by_uuid(connectionHandle, &ctsServiceUuid.u, OnDiscoveryEventCallback, this);
 }

--- a/src/components/ble/CurrentTimeClient.cpp
+++ b/src/components/ble/CurrentTimeClient.cpp
@@ -1,6 +1,5 @@
 #include "components/ble/CurrentTimeClient.h"
 #include <hal/nrf_rtc.h>
-#include <nrf_log.h>
 #include "components/datetime/DateTimeController.h"
 
 using namespace Pinetime::Controllers;

--- a/src/components/ble/CurrentTimeService.cpp
+++ b/src/components/ble/CurrentTimeService.cpp
@@ -22,20 +22,9 @@ void CurrentTimeService::Init() {
 }
 
 int CurrentTimeService::OnTimeAccessed(uint16_t conn_handle, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt) {
-
-  NRF_LOG_INFO("Setting time...");
-
   if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
     CtsData result;
     os_mbuf_copydata(ctxt->om, 0, sizeof(CtsData), &result);
-
-    NRF_LOG_INFO("Received data: %d-%d-%d %d:%d:%d",
-                 result.year,
-                 result.month,
-                 result.dayofmonth,
-                 result.hour,
-                 result.minute,
-                 result.second);
 
     m_dateTimeController.SetTime(result.year,
                                  result.month,

--- a/src/components/ble/CurrentTimeService.cpp
+++ b/src/components/ble/CurrentTimeService.cpp
@@ -1,6 +1,5 @@
 #include "components/ble/CurrentTimeService.h"
 #include <hal/nrf_rtc.h>
-#include <nrf_log.h>
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -3,7 +3,6 @@
 #include "components/ble/BleController.h"
 #include "drivers/SpiNorFlash.h"
 #include "systemtask/SystemTask.h"
-#include <nrf_log.h>
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -102,7 +102,6 @@ int DfuService::OnServiceData(uint16_t connectionHandle, uint16_t attributeHandl
     else
       return 0;
   } else {
-    NRF_LOG_INFO("[DFU] Unknown Characteristic : %d", attributeHandle);
     return 0;
   }
 }
@@ -119,11 +118,6 @@ int DfuService::WritePacketHandler(uint16_t connectionHandle, os_mbuf* om) {
       bootloaderSize = om->om_data[4] + (om->om_data[5] << 8) + (om->om_data[6] << 16) + (om->om_data[7] << 24);
       applicationSize = om->om_data[8] + (om->om_data[9] << 8) + (om->om_data[10] << 16) + (om->om_data[11] << 24);
       bleController.FirmwareUpdateTotalBytes(applicationSize);
-      NRF_LOG_INFO("[DFU] -> Start data received : SD size : %d, BT size : %d, app size : %d",
-                   softdeviceSize,
-                   bootloaderSize,
-                   applicationSize);
-
       // wait until SystemTask has finished waking up all devices
       while (systemTask.IsSleeping()) {
         vTaskDelay(50); // 50ms
@@ -137,24 +131,8 @@ int DfuService::WritePacketHandler(uint16_t connectionHandle, os_mbuf* om) {
     }
       return 0;
     case States::Init: {
-      uint16_t deviceType = om->om_data[0] + (om->om_data[1] << 8);
-      uint16_t deviceRevision = om->om_data[2] + (om->om_data[3] << 8);
-      uint32_t applicationVersion = om->om_data[4] + (om->om_data[5] << 8) + (om->om_data[6] << 16) + (om->om_data[7] << 24);
       uint16_t softdeviceArrayLength = om->om_data[8] + (om->om_data[9] << 8);
-      uint16_t sd[softdeviceArrayLength];
-      for (int i = 0; i < softdeviceArrayLength; i++) {
-        sd[i] = om->om_data[10 + (i * 2)] + (om->om_data[10 + (i * 2) + 1] << 8);
-      }
       expectedCrc = om->om_data[10 + (softdeviceArrayLength * 2)] + (om->om_data[10 + (softdeviceArrayLength * 2) + 1] << 8);
-
-      NRF_LOG_INFO(
-        "[DFU] -> Init data received : deviceType = %d, deviceRevision = %d, applicationVersion = %d, nb SD = %d, First SD = %d, CRC = %u",
-        deviceType,
-        deviceRevision,
-        applicationVersion,
-        softdeviceArrayLength,
-        sd[0],
-        expectedCrc);
 
       return 0;
     }
@@ -171,14 +149,12 @@ int DfuService::WritePacketHandler(uint16_t connectionHandle, os_mbuf* om) {
                          static_cast<uint8_t>(bytesReceived >> 8u),
                          static_cast<uint8_t>(bytesReceived >> 16u),
                          static_cast<uint8_t>(bytesReceived >> 24u)};
-        NRF_LOG_INFO("[DFU] -> Send packet notification: %d bytes received", bytesReceived);
         notificationManager.Send(connectionHandle, controlPointCharacteristicHandle, data, 5);
       }
       if (dfuImage.IsComplete()) {
         uint8_t data[3] {static_cast<uint8_t>(Opcodes::Response),
                          static_cast<uint8_t>(Opcodes::ReceiveFirmwareImage),
                          static_cast<uint8_t>(ErrorCodes::NoError)};
-        NRF_LOG_INFO("[DFU] -> Send packet notification : all bytes received!");
         notificationManager.Send(connectionHandle, controlPointCharacteristicHandle, data, 3);
         state = States::Validate;
       }
@@ -193,21 +169,17 @@ int DfuService::WritePacketHandler(uint16_t connectionHandle, os_mbuf* om) {
 
 int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
   auto opcode = static_cast<Opcodes>(om->om_data[0]);
-  NRF_LOG_INFO("[DFU] -> ControlPointHandler");
 
   switch (opcode) {
     case Opcodes::StartDFU: {
       if (state != States::Idle && state != States::Start) {
-        NRF_LOG_INFO("[DFU] -> Start DFU requested, but we are not in Idle state");
         return 0;
       }
       if (state == States::Start) {
-        NRF_LOG_INFO("[DFU] -> Start DFU requested, but we are already in Start state");
         return 0;
       }
       auto imageType = static_cast<ImageTypes>(om->om_data[1]);
       if (imageType == ImageTypes::Application) {
-        NRF_LOG_INFO("[DFU] -> Start DFU, mode = Application");
         state = States::Start;
         bleController.StartFirmwareUpdate();
         bleController.State(Pinetime::Controllers::Ble::FirmwareUpdateStates::Running);
@@ -216,17 +188,14 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
         systemTask.PushMessage(Pinetime::System::Messages::BleFirmwareUpdateStarted);
         return 0;
       } else {
-        NRF_LOG_INFO("[DFU] -> Start DFU, mode %d not supported!", imageType);
         return 0;
       }
     } break;
     case Opcodes::InitDFUParameters: {
       if (state != States::Init) {
-        NRF_LOG_INFO("[DFU] -> Init DFU requested, but we are not in Init state");
         return 0;
       }
       bool isInitComplete = (om->om_data[1] != 0);
-      NRF_LOG_INFO("[DFU] -> Init DFU parameters %s", isInitComplete ? " complete" : " not complete");
 
       if (isInitComplete) {
         uint8_t data[3] {static_cast<uint8_t>(Opcodes::Response),
@@ -239,38 +208,29 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
       return 0;
     case Opcodes::PacketReceiptNotificationRequest:
       nbPacketsToNotify = om->om_data[1];
-      NRF_LOG_INFO("[DFU] -> Receive Packet Notification Request, nb packet = %d", nbPacketsToNotify);
       return 0;
     case Opcodes::ReceiveFirmwareImage:
       if (state != States::Init) {
-        NRF_LOG_INFO("[DFU] -> Receive firmware image requested, but we are not in Start Init");
         return 0;
       }
       // TODO the chunk size is dependent of the implementation of the host application...
       dfuImage.Init(20, applicationSize, expectedCrc);
-      NRF_LOG_INFO("[DFU] -> Starting receive firmware");
       state = States::Data;
       return 0;
     case Opcodes::ValidateFirmware: {
       if (state != States::Validate) {
-        NRF_LOG_INFO("[DFU] -> Validate firmware image requested, but we are not in Data state %d", state);
         return 0;
       }
-
-      NRF_LOG_INFO("[DFU] -> Validate firmware image requested -- %d", connectionHandle);
 
       if (dfuImage.Validate()) {
         state = States::Validated;
         bleController.State(Pinetime::Controllers::Ble::FirmwareUpdateStates::Validated);
-        NRF_LOG_INFO("Image OK");
 
         uint8_t data[3] {static_cast<uint8_t>(Opcodes::Response),
                          static_cast<uint8_t>(Opcodes::ValidateFirmware),
                          static_cast<uint8_t>(ErrorCodes::NoError)};
         notificationManager.AsyncSend(connectionHandle, controlPointCharacteristicHandle, data, 3);
       } else {
-        NRF_LOG_INFO("Image Error : bad CRC");
-
         uint8_t data[3] {static_cast<uint8_t>(Opcodes::Response),
                          static_cast<uint8_t>(Opcodes::ValidateFirmware),
                          static_cast<uint8_t>(ErrorCodes::CrcError)};
@@ -283,10 +243,8 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
     }
     case Opcodes::ActivateImageAndReset:
       if (state != States::Validated) {
-        NRF_LOG_INFO("[DFU] -> Activate image and reset requested, but we are not in Validated state");
         return 0;
       }
-      NRF_LOG_INFO("[DFU] -> Activate image and reset!");
       bleController.State(Pinetime::Controllers::Ble::FirmwareUpdateStates::Validated);
       Reset();
       return 0;

--- a/src/components/ble/FSService.cpp
+++ b/src/components/ble/FSService.cpp
@@ -50,7 +50,6 @@ void FSService::Init() {
 
 int FSService::OnFSServiceRequested(uint16_t connectionHandle, uint16_t attributeHandle, ble_gatt_access_ctxt* context) {
   if (attributeHandle == versionCharacteristicHandle) {
-    NRF_LOG_INFO("FS_S : handle = %d", versionCharacteristicHandle);
     int res = os_mbuf_append(context->om, &fsVersion, sizeof(fsVersion));
     return (res == 0) ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
   }
@@ -62,7 +61,6 @@ int FSService::OnFSServiceRequested(uint16_t connectionHandle, uint16_t attribut
 
 int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
   auto command = static_cast<commands>(om->om_data[0]);
-  NRF_LOG_INFO("[FS_S] -> FSCommandHandler Command %d", command);
   // Just always make sure we are awake...
   systemTask.PushMessage(Pinetime::System::Messages::StartFileTransfer);
   vTaskDelay(10);
@@ -74,7 +72,6 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
   lfs_file f = {0};
   switch (command) {
     case commands::READ: {
-      NRF_LOG_INFO("[FS_S] -> Read");
       auto* header = (ReadHeader*) om->om_data;
       uint16_t plen = header->pathlen;
       if (plen > maxpathlen) { //> counts for null term
@@ -109,7 +106,6 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
       break;
     }
     case commands::READ_PACING: {
-      NRF_LOG_INFO("[FS_S] -> Readpacing");
       auto* header = (ReadHeader*) om->om_data;
       ReadResponse resp;
       resp.command = commands::READ_DATA;
@@ -141,7 +137,6 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
       break;
     }
     case commands::WRITE: {
-      NRF_LOG_INFO("[FS_S] -> Write");
       auto* header = (WriteHeader*) om->om_data;
       uint16_t plen = header->pathlen;
       if (plen > maxpathlen) { //> counts for null term
@@ -166,7 +161,6 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
       break;
     }
     case commands::WRITE_DATA: {
-      NRF_LOG_INFO("[FS_S] -> WriteData");
       auto* header = (WritePacing*) om->om_data;
       WriteResponse resp;
       resp.command = commands::WRITE_PACING;
@@ -188,7 +182,6 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
       break;
     }
     case commands::DELETE: {
-      NRF_LOG_INFO("[FS_S] -> Delete");
       auto* header = (DelHeader*) om->om_data;
       uint16_t plen = header->pathlen;
       char path[plen + 1] = {0};
@@ -203,7 +196,6 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
       break;
     }
     case commands::MKDIR: {
-      NRF_LOG_INFO("[FS_S] -> MKDir");
       auto* header = (MKDirHeader*) om->om_data;
       uint16_t plen = header->pathlen;
       char path[plen + 1] = {0};
@@ -219,7 +211,6 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
       break;
     }
     case commands::LISTDIR: {
-      NRF_LOG_INFO("[FS_S] -> ListDir");
       ListDirHeader* header = (ListDirHeader*) om->om_data;
       uint16_t plen = header->pathlen;
       char path[plen + 1] = {0};
@@ -283,7 +274,6 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
       break;
     }
     case commands::MOVE: {
-      NRF_LOG_INFO("[FS_S] -> Move");
       MoveHeader* header = (MoveHeader*) om->om_data;
       uint16_t plen = header->OldPathLength;
       // Null Terminate string
@@ -301,7 +291,6 @@ int FSService::FSCommandHandler(uint16_t connectionHandle, os_mbuf* om) {
     default:
       break;
   }
-  NRF_LOG_INFO("[FS_S] -> done ");
   systemTask.PushMessage(Pinetime::System::Messages::StopFileTransfer);
   return 0;
 }

--- a/src/components/ble/FSService.cpp
+++ b/src/components/ble/FSService.cpp
@@ -1,4 +1,3 @@
-#include <nrf_log.h>
 #include "FSService.h"
 #include "components/ble/BleController.h"
 #include "systemtask/SystemTask.h"

--- a/src/components/ble/HeartRateService.cpp
+++ b/src/components/ble/HeartRateService.cpp
@@ -47,7 +47,6 @@ void HeartRateService::Init() {
 
 int HeartRateService::OnHeartRateRequested(uint16_t connectionHandle, uint16_t attributeHandle, ble_gatt_access_ctxt* context) {
   if (attributeHandle == heartRateMeasurementHandle) {
-    NRF_LOG_INFO("HEARTRATE : handle = %d", heartRateMeasurementHandle);
     uint8_t buffer[2] = {0, heartRateController.HeartRate()}; // [0] = flags, [1] = hr value
 
     int res = os_mbuf_append(context->om, buffer, 2);

--- a/src/components/ble/HeartRateService.cpp
+++ b/src/components/ble/HeartRateService.cpp
@@ -1,7 +1,6 @@
 #include "components/ble/HeartRateService.h"
 #include "components/heartrate/HeartRateController.h"
 #include "systemtask/SystemTask.h"
-#include <nrf_log.h>
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/ble/MotionService.cpp
+++ b/src/components/ble/MotionService.cpp
@@ -1,7 +1,6 @@
 #include "components/ble/MotionService.h"
 #include "components/motion/MotionController.h"
 #include "systemtask/SystemTask.h"
-#include <nrf_log.h>
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/ble/MotionService.cpp
+++ b/src/components/ble/MotionService.cpp
@@ -61,7 +61,6 @@ void MotionService::Init() {
 
 int MotionService::OnStepCountRequested(uint16_t connectionHandle, uint16_t attributeHandle, ble_gatt_access_ctxt* context) {
   if (attributeHandle == stepCountHandle) {
-    NRF_LOG_INFO("Motion-stepcount : handle = %d", stepCountHandle);
     uint32_t buffer = motionController.NbSteps();
 
     int res = os_mbuf_append(context->om, &buffer, 4);

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -2,7 +2,6 @@
 #include <cstring>
 
 #include <hal/nrf_rtc.h>
-#include <nrf_log.h>
 #define min // workaround: nimble's min/max macros conflict with libstdc++
 #define max
 #include <host/ble_gap.h>

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -55,13 +55,10 @@ NimbleController::NimbleController(Pinetime::System::SystemTask& systemTask,
 }
 
 void nimble_on_reset(int reason) {
-  NRF_LOG_INFO("Nimble lost sync, resetting state; reason=%d", reason);
 }
 
 void nimble_on_sync(void) {
   int rc;
-
-  NRF_LOG_INFO("Nimble is synced");
 
   rc = ble_hs_util_ensure_addr(0);
   ASSERT(rc == 0);
@@ -183,8 +180,6 @@ void NimbleController::StartAdvertising() {
 int NimbleController::OnGAPEvent(ble_gap_event* event) {
   switch (event->type) {
     case BLE_GAP_EVENT_ADV_COMPLETE:
-      NRF_LOG_INFO("Advertising event : BLE_GAP_EVENT_ADV_COMPLETE");
-      NRF_LOG_INFO("reason=%d; status=%0X", event->adv_complete.reason, event->connect.status);
       if (bleController.IsRadioEnabled() && !bleController.IsConnected()) {
         StartAdvertising();
       }
@@ -192,9 +187,6 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
 
     case BLE_GAP_EVENT_CONNECT:
       /* A new connection was established or a connection attempt failed. */
-      NRF_LOG_INFO("Connect event : BLE_GAP_EVENT_CONNECT");
-      NRF_LOG_INFO("connection %s; status=%0X ", event->connect.status == 0 ? "established" : "failed", event->connect.status);
-
       if (event->connect.status != 0) {
         /* Connection failed; resume advertising. */
         currentTimeClient.Reset();
@@ -213,9 +205,6 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
 
     case BLE_GAP_EVENT_DISCONNECT:
       /* Connection terminated; resume advertising. */
-      NRF_LOG_INFO("Disconnect event : BLE_GAP_EVENT_DISCONNECT");
-      NRF_LOG_INFO("disconnect reason=%d", event->disconnect.reason);
-
       if (event->disconnect.conn.sec_state.bonded) {
         PersistBond(event->disconnect.conn);
       }
@@ -232,24 +221,14 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
 
     case BLE_GAP_EVENT_CONN_UPDATE:
       /* The central has updated the connection parameters. */
-      NRF_LOG_INFO("Update event : BLE_GAP_EVENT_CONN_UPDATE");
-      NRF_LOG_INFO("update status=%0X ", event->conn_update.status);
       break;
 
     case BLE_GAP_EVENT_CONN_UPDATE_REQ:
       /* The central has requested updated connection parameters */
-      NRF_LOG_INFO("Update event : BLE_GAP_EVENT_CONN_UPDATE_REQ");
-      NRF_LOG_INFO("update request : itvl_min=%d itvl_max=%d latency=%d supervision=%d",
-                   event->conn_update_req.peer_params->itvl_min,
-                   event->conn_update_req.peer_params->itvl_max,
-                   event->conn_update_req.peer_params->latency,
-                   event->conn_update_req.peer_params->supervision_timeout);
       break;
 
     case BLE_GAP_EVENT_ENC_CHANGE:
       /* Encryption has been enabled or disabled for this connection. */
-      NRF_LOG_INFO("Security event : BLE_GAP_EVENT_ENC_CHANGE");
-      NRF_LOG_INFO("encryption change event; status=%0X ", event->enc_change.status);
 
       if (event->enc_change.status == 0) {
         struct ble_gap_conn_desc desc;
@@ -257,12 +236,6 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
         if (desc.sec_state.bonded) {
           PersistBond(desc);
         }
-
-        NRF_LOG_INFO("new state: encrypted=%d authenticated=%d bonded=%d key_size=%d",
-                     desc.sec_state.encrypted,
-                     desc.sec_state.authenticated,
-                     desc.sec_state.bonded,
-                     desc.sec_state.key_size);
       }
       break;
 
@@ -279,7 +252,6 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
        * Standards insist that the rand() PRNG be deterministic.
        * Use the tinycrypt prng here since rand() is predictable.
        */
-      NRF_LOG_INFO("Security event : BLE_GAP_EVENT_PASSKEY_ACTION");
       if (event->passkey.params.action == BLE_SM_IOACT_DISP) {
         struct ble_sm_io pkey = {0};
         pkey.action = event->passkey.params.action;
@@ -312,15 +284,6 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
       break;
 
     case BLE_GAP_EVENT_SUBSCRIBE:
-      NRF_LOG_INFO("Subscribe event; conn_handle=%d attr_handle=%d "
-                   "reason=%d prevn=%d curn=%d previ=%d curi=???\n",
-                   event->subscribe.conn_handle,
-                   event->subscribe.attr_handle,
-                   event->subscribe.reason,
-                   event->subscribe.prev_notify,
-                   event->subscribe.cur_notify,
-                   event->subscribe.prev_indicate);
-
       if (event->subscribe.reason == BLE_GAP_SUBSCRIBE_REASON_TERM) {
         heartRateService.UnsubscribeNotification(event->subscribe.conn_handle, event->subscribe.attr_handle);
         motionService.UnsubscribeNotification(event->subscribe.conn_handle, event->subscribe.attr_handle);
@@ -334,11 +297,9 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
       break;
 
     case BLE_GAP_EVENT_MTU:
-      NRF_LOG_INFO("MTU Update event; conn_handle=%d cid=%d mtu=%d", event->mtu.conn_handle, event->mtu.channel_id, event->mtu.value);
       break;
 
     case BLE_GAP_EVENT_REPEAT_PAIRING: {
-      NRF_LOG_INFO("Pairing event : BLE_GAP_EVENT_REPEAT_PAIRING");
       /* We already have a bond with the peer, but it is attempting to
        * establish a new secure link.  This app sacrifices security for
        * convenience: just throw away the old bond and accept the new link.
@@ -358,29 +319,16 @@ int NimbleController::OnGAPEvent(ble_gap_event* event) {
     case BLE_GAP_EVENT_NOTIFY_RX: {
       /* Peer sent us a notification or indication. */
       /* Attribute data is contained in event->notify_rx.attr_data. */
-      NRF_LOG_INFO("Notify event : BLE_GAP_EVENT_NOTIFY_RX");
-      size_t notifSize = OS_MBUF_PKTLEN(event->notify_rx.om);
-
-      NRF_LOG_INFO("received %s; conn_handle=%d attr_handle=%d "
-                   "attr_len=%d",
-                   event->notify_rx.indication ? "indication" : "notification",
-                   event->notify_rx.conn_handle,
-                   event->notify_rx.attr_handle,
-                   notifSize);
-
       alertNotificationClient.OnNotification(event);
     } break;
 
     case BLE_GAP_EVENT_NOTIFY_TX:
-      NRF_LOG_INFO("Notify event : BLE_GAP_EVENT_NOTIFY_TX");
       break;
 
     case BLE_GAP_EVENT_IDENTITY_RESOLVED:
-      NRF_LOG_INFO("Identity event : BLE_GAP_EVENT_IDENTITY_RESOLVED");
       break;
 
     default:
-      NRF_LOG_INFO("UNHANDLED GAP event : %d", event->type);
       break;
   }
   return 0;

--- a/src/components/ble/ServiceDiscovery.cpp
+++ b/src/components/ble/ServiceDiscovery.cpp
@@ -8,7 +8,6 @@ ServiceDiscovery::ServiceDiscovery(std::array<BleClient*, 2>&& clients) : client
 }
 
 void ServiceDiscovery::StartDiscovery(uint16_t connectionHandle) {
-  NRF_LOG_INFO("[Discovery] Starting discovery");
   clientIterator = clients.begin();
   DiscoverNextService(connectionHandle);
 }
@@ -17,14 +16,10 @@ void ServiceDiscovery::OnServiceDiscovered(uint16_t connectionHandle) {
   clientIterator++;
   if (clientIterator != clients.end()) {
     DiscoverNextService(connectionHandle);
-  } else {
-    NRF_LOG_INFO("End of service discovery");
   }
 }
 
 void ServiceDiscovery::DiscoverNextService(uint16_t connectionHandle) {
-  NRF_LOG_INFO("[Discovery] Discover next service");
-
   auto discoverNextService = [this](uint16_t connectionHandle) {
     this->OnServiceDiscovered(connectionHandle);
   };

--- a/src/components/ble/ServiceDiscovery.cpp
+++ b/src/components/ble/ServiceDiscovery.cpp
@@ -1,5 +1,4 @@
 #include "components/ble/ServiceDiscovery.h"
-#include <libraries/log/nrf_log.h>
 #include "components/ble/BleClient.h"
 
 using namespace Pinetime::Controllers;

--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -1,6 +1,5 @@
 #include "components/datetime/DateTimeController.h"
 #include <date/date.h>
-#include <libraries/log/nrf_log.h>
 #include <systemtask/SystemTask.h>
 
 using namespace Pinetime::Controllers;

--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -38,13 +38,9 @@ void DateTime::SetTime(uint16_t year,
   tm.tm_isdst = -1; // Use DST value from local time zone
   currentDateTime = std::chrono::system_clock::from_time_t(std::mktime(&tm));
 
-  NRF_LOG_INFO("%d %d %d ", day, month, year);
-  NRF_LOG_INFO("%d %d %d ", hour, minute, second);
   previousSystickCounter = systickCounter;
 
   UpdateTime(systickCounter);
-  NRF_LOG_INFO("* %d %d %d ", this->hour, this->minute, this->second);
-  NRF_LOG_INFO("* %d %d %d ", this->day, this->month, this->year);
 
   systemTask->PushMessage(System::Messages::OnNewTime);
 }

--- a/src/components/heartrate/Ppg.cpp
+++ b/src/components/heartrate/Ppg.cpp
@@ -6,7 +6,6 @@
 
 #include "components/heartrate/Ppg.h"
 #include <vector>
-#include <nrf_log.h>
 using namespace Pinetime::Controllers;
 
 /** Original implementation from wasp-os : https://github.com/daniel-thompson/wasp-os/blob/master/wasp/ppg.py */

--- a/src/components/heartrate/Ppg.cpp
+++ b/src/components/heartrate/Ppg.cpp
@@ -61,7 +61,6 @@ float Ppg::HeartRate() {
   if (dataIndex < 200)
     return 0;
 
-  NRF_LOG_INFO("PREPROCESS, offset = %d", offset);
   auto hr = ProcessHeartRate();
   dataIndex = 0;
   return hr;

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -112,7 +112,6 @@ void DisplayApp::Start(System::BootErrors error) {
 
 void DisplayApp::Process(void* instance) {
   auto* app = static_cast<DisplayApp*>(instance);
-  NRF_LOG_INFO("displayapp task started!");
   app->InitHw();
 
   // Send a dummy notification to unlock the lvgl display driver for the first iteration

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -1,5 +1,4 @@
 #include "displayapp/DisplayApp.h"
-#include <libraries/log/nrf_log.h>
 #include "displayapp/screens/HeartRate.h"
 #include "displayapp/screens/Motion.h"
 #include "displayapp/screens/Timer.h"

--- a/src/displayapp/DisplayAppRecovery.cpp
+++ b/src/displayapp/DisplayAppRecovery.cpp
@@ -1,7 +1,6 @@
 #include "displayapp/DisplayAppRecovery.h"
 #include <FreeRTOS.h>
 #include <task.h>
-#include <libraries/log/nrf_log.h>
 #include "components/rle/RleDecoder.h"
 #include "touchhandler/TouchHandler.h"
 #include "displayapp/icons/infinitime/infinitime-nb.c"

--- a/src/displayapp/DisplayAppRecovery.cpp
+++ b/src/displayapp/DisplayAppRecovery.cpp
@@ -36,7 +36,6 @@ void DisplayApp::Start() {
 
 void DisplayApp::Process(void* instance) {
   auto* app = static_cast<DisplayApp*>(instance);
-  NRF_LOG_INFO("displayapp task started!");
 
   // Send a dummy notification to unlock the lvgl display driver for the first iteration
   xTaskNotifyGive(xTaskGetCurrentTaskHandle());

--- a/src/displayapp/screens/settings/SettingSetDate.cpp
+++ b/src/displayapp/screens/settings/SettingSetDate.cpp
@@ -1,7 +1,6 @@
 #include "displayapp/screens/settings/SettingSetDate.h"
 #include <lvgl/lvgl.h>
 #include <hal/nrf_rtc.h>
-#include <nrf_log.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Symbols.h"
 

--- a/src/displayapp/screens/settings/SettingSetDate.cpp
+++ b/src/displayapp/screens/settings/SettingSetDate.cpp
@@ -92,7 +92,6 @@ void SettingSetDate::HandleButtonPress() {
   const uint16_t yearValue = yearCounter.GetValue();
   const uint8_t monthValue = monthCounter.GetValue();
   const uint8_t dayValue = dayCounter.GetValue();
-  NRF_LOG_INFO("Setting date (manually) to %04d-%02d-%02d", yearValue, monthValue, dayValue);
   dateTimeController.SetTime(yearValue,
                              monthValue,
                              dayValue,

--- a/src/displayapp/screens/settings/SettingSetTime.cpp
+++ b/src/displayapp/screens/settings/SettingSetTime.cpp
@@ -94,7 +94,6 @@ void SettingSetTime::UpdateScreen() {
 void SettingSetTime::SetTime() {
   const int hoursValue = hourCounter.GetValue();
   const int minutesValue = minuteCounter.GetValue();
-  NRF_LOG_INFO("Setting time (manually) to %02d:%02d:00", hoursValue, minutesValue);
   dateTimeController.SetTime(dateTimeController.Year(),
                              static_cast<uint8_t>(dateTimeController.Month()),
                              dateTimeController.Day(),

--- a/src/displayapp/screens/settings/SettingSetTime.cpp
+++ b/src/displayapp/screens/settings/SettingSetTime.cpp
@@ -1,7 +1,6 @@
 #include "displayapp/screens/settings/SettingSetTime.h"
 #include <lvgl/lvgl.h>
 #include <hal/nrf_rtc.h>
-#include <nrf_log.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Symbols.h"
 #include "components/settings/Settings.h"

--- a/src/drivers/Bma421.cpp
+++ b/src/drivers/Bma421.cpp
@@ -1,6 +1,5 @@
 #include "drivers/Bma421.h"
 #include <libraries/delay/nrf_delay.h>
-#include <libraries/log/nrf_log.h>
 #include "drivers/TwiMaster.h"
 #include <drivers/Bma421_C/bma423.h>
 

--- a/src/drivers/Cst816s.cpp
+++ b/src/drivers/Cst816s.cpp
@@ -103,12 +103,10 @@ void Cst816S::Sleep() {
   vTaskDelay(50);
   static constexpr uint8_t sleepValue = 0x03;
   twiMaster.Write(twiAddress, 0xA5, &sleepValue, 1);
-  NRF_LOG_INFO("[TOUCHPANEL] Sleep");
 }
 
 void Cst816S::Wakeup() {
   Init();
-  NRF_LOG_INFO("[TOUCHPANEL] Wakeup");
 }
 
 bool Cst816S::CheckDeviceIds() {

--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -10,7 +10,6 @@
 
 #include <FreeRTOS.h>
 #include <task.h>
-#include <nrf_log.h>
 
 using namespace Pinetime::Drivers;
 /** Driver for the HRS3300 heart rate sensor.

--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -41,14 +41,12 @@ void Hrs3300::Init() {
 }
 
 void Hrs3300::Enable() {
-  NRF_LOG_INFO("ENABLE");
   auto value = ReadRegister(static_cast<uint8_t>(Registers::Enable));
   value |= 0x80;
   WriteRegister(static_cast<uint8_t>(Registers::Enable), value);
 }
 
 void Hrs3300::Disable() {
-  NRF_LOG_INFO("DISABLE");
   auto value = ReadRegister(static_cast<uint8_t>(Registers::Enable));
   value &= ~0x80;
   WriteRegister(static_cast<uint8_t>(Registers::Enable), value);
@@ -91,15 +89,11 @@ void Hrs3300::SetDrive(uint8_t drive) {
 }
 
 void Hrs3300::WriteRegister(uint8_t reg, uint8_t data) {
-  auto ret = twiMaster.Write(twiAddress, reg, &data, 1);
-  if (ret != TwiMaster::ErrorCodes::NoError)
-    NRF_LOG_INFO("WRITE ERROR");
+  twiMaster.Write(twiAddress, reg, &data, 1);
 }
 
 uint8_t Hrs3300::ReadRegister(uint8_t reg) {
   uint8_t value;
-  auto ret = twiMaster.Read(twiAddress, reg, &value, 1);
-  if (ret != TwiMaster::ErrorCodes::NoError)
-    NRF_LOG_INFO("READ ERROR");
+  twiMaster.Read(twiAddress, reg, &value, 1);
   return value;
 }

--- a/src/drivers/Spi.cpp
+++ b/src/drivers/Spi.cpp
@@ -19,7 +19,6 @@ bool Spi::Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize) {
 
 void Spi::Sleep() {
   nrf_gpio_cfg_default(pinCsn);
-  NRF_LOG_INFO("[SPI] Sleep")
 }
 
 bool Spi::WriteCmdAndBuffer(const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize) {
@@ -34,5 +33,4 @@ bool Spi::Init() {
 void Spi::Wakeup() {
   nrf_gpio_cfg_output(pinCsn);
   nrf_gpio_pin_set(pinCsn);
-  NRF_LOG_INFO("[SPI] Wakeup")
 }

--- a/src/drivers/SpiMaster.cpp
+++ b/src/drivers/SpiMaster.cpp
@@ -253,13 +253,10 @@ void SpiMaster::Sleep() {
   nrf_gpio_cfg_default(params.pinSCK);
   nrf_gpio_cfg_default(params.pinMOSI);
   nrf_gpio_cfg_default(params.pinMISO);
-
-  NRF_LOG_INFO("[SPIMASTER] sleep")
 }
 
 void SpiMaster::Wakeup() {
   Init();
-  NRF_LOG_INFO("[SPIMASTER] Wakeup");
 }
 
 bool SpiMaster::WriteCmdAndBuffer(uint8_t pinCsn, const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize) {

--- a/src/drivers/SpiNorFlash.cpp
+++ b/src/drivers/SpiNorFlash.cpp
@@ -1,7 +1,6 @@
 #include "drivers/SpiNorFlash.h"
 #include <hal/nrf_gpio.h>
 #include <libraries/delay/nrf_delay.h>
-#include <libraries/log/nrf_log.h>
 #include "drivers/Spi.h"
 
 using namespace Pinetime::Drivers;

--- a/src/drivers/SpiNorFlash.cpp
+++ b/src/drivers/SpiNorFlash.cpp
@@ -11,10 +11,6 @@ SpiNorFlash::SpiNorFlash(Spi& spi) : spi {spi} {
 
 void SpiNorFlash::Init() {
   device_id = ReadIdentificaion();
-  NRF_LOG_INFO("[SpiNorFlash] Manufacturer : %d, Memory type : %d, memory density : %d",
-               device_id.manufacturer,
-               device_id.type,
-               device_id.density);
 }
 
 void SpiNorFlash::Uninit() {
@@ -23,7 +19,6 @@ void SpiNorFlash::Uninit() {
 void SpiNorFlash::Sleep() {
   auto cmd = static_cast<uint8_t>(Commands::DeepPowerDown);
   spi.Write(&cmd, sizeof(uint8_t));
-  NRF_LOG_INFO("[SpiNorFlash] Sleep")
 }
 
 void SpiNorFlash::Wakeup() {
@@ -32,13 +27,7 @@ void SpiNorFlash::Wakeup() {
   uint8_t cmd[cmdSize] = {static_cast<uint8_t>(Commands::ReleaseFromDeepPowerDown), 0x01, 0x02, 0x03};
   uint8_t id = 0;
   spi.Read(reinterpret_cast<uint8_t*>(&cmd), cmdSize, &id, 1);
-  auto devId = device_id = ReadIdentificaion();
-  if (devId.type != device_id.type) {
-    NRF_LOG_INFO("[SpiNorFlash] ID on Wakeup: Failed");
-  } else {
-    NRF_LOG_INFO("[SpiNorFlash] ID on Wakeup: %d", id);
-  }
-  NRF_LOG_INFO("[SpiNorFlash] Wakeup")
+  device_id = ReadIdentificaion();
 }
 
 SpiNorFlash::Identification SpiNorFlash::ReadIdentificaion() {

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -173,7 +173,6 @@ void St7789::HardwareReset() {
 void St7789::Sleep() {
   SleepIn();
   nrf_gpio_cfg_default(pinDataCommand);
-  NRF_LOG_INFO("[LCD] Sleep");
 }
 
 void St7789::Wakeup() {
@@ -181,5 +180,4 @@ void St7789::Wakeup() {
   SleepOut();
   VerticalScrollStartAddress(verticalScrollingStartAddress);
   DisplayOn();
-  NRF_LOG_INFO("[LCD] Wakeup")
 }

--- a/src/drivers/TwiMaster.cpp
+++ b/src/drivers/TwiMaster.cpp
@@ -169,8 +169,6 @@ void TwiMaster::Wakeup() {
  * this issue from happening.
  * */
 void TwiMaster::FixHwFreezed() {
-  NRF_LOG_INFO("I2C device frozen, reinitializing it!");
-
   uint32_t twi_state = NRF_TWI1->ENABLE;
 
   Sleep();

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -1,7 +1,6 @@
 #include "heartratetask/HeartRateTask.h"
 #include <drivers/Hrs3300.h>
 #include <components/heartrate/HeartRateController.h>
-#include <nrf_log.h>
 
 using namespace Pinetime::Applications;
 

--- a/src/logging/NrfLogger.cpp
+++ b/src/logging/NrfLogger.cpp
@@ -18,8 +18,6 @@ void NrfLogger::Init() {
 }
 
 void NrfLogger::Process(void*) {
-  NRF_LOG_INFO("Logger task started!");
-
 #pragma clang diagnostic push
 #pragma ide diagnostic ignored "EndlessLoop"
   while (true) {

--- a/src/recoveryLoader.cpp
+++ b/src/recoveryLoader.cpp
@@ -3,7 +3,6 @@
 #include <drivers/SpiMaster.h>
 #include <drivers/Spi.h>
 #include <drivers/SpiNorFlash.h>
-#include <libraries/log/nrf_log.h>
 #include <FreeRTOS.h>
 #include <task.h>
 #include <legacy/nrf_drv_gpiote.h>

--- a/src/recoveryLoader.cpp
+++ b/src/recoveryLoader.cpp
@@ -85,7 +85,6 @@ void Process(void* instance) {
   RefreshWatchdog();
   APP_GPIOTE_INIT(2);
 
-  NRF_LOG_INFO("Init...");
   spi.Init();
   spiNorFlash.Init();
   spiNorFlash.Wakeup();
@@ -93,16 +92,13 @@ void Process(void* instance) {
   lcd.Init();
   gfx.Init();
 
-  NRF_LOG_INFO("Display logo")
   DisplayLogo();
 
-  NRF_LOG_INFO("Erasing...");
   for (uint32_t erased = 0; erased < sizeof(recoveryImage); erased += 0x1000) {
     spiNorFlash.SectorErase(erased);
     RefreshWatchdog();
   }
 
-  NRF_LOG_INFO("Writing factory image...");
   static constexpr uint32_t memoryChunkSize = 200;
   uint8_t writeBuffer[memoryChunkSize];
   for (size_t offset = 0; offset < sizeof(recoveryImage); offset += memoryChunkSize) {
@@ -111,7 +107,6 @@ void Process(void* instance) {
     DisplayProgressBar((static_cast<float>(offset) / static_cast<float>(sizeof(recoveryImage))) * 100.0f, colorWhite);
     RefreshWatchdog();
   }
-  NRF_LOG_INFO("Writing factory image done!");
   DisplayProgressBar(100.0f, colorGreen);
 
   while (1) {

--- a/src/systemtask/SystemMonitor.cpp
+++ b/src/systemtask/SystemMonitor.cpp
@@ -12,10 +12,11 @@ void Pinetime::System::SystemMonitor::Process() {
     auto nb = uxTaskGetSystemState(tasksStatus, 10, nullptr);
     for (uint32_t i = 0; i < nb; i++) {
       NRF_LOG_INFO("Task [%s] - %d", tasksStatus[i].pcTaskName, tasksStatus[i].usStackHighWaterMark);
-      if (tasksStatus[i].usStackHighWaterMark < 20)
-        NRF_LOG_INFO("WARNING!!! Task %s task is nearly full, only %dB available",
-                     tasksStatus[i].pcTaskName,
-                     tasksStatus[i].usStackHighWaterMark * 4);
+      if (tasksStatus[i].usStackHighWaterMark < 20) {
+        NRF_LOG_WARNING("WARNING!!! Task %s task is nearly full, only %dB available",
+                        tasksStatus[i].pcTaskName,
+                        tasksStatus[i].usStackHighWaterMark * 4);
+      }
     }
     lastTick = xTaskGetTickCount();
   }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -1,7 +1,6 @@
 #include "systemtask/SystemTask.h"
 #include <hal/nrf_rtc.h>
 #include <libraries/gpiote/app_gpiote.h>
-#include <libraries/log/nrf_log.h>
 #include "BootloaderVersion.h"
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -28,15 +28,11 @@ namespace {
 }
 
 void DimTimerCallback(TimerHandle_t xTimer) {
-
-  NRF_LOG_INFO("DimTimerCallback");
   auto sysTask = static_cast<SystemTask*>(pvTimerGetTimerID(xTimer));
   sysTask->OnDim();
 }
 
 void IdleTimerCallback(TimerHandle_t xTimer) {
-
-  NRF_LOG_INFO("IdleTimerCallback");
   auto sysTask = static_cast<SystemTask*>(pvTimerGetTimerID(xTimer));
   sysTask->OnIdle();
 }
@@ -114,7 +110,6 @@ void SystemTask::Start() {
 
 void SystemTask::Process(void* instance) {
   auto* app = static_cast<SystemTask*>(instance);
-  NRF_LOG_INFO("systemtask task started!");
   app->Work();
 }
 
@@ -123,7 +118,6 @@ void SystemTask::Work() {
 
   watchdog.Setup(7);
   watchdog.Start();
-  NRF_LOG_INFO("Last reset reason : %s", Pinetime::Drivers::Watchdog::ResetReasonToString(watchdog.ResetReason()));
   APP_GPIOTE_INIT(2);
 
   spi.Init();
@@ -266,7 +260,6 @@ void SystemTask::Work() {
             break;
           }
           state = SystemTaskState::GoingToSleep; // Already set in PushMessage()
-          NRF_LOG_INFO("[systemtask] Going to sleep");
           xTimerStop(idleTimer, 0);
           xTimerStop(dimTimer, 0);
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::GoToSleep);
@@ -326,7 +319,6 @@ void SystemTask::Work() {
           xTimerStart(dimTimer, 0);
           break;
         case Messages::StartFileTransfer:
-          NRF_LOG_INFO("[systemtask] FS Started");
           doNotGoToSleep = true;
           if (state == SystemTaskState::Sleeping) {
             GoToRunning();
@@ -334,7 +326,6 @@ void SystemTask::Work() {
           // TODO add intent of fs access icon or something
           break;
         case Messages::StopFileTransfer:
-          NRF_LOG_INFO("[systemtask] FS Stopped");
           doNotGoToSleep = false;
           xTimerStart(dimTimer, 0);
           // TODO add intent of fs access icon or something
@@ -565,7 +556,6 @@ void SystemTask::OnDim() {
   if (doNotGoToSleep) {
     return;
   }
-  NRF_LOG_INFO("Dim timeout -> Dim screen")
   displayApp.PushMessage(Pinetime::Applications::Display::Messages::DimScreen);
   xTimerStart(idleTimer, 0);
   isDimmed = true;
@@ -575,7 +565,6 @@ void SystemTask::OnIdle() {
   if (doNotGoToSleep) {
     return;
   }
-  NRF_LOG_INFO("Idle timeout -> Going to sleep")
   PushMessage(Messages::GoToSleep);
 }
 


### PR DESCRIPTION
Remove NRF_LOG_INFO, as they're mostly leftovers from debugging. Devs can add the logs they need to their working copy during development instead of relying on the ones created by someone else.