### PR TITLE
Clang tidy check

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,9 +17,8 @@ jobs:
         with:
           fetch-depth: 1000
 
-      - name: Configure git
-        run: |
-          git fetch origin "$GITHUB_BASE_REF":"$GITHUB_BASE_REF" --depth=1000
+      - name: Fetch base branch
+        run: git fetch origin "$GITHUB_BASE_REF":"$GITHUB_BASE_REF"
 
       - name: Install clang-format
         run: |
@@ -35,3 +34,36 @@ jobs:
         with:
           name: Patches
           path: ./*.patch
+  test-clang-tidy:
+    runs-on: ubuntu-latest
+    container:
+      image: infinitime/infinitime-build
+    steps:
+    # This workaround fixes the error "unsafe repository (REPO is owned by someone else)".
+    # See https://github.com/actions/checkout/issues/760 and https://github.com/actions/checkout/issues/766
+    # The fix in "actions/checkout@v2" was not sufficient as the build process also uses git (to get the current
+    # commit hash, for example).
+    - name: Workaround permission issues
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+    - name: Checkout source files
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 1000
+    - name: Fetch base branch
+      run: git fetch origin "$GITHUB_BASE_REF":"$GITHUB_BASE_REF"
+    - name: Install clang-tidy
+      run: |
+        apt-get update
+        apt-get -y install clang-tidy-12
+    - name: Prepare environment
+      shell: bash
+      env:
+        SOURCES_DIR: .
+      run: |
+        . docker/build.sh
+        GetGcc
+        GetNrfSdk
+        GetMcuBoot
+        CmakeGenerate
+    - run: tests/test-tidy.sh

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -63,7 +63,8 @@ jobs:
       run: |
         . docker/build.sh
         GetGcc
-        GetNrfSdk
-        GetMcuBoot
+        # I guess these already exist inside the docker?
+        #GetNrfSdk
+        #GetMcuBoot
         CmakeGenerate
     - run: tests/test-tidy.sh

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -55,7 +55,7 @@ using namespace Pinetime::Applications;
 using namespace Pinetime::Applications::Display;
 
 namespace {
-  static inline bool in_isr(void) {
+  inline bool in_isr() {
     return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
   }
 }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -22,7 +22,7 @@
 using namespace Pinetime::System;
 
 namespace {
-  static inline bool in_isr(void) {
+  inline bool in_isr() {
     return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0;
   }
 }

--- a/tests/test-tidy.sh
+++ b/tests/test-tidy.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+if [ -z "$GITHUB_BASE_REF" ]
+then
+  echo "This script is only meant to be run in a GitHub Workflow"
+  exit 1
+fi
+
+CHANGED_FILES=$(git diff --name-only "$GITHUB_BASE_REF"...HEAD)
+
+for file in $CHANGED_FILES
+do
+  [ -e "$file" ] || continue
+  case "$file" in
+  src/libs/*|src/FreeRTOS/*) continue ;;
+  *.cpp|*.h)
+    echo "::group::$file"
+    clang-tidy-12 -p build "$file" || true
+    echo "::endgroup::"
+  esac
+done
+
+exit 0


### PR DESCRIPTION
Added a new check that displays clang-tidy warnings for changed files. This check isn't blocking, because a lot of warnings exist in the codebase and the rules may need to be tweaked, but can be used for reference. I've added some fixes that trigger the check for demonstration.

I think we should work to fix these warnings or disable them if they're not important. These warnings aren't necessarily about fixing bad code, but rather consistent practices, so silencing or switching some of them isn't an issue. Let me know what you think.