### PR TITLE
Change uknown incoming call from null to unknown

### DIFF
--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -306,7 +306,11 @@ Notifications::NotificationItem::NotificationItem(const char* title,
       lv_obj_align(alert_caller, alert_subject, LV_ALIGN_OUT_BOTTOM_LEFT, 0, 0);
       lv_label_set_long_mode(alert_caller, LV_LABEL_LONG_BREAK);
       lv_obj_set_width(alert_caller, LV_HOR_RES - 20);
-      lv_label_set_text(alert_caller, msg);
+      if (strcmp(msg, "null") != 0) {
+        lv_label_set_text(alert_caller, msg);
+      } else {
+        lv_label_set_text(alert_caller, "Unknown");
+      }
 
       bt_accept = lv_btn_create(container, nullptr);
       bt_accept->user_data = this;


### PR DESCRIPTION
When using Gadgetbridge as a companion app, Infinitime shows that unknown call is coming from "null". 
This modification changes it to "Unknown"

![image](https://user-images.githubusercontent.com/52790629/185992475-b89e3458-5210-4135-8527-0e19a91f5e89.png)

![image](https://user-images.githubusercontent.com/52790629/185992499-45a3d0ff-7044-4056-9b39-d3c7efc405c2.png)
