### PR TITLE
Tweaked issue forms, second proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -2,16 +2,11 @@ name: Bug Report
 description: File a bug report
 labels: ["bug"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        **Thanks for taking the time to fill out this bug report!**
-        *Please, before opening a bug report, check if similar issues already exist. In that case, use those issues to provide your feedback instead.*
   - type: checkboxes
     attributes:
       label: Verification
       options:
-      - label: I searched for similar bug reports and found none was relevant.
+      - label: I searched for similar issues and found none was relevant.
         required: true
   - type: input
     id: desc-brief

--- a/.github/ISSUE_TEMPLATE/feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yaml
@@ -2,22 +2,14 @@ name: Feature Request
 description: File a feature request
 labels: ["feature request"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        **Thanks for taking the time to fill out this feature request!**
-        *Please, before opening a feature request, check if similar issues already exist. In that case, use those issues to provide your feedback instead.*
   - type: checkboxes
     attributes:
       label: Verification
       options:
-      - label: I searched for similar feature request and found none was relevant.
+      - label: I searched for similar issues and found none was relevant.
         required: true
-  - type: markdown
-    attributes:
-      value: |
-        **Note:** keep in mind that, while InfiniTime is usable, it is still under heavy development and as such it is continuously evolving.
-        Some features you want to see implemented might not be compatible with the current state of the project, or might not even be suitable to include *in the firmware* of the watch.
+      - label: This feature is **not** related to a problem. If this feature relates to a problem, use the issue report form instead.
+        required: true
   - type: input
     id: desc-brief
     attributes:

--- a/.github/ISSUE_TEMPLATE/issue-report.yaml
+++ b/.github/ISSUE_TEMPLATE/issue-report.yaml
@@ -1,0 +1,35 @@
+name: Issue report
+description: Report an issue
+body:
+- type: checkboxes
+  attributes:
+    label: Verification
+    options:
+      - label: I searched for similar issues and found none was relevant.
+        required: true
+- type: textarea
+  attributes:
+    label: Introduce the issue
+    description: Explain why it is an issue if necessary.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Preferred solution
+    description: You can suggest a solution to the issue here.
+    placeholder: Optional
+- type: input
+  attributes:
+    label: Version
+    description: |
+      What [version of the firmware](https://github.com/JF002/InfiniTime/blob/develop/doc/gettingStarted/gettingStarted-1.0.md#how-to-check-the-version-of-infinitime-and-the-bootloader) are you running?
+      If you are running an older version, please consider [updating to the latest firmware](https://github.com/JF002/InfiniTime/blob/develop/doc/gettingStarted/gettingStarted-1.0.md#how-to-update-your-pinetime).
+      If you are running directly from git, specify the branch or the commit hash directly.
+    placeholder: Ex. v1.6.0 or develop or fc922b60
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Companion app
+    description: Which companion app are you using (if relevant)?
+    placeholder: Ex. Gadgetbridge v0.60.0, Siglo v0.9.4


### PR DESCRIPTION
This is an alternative to #1267, where we keep the feature request form, but add a verification that the feature does **not** relate to a problem. We could also merge this first and discuss the other PR further.