### PR TITLE
Edit all occurences of "watch face" to "watchface"

### DIFF
--- a/doc/gettingStarted/gettingStarted-1.0.md
+++ b/doc/gettingStarted/gettingStarted-1.0.md
@@ -20,11 +20,11 @@ You can also set the time in the settings without a companion app. (version >1.7
 
 InfiniTime doesn't handle daylight savings automatically, so make sure to set the correct time or sync it with a companion app.
 
-### Digital watch face
+### Digital Watchface
 
-![Digital watch face](ui/watchface.jpg)
+![Digital Watchface](ui/watchface.jpg)
 
-This is what the default digital watch face looks like. You can change watch faces in the settings.
+This is what the default digital watchface looks like. You can change watchfaces in the settings.
 
 The indicator on the top left is visible if you have unread notifications
 
@@ -54,4 +54,4 @@ On the bottom right you can see how many steps you have taken today.
   - Enter the **settings** menu
     - Swipe up and down to see all options
 - Click the button to go back a screen.
-- You can hold the button for a short time to return to the watch face. (version >1.7.0)
+- You can hold the button for a short time to return to the Watchface. (version >1.7.0)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -422,7 +422,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/settings/SettingShakeThreshold.cpp
         displayapp/screens/settings/SettingBluetooth.cpp
 
-        ## Watch faces
+        ## Watchfaces
         displayapp/icons/bg_clock.c
         displayapp/screens/WatchFaceAnalog.cpp
         displayapp/screens/WatchFaceDigital.cpp

--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -32,7 +32,7 @@ SettingWatchFace::SettingWatchFace(Pinetime::Applications::DisplayApp* app, Pine
   lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
 
   lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_static(title, "Watch face");
+  lv_label_set_text_static(title, "Watchface");
   lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 10, 15);
 

--- a/src/displayapp/screens/settings/Settings.h
+++ b/src/displayapp/screens/settings/Settings.h
@@ -34,7 +34,7 @@ namespace Pinetime {
           {Symbols::sun, "Display", Apps::SettingDisplay},
           {Symbols::eye, "Wake Up", Apps::SettingWakeUp},
           {Symbols::clock, "Time format", Apps::SettingTimeFormat},
-          {Symbols::home, "Watch face", Apps::SettingWatchFace},
+          {Symbols::home, "Watchface", Apps::SettingWatchFace},
 
           {Symbols::shoe, "Steps", Apps::SettingSteps},
           {Symbols::clock, "Set date", Apps::SettingSetDate},


### PR DESCRIPTION
In some of the docs, settings and CMakeList, "watchface" was written as two words:

```
╰─$ grep -ri "watch face"
doc/gettingStarted/gettingStarted-1.0.md:### Digital watch face
doc/gettingStarted/gettingStarted-1.0.md:![Digital watch face](ui/watchface.jpg)
doc/gettingStarted/gettingStarted-1.0.md:This is what the default digital watch face looks like. You can change watch faces in the settings.
doc/gettingStarted/gettingStarted-1.0.md:- You can hold the button for a short time to return to the watch face. (version >1.7.0)
src/CMakeLists.txt:        ## Watch faces
src/displayapp/screens/settings/Settings.h:          {Symbols::home, "Watch face", Apps::SettingWatchFace},
src/displayapp/screens/settings/SettingWatchFace.cpp:  lv_label_set_text_static(title, "Watch face");
```
While most of the time it was referenced as single word:
```
╰─$ grep -r "Watchface\|watchface"
doc/MemoryAnalysis.md:Using this technique, I was able to trace all malloc calls at boot (boot -> digital watchface):
doc/InfiniTimeVision.md:- Personalization is achieved through custom watchfaces.
doc/InfiniTimeVision.md:- Capability to sideload apps and watchfaces
doc/gettingStarted/updating-software.md:You can check the InfiniTime version by first swiping right on the watchface to open quick settings, tapping the cogwheel to open settings, swipe up until you find an entry named "About" and tap on it.
doc/gettingStarted/updating-software.md:- From the watchface, swipe **right** to display the *quick settings menu*
doc/gettingStarted/gettingStarted-1.0.md:By default, InfiniTime starts on the digital watchface. It'll probably display the epoch time (1 Jan 1970, 00:00).
doc/gettingStarted/gettingStarted-1.0.md:![Digital watch face](ui/watchface.jpg)
src/displayapp/screens/WatchFacePineTimeStyle.cpp: * PineTimeStyle watchface for Infinitime created by Kieran Cawthray
src/components/ble/weather/WeatherData.h:       * As direction can fluctuate wildly and some watchfaces might wish to display it nicely,
src/components/ble/weather/WeatherData.h:       * Location info can be for some kind of map watchface
src/components/ble/weather/WeatherData.h:       * this allows watchface or watchapp makers to generate accurate alerts and graphics
```
I've changed all occurences to a single word, in accordance with most of the docs and code.