### PR TITLE
Edit all occurences of "watchface" to "watch face"

### DIFF
--- a/doc/InfiniTimeVision.md
+++ b/doc/InfiniTimeVision.md
@@ -17,7 +17,7 @@ InfiniTime is not to be used for medical or other health tracking purposes.
 - Easy and simple navigation
 - Behaviour should be predictable and easy to understand
 - Prefer solid default experience over customization
-- Personalization is achieved through custom watchfaces.
+- Personalization is achieved through custom watch faces.
   More options may be available through a companion app.
 - Use standard protocols and methods
 
@@ -25,7 +25,7 @@ InfiniTime is not to be used for medical or other health tracking purposes.
 
 The perfect version of InfiniTime would include:
 
-- Capability to sideload apps and watchfaces
+- Capability to sideload apps and watch faces
 - Only a minimal feature set in the flashed firmware.
   Users would add the features they want.
 - Ports to other devices

--- a/doc/MemoryAnalysis.md
+++ b/doc/MemoryAnalysis.md
@@ -245,7 +245,7 @@ void* __wrap_malloc(size_t size) {
 
 Now, your function `__wrap_malloc()` will be called instead of `malloc()`. You can call the actual malloc from the stdlib by calling `__real_malloc()`.
 
-Using this technique, I was able to trace all malloc calls at boot (boot -> digital watchface):
+Using this technique, I was able to trace all malloc calls at boot (boot -> digital watch face):
 
 - system task = 3464 bytes (SystemTask could potentially be declared as a global variable to avoid heap allocation here)
 - string music = 31 (maybe we should not use std::string when not needed, as it does heap allocation)

--- a/doc/gettingStarted/gettingStarted-1.0.md
+++ b/doc/gettingStarted/gettingStarted-1.0.md
@@ -8,7 +8,7 @@ It is highly recommended to update the firmware to the latest version when you r
 
 ### Setting the time
 
-By default, InfiniTime starts on the digital watchface. It'll probably display the epoch time (1 Jan 1970, 00:00).
+By default, InfiniTime starts on the digital watch face. It'll probably display the epoch time (1 Jan 1970, 00:00).
 
 You can sync the time using companion apps.
 
@@ -22,7 +22,7 @@ InfiniTime doesn't handle daylight savings automatically, so make sure to set th
 
 ### Digital watch face
 
-![Digital watch face](ui/watchface.jpg)
+![Digital watch face](ui/watch face.jpg)
 
 This is what the default digital watch face looks like. You can change watch faces in the settings.
 

--- a/doc/gettingStarted/gettingStarted-1.0.md
+++ b/doc/gettingStarted/gettingStarted-1.0.md
@@ -22,7 +22,7 @@ InfiniTime doesn't handle daylight savings automatically, so make sure to set th
 
 ### Digital watch face
 
-![Digital watch face](ui/watch face.jpg)
+![Digital watch face](ui/watchface.jpg)
 
 This is what the default digital watch face looks like. You can change watch faces in the settings.
 

--- a/doc/gettingStarted/updating-software.md
+++ b/doc/gettingStarted/updating-software.md
@@ -4,7 +4,7 @@ If you just want to flash or upgrade InfiniTime on your PineTime, this page is f
 
 ## Checking the version of InfiniTime
 
-You can check the InfiniTime version by first swiping right on the watchface to open quick settings, tapping the cogwheel to open settings, swipe up until you find an entry named "About" and tap on it.
+You can check the InfiniTime version by first swiping right on the watch face to open quick settings, tapping the cogwheel to open settings, swipe up until you find an entry named "About" and tap on it.
 
 ![InfiniTime 1.0 version](version-1.0.jpg)
 
@@ -35,7 +35,7 @@ Firmware updates must be manually validated. If the firmware isn't validated and
 
 You can validate your updated firmware on InfiniTime >= 1.0 by following this simple procedure:
 
-- From the watchface, swipe **right** to display the *quick settings menu*
+- From the watch face, swipe **right** to display the *quick settings menu*
 - Open settings by tapping the cogwheel on the bottom right
 - Swipe up until you find an entry named **Firmware** and tap on it
 - If the firmware is not validated yet, you can either validate the running firmware, or reset and revert to the previous firmware version

--- a/src/components/ble/weather/WeatherData.h
+++ b/src/components/ble/weather/WeatherData.h
@@ -239,7 +239,7 @@ namespace Pinetime {
        * In order to represent bursts of wind instead of constant wind,
        * you have minimum and maximum speeds.
        *
-       * As direction can fluctuate wildly and some watchfaces might wish to display it nicely,
+       * As direction can fluctuate wildly and some watch faces might wish to display it nicely,
        * we're following the aerospace industry weather report option of specifying a range.
        */
       class Wind : public TimelineHeader {
@@ -283,7 +283,7 @@ namespace Pinetime {
        * as it usually is, but it could change during a trip for ex.
        * so we allow changing it dynamically.
        *
-       * Location info can be for some kind of map watchface
+       * Location info can be for some kind of map watch face
        * or daylight calculations, should those be required.
        *
        */
@@ -331,7 +331,7 @@ namespace Pinetime {
        *
        * These events are a bit more complex because the topic is not simple,
        * the intention is to heavy-lift the annoying preprocessing from the watch
-       * this allows watchface or watchapp makers to generate accurate alerts and graphics
+       * this allows watch face or watchapp makers to generate accurate alerts and graphics
        *
        * If this needs further enforced standardization, pull requests are welcome
        */

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
- * PineTimeStyle watchface for Infinitime created by Kieran Cawthray
+ * PineTimeStyle watch face for Infinitime created by Kieran Cawthray
  * Based on WatchFaceDigital
  * Style/layout copied from TimeStyle for Pebble by Dan Tilden (github.com/tilden)
  */


### PR DESCRIPTION
Exact opposite of #1303 .

Before:
```bash
╰─$ grep -r "Watchface\|watchface"                                                                                                                                                                           130 ↵
doc/MemoryAnalysis.md:Using this technique, I was able to trace all malloc calls at boot (boot -> digital watchface):
doc/InfiniTimeVision.md:- Personalization is achieved through custom watchfaces.
doc/InfiniTimeVision.md:- Capability to sideload apps and watchfaces
doc/gettingStarted/updating-software.md:You can check the InfiniTime version by first swiping right on the watchface to open quick settings, tapping the cogwheel to open settings, swipe up until you find an entry named "About" and tap on it.
doc/gettingStarted/updating-software.md:- From the watchface, swipe **right** to display the *quick settings menu*
doc/gettingStarted/gettingStarted-1.0.md:By default, InfiniTime starts on the digital watchface. It'll probably display the epoch time (1 Jan 1970, 00:00).
doc/gettingStarted/gettingStarted-1.0.md:![Digital watch face](ui/watchface.jpg)
src/displayapp/screens/WatchFacePineTimeStyle.cpp: * PineTimeStyle watchface for Infinitime created by Kieran Cawthray
src/components/ble/weather/WeatherData.h:       * As direction can fluctuate wildly and some watchfaces might wish to display it nicely,
src/components/ble/weather/WeatherData.h:       * Location info can be for some kind of map watchface
src/components/ble/weather/WeatherData.h:       * this allows watchface or watchapp makers to generate accurate alerts and graphics
```
After:
```bash
╰─$ grep -ri "watch face"                                                                                                                                                                                    130 ↵
doc/MemoryAnalysis.md:Using this technique, I was able to trace all malloc calls at boot (boot -> digital watch face):
doc/InfiniTimeVision.md:- Personalization is achieved through custom watch faces.
doc/InfiniTimeVision.md:- Capability to sideload apps and watch faces
doc/gettingStarted/updating-software.md:You can check the InfiniTime version by first swiping right on the watch face to open quick settings, tapping the cogwheel to open settings, swipe up until you find an entry named "About" and tap on it.
doc/gettingStarted/updating-software.md:- From the watch face, swipe **right** to display the *quick settings menu*
doc/gettingStarted/gettingStarted-1.0.md:By default, InfiniTime starts on the digital watch face. It'll probably display the epoch time (1 Jan 1970, 00:00).
doc/gettingStarted/gettingStarted-1.0.md:### Digital watch face
doc/gettingStarted/gettingStarted-1.0.md:![Digital watch face](ui/watch face.jpg)
doc/gettingStarted/gettingStarted-1.0.md:This is what the default digital watch face looks like. You can change watch faces in the settings.
doc/gettingStarted/gettingStarted-1.0.md:- You can hold the button for a short time to return to the watch face. (version >1.7.0)
src/CMakeLists.txt:        ## Watch faces
src/displayapp/screens/WatchFacePineTimeStyle.cpp: * PineTimeStyle watch face for Infinitime created by Kieran Cawthray
src/displayapp/screens/settings/Settings.h:          {Symbols::home, "Watch face", Apps::SettingWatchFace},
src/displayapp/screens/settings/SettingWatchFace.cpp:  lv_label_set_text_static(title, "Watch face");
src/components/ble/weather/WeatherData.h:       * As direction can fluctuate wildly and some watch faces might wish to display it nicely,
src/components/ble/weather/WeatherData.h:       * Location info can be for some kind of map watch face
src/components/ble/weather/WeatherData.h:       * this allows watch face or watchapp makers to generate accurate alerts and graphics
```