### PR TITLE
Digital watchface seconds instead of colon

### DIFF
--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -45,9 +45,19 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   label_time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(label_time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_extrabold_compressed);
 
+  label_hours = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_font(label_hours, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_extrabold_compressed);
+  lv_obj_set_style_local_text_color(label_hours, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
+
+  label_minutes = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_font(label_minutes, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_extrabold_compressed);
+  lv_obj_set_style_local_text_color(label_minutes, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
+
   label_time_seconds = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(label_time_seconds, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
   lv_obj_set_style_local_text_color(label_time_seconds, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
+
+
 
   lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
 
@@ -134,13 +144,27 @@ void WatchFaceDigital::Refresh() {
           1. Align hours and minutes manually
           2. find a way to insert a space character between hour and minute
         */
+
         lv_label_set_text(label_time_ampm, ampmChar);
-        lv_label_set_text_fmt(label_time, "%02d:%02d", hour, minute);
+        lv_label_set_text_fmt(label_time, "%02d:%02d", hour, minute); //how the fuck do I insert a blank instead of the : ?!? Possibly time for stackoverflow...
         lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
 
       } else {
-        lv_label_set_text_fmt(label_time, "%02d:%02d", hour, minute);
-        lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
+        //lv_label_set_text_fmt(label_time, "%02d:%02d", hour, minute);
+        //lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
+
+        //split hours and minutes 
+        lv_label_set_text_fmt(label_hours, "%02d", hour);
+        lv_obj_align(label_hours, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, 0);
+        lv_label_set_text_fmt(label_minutes, "%02d", hour);
+        lv_obj_align(label_minutes, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
+        
+
+
+        //align digits
+
+        //place seconds inbetween
+
       }
     }
 

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -48,11 +48,11 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   label_minutes = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(label_minutes, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_extrabold_compressed);
 
-  label_seconds_first = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(label_seconds_first, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
+  label_seconds_first_digit = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_font(label_seconds_first_digit, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
 
-  label_seconds_second = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(label_seconds_second, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
+  label_seconds_second_digit = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_font(label_seconds_second_digit, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
 
   heartbeatIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_static(heartbeatIcon, Symbols::heartBeat);
@@ -118,11 +118,11 @@ void WatchFaceDigital::Refresh() {
       secondFirstDigit = second / 10;
       secondSecondDigit = second % 10;
 
-        lv_label_set_text_fmt(label_seconds_first, "%2d", secondFirstDigit);
-        lv_obj_align(label_seconds_first, lv_scr_act(), LV_ALIGN_CENTER, -8, -6);
+        lv_label_set_text_fmt(label_seconds_first_digit, "%2d", secondFirstDigit);
+        lv_obj_align(label_seconds_first_digit, lv_scr_act(), LV_ALIGN_CENTER, -8, -6);
 
-        lv_label_set_text_fmt(label_seconds_second, "%2d", secondSecondDigit);
-        lv_obj_align(label_seconds_second, lv_scr_act(), LV_ALIGN_CENTER, -8, 20);
+        lv_label_set_text_fmt(label_seconds_second_digit, "%2d", secondSecondDigit);
+        lv_obj_align(label_seconds_second_digit, lv_scr_act(), LV_ALIGN_CENTER, -8, 20);
 
         lv_label_set_text_fmt(label_minutes, "%02d", minute);
         lv_obj_align(label_minutes, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -45,6 +45,10 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   label_time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(label_time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_extrabold_compressed);
 
+  label_time_seconds = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_font(label_time_seconds, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_obj_set_style_local_text_color(label_time_seconds, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
+
   lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
 
   label_time_ampm = lv_label_create(lv_scr_act(), nullptr);
@@ -104,10 +108,12 @@ void WatchFaceDigital::Refresh() {
 
     uint8_t hour = time.hours().count();
     uint8_t minute = time.minutes().count();
+    uint8_t second = time.seconds().count();
 
-    if (displayedHour != hour || displayedMinute != minute) {
+    if (displayedHour != hour || displayedMinute != minute || displayedSecond != second) {
       displayedHour = hour;
       displayedMinute = minute;
+      displayedSecond = second;
 
       if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
         char ampmChar[3] = "AM";
@@ -122,9 +128,15 @@ void WatchFaceDigital::Refresh() {
         lv_label_set_text(label_time_ampm, ampmChar);
         lv_label_set_text_fmt(label_time, "%2d:%02d", hour, minute);
         lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
+        //very crude way of adding the seconds, maybe better create a new font where all elements fit horizontally
+        lv_label_set_text_fmt(label_time_seconds, "%02d", second);
+        lv_obj_align(label_time_seconds, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, -8);
+
       } else {
         lv_label_set_text_fmt(label_time, "%02d:%02d", hour, minute);
         lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
+        lv_label_set_text_fmt(label_time_seconds, "%02d", second);
+        lv_obj_align(label_time_seconds, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, -8);
       }
     }
 

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -124,6 +124,9 @@ void WatchFaceDigital::Refresh() {
         lv_label_set_text_fmt(label_seconds_second, "%2d", secondSecondDigit);
         lv_obj_align(label_seconds_second, lv_scr_act(), LV_ALIGN_CENTER, -8, 20);
 
+        lv_label_set_text_fmt(label_minutes, "%02d", minute);
+        lv_obj_align(label_minutes, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
+
       if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
         char ampmChar[3] = "AM";
         if (hour == 0) {
@@ -135,18 +138,16 @@ void WatchFaceDigital::Refresh() {
           ampmChar[0] = 'P';
         }
 
-        //ToDo: fix leading 0 of hours in 12H mode
-        //could be problematic with aligning or maybee needs manual alignment
-        lv_label_set_text_fmt(label_hours, "%02d", hour);
-        lv_obj_align(label_hours, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, 0);
-        lv_label_set_text_fmt(label_minutes, "%02d", minute);
-        lv_obj_align(label_minutes, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
-
+        if (hour < 10) {
+          lv_label_set_text_fmt(label_hours, "%1d", hour);
+          lv_obj_align(label_hours, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 45, 0);
+        } else {
+          lv_label_set_text_fmt(label_hours, "%2d", hour);
+          lv_obj_align(label_hours, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, 0);
+        }
       } else {
         lv_label_set_text_fmt(label_hours, "%02d", hour);
         lv_obj_align(label_hours, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, 0);
-        lv_label_set_text_fmt(label_minutes, "%02d", minute);
-        lv_obj_align(label_minutes, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
       }
     }
 

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -122,7 +122,7 @@ void WatchFaceDigital::Refresh() {
         lv_obj_align(label_seconds_first_digit, lv_scr_act(), LV_ALIGN_CENTER, -8, -6);
 
         lv_label_set_text_fmt(label_seconds_second_digit, "%2d", secondSecondDigit);
-        lv_obj_align(label_seconds_second_digit, lv_scr_act(), LV_ALIGN_CENTER, -8, 20);
+        lv_obj_align(label_seconds_second_digit, lv_scr_act(), LV_ALIGN_CENTER, -8, 22);
 
         lv_label_set_text_fmt(label_minutes, "%02d", minute);
         lv_obj_align(label_minutes, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -115,6 +115,10 @@ void WatchFaceDigital::Refresh() {
       displayedMinute = minute;
       displayedSecond = second;
 
+      //very crude way of adding the seconds to the watchface, maybe better create a new font where all elements fit horizontally
+        lv_label_set_text_fmt(label_time_seconds, "%02d", second);
+        lv_obj_align(label_time_seconds, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, -8);
+
       if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
         char ampmChar[3] = "AM";
         if (hour == 0) {
@@ -125,18 +129,18 @@ void WatchFaceDigital::Refresh() {
           hour = hour - 12;
           ampmChar[0] = 'P';
         }
+        /*
+          Show seconds instead of : seperator between hour & minute
+          1. Align hours and minutes manually
+          2. find a way to insert a space character between hour and minute
+        */
         lv_label_set_text(label_time_ampm, ampmChar);
-        lv_label_set_text_fmt(label_time, "%2d:%02d", hour, minute);
+        lv_label_set_text_fmt(label_time, "%02d:%02d", hour, minute);
         lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
-        //very crude way of adding the seconds, maybe better create a new font where all elements fit horizontally
-        lv_label_set_text_fmt(label_time_seconds, "%02d", second);
-        lv_obj_align(label_time_seconds, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, -8);
 
       } else {
         lv_label_set_text_fmt(label_time, "%02d:%02d", hour, minute);
         lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
-        lv_label_set_text_fmt(label_time_seconds, "%02d", second);
-        lv_obj_align(label_time_seconds, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, -8);
       }
     }
 

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -118,14 +118,14 @@ void WatchFaceDigital::Refresh() {
       secondFirstDigit = second / 10;
       secondSecondDigit = second % 10;
 
-        lv_label_set_text_fmt(label_seconds_first_digit, "%2d", secondFirstDigit);
-        lv_obj_align(label_seconds_first_digit, lv_scr_act(), LV_ALIGN_CENTER, -8, -6);
+      lv_label_set_text_fmt(label_seconds_first_digit, "%2d", secondFirstDigit);
+      lv_obj_align(label_seconds_first_digit, lv_scr_act(), LV_ALIGN_CENTER, -8, -6);
 
-        lv_label_set_text_fmt(label_seconds_second_digit, "%2d", secondSecondDigit);
-        lv_obj_align(label_seconds_second_digit, lv_scr_act(), LV_ALIGN_CENTER, -8, 22);
+      lv_label_set_text_fmt(label_seconds_second_digit, "%2d", secondSecondDigit);
+      lv_obj_align(label_seconds_second_digit, lv_scr_act(), LV_ALIGN_CENTER, -8, 22);
 
-        lv_label_set_text_fmt(label_minutes, "%02d", minute);
-        lv_obj_align(label_minutes, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
+      lv_label_set_text_fmt(label_minutes, "%02d", minute);
+      lv_obj_align(label_minutes, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
 
       if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
         char ampmChar[3] = "AM";

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -57,6 +57,13 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   lv_obj_set_style_local_text_font(label_time_seconds, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
   lv_obj_set_style_local_text_color(label_time_seconds, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
 
+  label_time_seconds_first = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_font(label_time_seconds_first, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
+  lv_obj_set_style_local_text_color(label_time_seconds_first, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
+
+  label_time_seconds_second = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_font(label_time_seconds_second, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
+  lv_obj_set_style_local_text_color(label_time_seconds_second, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
 
 
   lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
@@ -119,15 +126,22 @@ void WatchFaceDigital::Refresh() {
     uint8_t hour = time.hours().count();
     uint8_t minute = time.minutes().count();
     uint8_t second = time.seconds().count();
+    uint8_t secondFirstDigit = second % 10;
+    uint8_t secondSecondDigit = second / 10;
 
     if (displayedHour != hour || displayedMinute != minute || displayedSecond != second) {
       displayedHour = hour;
       displayedMinute = minute;
       displayedSecond = second;
+      secondFirstDigit = second / 10;
+      secondSecondDigit = second % 10;
+        //very crude way of adding the seconds to the watchface, maybe better create a new font where all elements fit horizontally
 
-      //very crude way of adding the seconds to the watchface, maybe better create a new font where all elements fit horizontally
-        lv_label_set_text_fmt(label_time_seconds, "%02d", second);
-        lv_obj_align(label_time_seconds, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, -8);
+        lv_label_set_text_fmt(label_time_seconds_first, "%2d", secondFirstDigit);
+        lv_obj_align(label_time_seconds_first, lv_scr_act(), LV_ALIGN_CENTER, -8, -6);
+
+        lv_label_set_text_fmt(label_time_seconds_second, "%2d", secondSecondDigit);
+        lv_obj_align(label_time_seconds_second, lv_scr_act(), LV_ALIGN_CENTER, -8, 20);
 
       if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
         char ampmChar[3] = "AM";
@@ -139,32 +153,19 @@ void WatchFaceDigital::Refresh() {
           hour = hour - 12;
           ampmChar[0] = 'P';
         }
-        /*
-          Show seconds instead of : seperator between hour & minute
-          1. Align hours and minutes manually
-          2. find a way to insert a space character between hour and minute
-        */
 
-        lv_label_set_text(label_time_ampm, ampmChar);
-        lv_label_set_text_fmt(label_time, "%02d:%02d", hour, minute); //how the fuck do I insert a blank instead of the : ?!? Possibly time for stackoverflow...
-        lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
-
-      } else {
-        //lv_label_set_text_fmt(label_time, "%02d:%02d", hour, minute);
-        //lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
-
-        //split hours and minutes 
+        //ToDo: fix leading 0 of hours in 12H mode
+        //could be problematic with aligning or maybee needs manual alignment
         lv_label_set_text_fmt(label_hours, "%02d", hour);
         lv_obj_align(label_hours, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, 0);
-        lv_label_set_text_fmt(label_minutes, "%02d", hour);
+        lv_label_set_text_fmt(label_minutes, "%02d", minute);
         lv_obj_align(label_minutes, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
-        
 
-
-        //align digits
-
-        //place seconds inbetween
-
+      } else {
+        lv_label_set_text_fmt(label_hours, "%02d", hour);
+        lv_obj_align(label_hours, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, 0);
+        lv_label_set_text_fmt(label_minutes, "%02d", minute);
+        lv_obj_align(label_minutes, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
       }
     }
 

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -42,35 +42,17 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_CENTER, 0, 60);
   lv_obj_set_style_local_text_color(label_date, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x999999));
 
-  label_time = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(label_time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_extrabold_compressed);
-
   label_hours = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(label_hours, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_extrabold_compressed);
-  lv_obj_set_style_local_text_color(label_hours, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
 
   label_minutes = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(label_minutes, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_extrabold_compressed);
-  lv_obj_set_style_local_text_color(label_minutes, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
 
-  label_time_seconds = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(label_time_seconds, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
-  lv_obj_set_style_local_text_color(label_time_seconds, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
+  label_seconds_first = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_font(label_seconds_first, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
 
-  label_time_seconds_first = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(label_time_seconds_first, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
-  lv_obj_set_style_local_text_color(label_time_seconds_first, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
-
-  label_time_seconds_second = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_font(label_time_seconds_second, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
-  lv_obj_set_style_local_text_color(label_time_seconds_second, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x24FF00));
-
-
-  lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 0);
-
-  label_time_ampm = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_static(label_time_ampm, "");
-  lv_obj_align(label_time_ampm, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -30, -55);
+  label_seconds_second = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_font(label_seconds_second, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_bold_20);
 
   heartbeatIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_static(heartbeatIcon, Symbols::heartBeat);
@@ -135,13 +117,12 @@ void WatchFaceDigital::Refresh() {
       displayedSecond = second;
       secondFirstDigit = second / 10;
       secondSecondDigit = second % 10;
-        //very crude way of adding the seconds to the watchface, maybe better create a new font where all elements fit horizontally
 
-        lv_label_set_text_fmt(label_time_seconds_first, "%2d", secondFirstDigit);
-        lv_obj_align(label_time_seconds_first, lv_scr_act(), LV_ALIGN_CENTER, -8, -6);
+        lv_label_set_text_fmt(label_seconds_first, "%2d", secondFirstDigit);
+        lv_obj_align(label_seconds_first, lv_scr_act(), LV_ALIGN_CENTER, -8, -6);
 
-        lv_label_set_text_fmt(label_time_seconds_second, "%2d", secondSecondDigit);
-        lv_obj_align(label_time_seconds_second, lv_scr_act(), LV_ALIGN_CENTER, -8, 20);
+        lv_label_set_text_fmt(label_seconds_second, "%2d", secondSecondDigit);
+        lv_obj_align(label_seconds_second, lv_scr_act(), LV_ALIGN_CENTER, -8, 20);
 
       if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
         char ampmChar[3] = "AM";

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -57,13 +57,10 @@ namespace Pinetime {
         DirtyValue<bool> heartbeatRunning {};
         DirtyValue<bool> notificationState {};
 
-        lv_obj_t* label_time;
-        lv_obj_t* label_time_ampm;
         lv_obj_t* label_hours;
         lv_obj_t* label_minutes;
-        lv_obj_t* label_time_seconds;
-        lv_obj_t* label_time_seconds_first;
-        lv_obj_t* label_time_seconds_second;
+        lv_obj_t* label_seconds_first;
+        lv_obj_t* label_seconds_second;
         lv_obj_t* label_date;
         lv_obj_t* heartbeatIcon;
         lv_obj_t* heartbeatValue;

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -39,6 +39,7 @@ namespace Pinetime {
       private:
         uint8_t displayedHour = -1;
         uint8_t displayedMinute = -1;
+        uint8_t displayedSecond = -1;
 
         uint16_t currentYear = 1970;
         Controllers::DateTime::Months currentMonth = Pinetime::Controllers::DateTime::Months::Unknown;
@@ -58,6 +59,7 @@ namespace Pinetime {
 
         lv_obj_t* label_time;
         lv_obj_t* label_time_ampm;
+        lv_obj_t* label_time_seconds;
         lv_obj_t* label_date;
         lv_obj_t* heartbeatIcon;
         lv_obj_t* heartbeatValue;

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -62,6 +62,8 @@ namespace Pinetime {
         lv_obj_t* label_hours;
         lv_obj_t* label_minutes;
         lv_obj_t* label_time_seconds;
+        lv_obj_t* label_time_seconds_first;
+        lv_obj_t* label_time_seconds_second;
         lv_obj_t* label_date;
         lv_obj_t* heartbeatIcon;
         lv_obj_t* heartbeatValue;

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -59,8 +59,8 @@ namespace Pinetime {
 
         lv_obj_t* label_hours;
         lv_obj_t* label_minutes;
-        lv_obj_t* label_seconds_first;
-        lv_obj_t* label_seconds_second;
+        lv_obj_t* label_seconds_first_digit;
+        lv_obj_t* label_seconds_second_digit;
         lv_obj_t* label_date;
         lv_obj_t* heartbeatIcon;
         lv_obj_t* heartbeatValue;

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -59,6 +59,8 @@ namespace Pinetime {
 
         lv_obj_t* label_time;
         lv_obj_t* label_time_ampm;
+        lv_obj_t* label_hours;
+        lv_obj_t* label_minutes;
         lv_obj_t* label_time_seconds;
         lv_obj_t* label_date;
         lv_obj_t* heartbeatIcon;


### PR DESCRIPTION
Shows seconds instead of colon seperator.

![InfiniSim_2022-08-21_123405](https://user-images.githubusercontent.com/54219098/185791136-05f8afd9-df0d-42f9-95a1-8dd454563e5e.gif)

Please be gentle with my code, this is the first bigger project I am working on.

Currently the label objects are split into hh, mm, s1, and s2.
The fine-positioning of the clocks elements and fixing the position of the 12H digits is done with pixel offsets.

