### PR TITLE
Allow manual trigger of CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,9 @@ on:
     branches: [ develop ]
     paths-ignore:
       - 'doc/**'
-
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    
 jobs:
   build-firmware:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
     paths-ignore:
       - 'doc/**'
   # Allows you to run this workflow manually from the Actions tab
+  # this can be useful for running workflows for other branches than develop
   workflow_dispatch:
     
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ on:
     branches: [ develop ]
     paths-ignore:
       - 'doc/**'
-  # Allows you to run this workflow manually from the Actions tab
-  # this can be useful for running workflows for other branches than develop
+  # Allows to manually run the workflow from the Github Actions tab, optionally on another branch
+  #More information: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
   workflow_dispatch:
     
 jobs:


### PR DESCRIPTION
#1229 introduced a manual trigger for the workflows.
With #1279 the functionality  was removed again.

As this can be a useful feature for running workflows for other branches than develop, this PR reintroduces the workflow_dispatch trigger.