### PR TITLE
Add support for BMA425's wrist-tilt interrupt (raise-to-wake)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -128,7 +128,7 @@ Standard: Latest
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
-TabWidth: 8
+TabWidth: 2
 UseCRLF: false
 UseTab: Never
 ...

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ Testing/Temporary/
 #build files
 src/nRF5_SDK_15.3.0_59ac345
 src/arm-none-eabi
+
+# clangd (VSCode)
+tags
+.cache

--- a/src/components/motion/MotionController.h
+++ b/src/components/motion/MotionController.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <drivers/Bma421.h>
 #include <components/ble/MotionService.h>
+#include <functional>
 
 namespace Pinetime {
   namespace Controllers {
@@ -36,9 +37,12 @@ namespace Pinetime {
         return currentTripSteps;
       }
 
+      bool shouldRaiseWake() const {
+        return callbackShouldRaiseWake();
+      }
+
       bool Should_ShakeWake(uint16_t thresh);
-      bool Should_RaiseWake(bool isSleeping);
-      int32_t currentShakeSpeed();
+      int32_t currentShakeSpeed() const;
       void IsSensorOk(bool isOk);
       bool IsSensorOk() const {
         return isSensorOk;
@@ -48,25 +52,37 @@ namespace Pinetime {
         return deviceType;
       }
 
-      void Init(Pinetime::Drivers::Bma421::DeviceTypes types);
+      void Init(Pinetime::Drivers::Bma421::DeviceTypes types, Pinetime::Drivers::Bma421* bma);
       void SetService(Pinetime::Controllers::MotionService* service);
 
     private:
-      uint32_t nbSteps;
+      uint32_t nbSteps = 0;
       uint32_t currentTripSteps = 0;
-      int16_t x;
-      int16_t y;
-      int16_t z;
+      int16_t x = 0;
+      int16_t y = 0;
+      int16_t z = 0;
       int16_t lastYForWakeUp = 0;
       bool isSensorOk = false;
       DeviceTypes deviceType = DeviceTypes::Unknown;
       Pinetime::Controllers::MotionService* service = nullptr;
+      Pinetime::Drivers::Bma421* bmaDriver = nullptr;
 
       int16_t lastXForShake = 0;
       int16_t lastYForShake = 0;
       int16_t lastZForShake = 0;
       int32_t accumulatedspeed = 0;
       uint32_t lastShakeTime = 0;
+
+      // Use the software check by default. Optionally, this can be overriden during runtime, without the SystemTask's knowledge.
+      // Using std::function will allow for changing the algorithm during runtime. This is better than having many if statements select the
+      // correct algorithm.
+      // Currently, this will be overridden if the BMA chip is a BMA425
+      std::function<bool()> callbackShouldRaiseWake = [this]() -> bool {
+        return Should_RaiseWake();
+      };
+
+      bool Should_RaiseWake();
+      bool BMA425ShouldRaiseWake() const;
     };
   }
 }

--- a/src/displayapp/screens/Motion.cpp
+++ b/src/displayapp/screens/Motion.cpp
@@ -28,13 +28,13 @@ Motion::Motion(Pinetime::Applications::DisplayApp* app, Controllers::MotionContr
   lv_chart_init_points(chart, ser3, 0);
   lv_chart_refresh(chart); /*Required after direct set*/
 
-  label = lv_label_create(lv_scr_act(), NULL);
+  label = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_fmt(label, "X #FF0000 %d# Y #00B000 %d# Z #FFFF00 %d#", 0, 0, 0);
   lv_label_set_align(label, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(label, NULL, LV_ALIGN_IN_TOP_MID, 0, 10);
+  lv_obj_align(label, nullptr, LV_ALIGN_IN_TOP_MID, 0, 10);
   lv_label_set_recolor(label, true);
 
-  labelStep = lv_label_create(lv_scr_act(), NULL);
+  labelStep = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_align(labelStep, chart, LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
   lv_label_set_text_static(labelStep, "Steps ---");
 
@@ -58,5 +58,5 @@ void Motion::Refresh() {
                         motionController.X() / 0x10,
                         motionController.Y() / 0x10,
                         motionController.Z() / 0x10);
-  lv_obj_align(label, NULL, LV_ALIGN_IN_TOP_MID, 0, 10);
+  lv_obj_align(label, nullptr, LV_ALIGN_IN_TOP_MID, 0, 10);
 }

--- a/src/drivers/Bma421.cpp
+++ b/src/drivers/Bma421.cpp
@@ -86,7 +86,6 @@ void Bma421::Init() {
   remap_data = {1, 0, 2, 1, 1, 1};
   ret = bma423_set_remap_axes(&remap_data, &bma);
   if (ret != BMA4_OK) {
-    remap_data = {0, 1, 2, 0, 0, 0};
     return;
   }
 

--- a/src/drivers/Bma421.cpp
+++ b/src/drivers/Bma421.cpp
@@ -1,20 +1,22 @@
 #include "drivers/Bma421.h"
+#include "drivers/Bma421_C/bma4.h"
 #include <libraries/delay/nrf_delay.h>
 #include <libraries/log/nrf_log.h>
 #include "drivers/TwiMaster.h"
 #include <drivers/Bma421_C/bma423.h>
+#include <cstdint>
 
 using namespace Pinetime::Drivers;
 
 namespace {
   int8_t user_i2c_read(uint8_t reg_addr, uint8_t* reg_data, uint32_t length, void* intf_ptr) {
-    auto bma421 = static_cast<Bma421*>(intf_ptr);
+    auto* bma421 = static_cast<Bma421*>(intf_ptr);
     bma421->Read(reg_addr, reg_data, length);
     return 0;
   }
 
   int8_t user_i2c_write(uint8_t reg_addr, const uint8_t* reg_data, uint32_t length, void* intf_ptr) {
-    auto bma421 = static_cast<Bma421*>(intf_ptr);
+    auto* bma421 = static_cast<Bma421*>(intf_ptr);
     bma421->Write(reg_addr, reg_data, length);
     return 0;
   }
@@ -35,9 +37,12 @@ Bma421::Bma421(TwiMaster& twiMaster, uint8_t twiAddress) : twiMaster {twiMaster}
 }
 
 void Bma421::Init() {
-  if (not isResetOk)
+  if (not isResetOk) {
     return; // Call SoftReset (and reset TWI device) first!
+  }
 
+  // Use a uint8_t to hold the feature flags, and enable all at once.
+  uint8_t features_to_enable = BMA423_STEP_CNTR;
   auto ret = bma423_init(&bma);
   if (ret != BMA4_OK)
     return;
@@ -62,19 +67,11 @@ void Bma421::Init() {
   if (ret != BMA4_OK)
     return;
 
-  ret = bma423_feature_enable(BMA423_STEP_CNTR, 1, &bma);
-  if (ret != BMA4_OK)
-    return;
-
-  ret = bma423_step_detector_enable(0, &bma);
-  if (ret != BMA4_OK)
-    return;
-
   ret = bma4_set_accel_enable(1, &bma);
   if (ret != BMA4_OK)
     return;
 
-  struct bma4_accel_config accel_conf;
+  struct bma4_accel_config accel_conf {};
   accel_conf.odr = BMA4_OUTPUT_DATA_RATE_100HZ;
   accel_conf.range = BMA4_ACCEL_RANGE_2G;
   accel_conf.bandwidth = BMA4_ACCEL_NORMAL_AVG4;
@@ -82,6 +79,33 @@ void Bma421::Init() {
   ret = bma4_set_accel_config(&accel_conf, &bma);
   if (ret != BMA4_OK)
     return;
+
+  // Remap the axes to the proper orientation. See datasheet for BMA425 for a diagram and more information.
+  // Remap depending on right or left hand. Currently set to left hand (which is {1, 0, 2, 1, 1, 1}).
+  // remap_data will be used for the BMA425's raise-to-wake interrupt, and for this driver's axes remap
+  remap_data = {1, 0, 2, 1, 1, 1};
+  ret = bma423_set_remap_axes(&remap_data, &bma);
+  if (ret != BMA4_OK) {
+    remap_data = {0, 1, 2, 0, 0, 0};
+    return;
+  }
+
+  // Enable the raise-to-wake interrupt on supported devices
+  if (deviceType == DeviceTypes::BMA425) {
+    features_to_enable |= BMA423_WRIST_WEAR;
+  }
+
+  // Enable all features at once
+  ret = bma423_feature_enable(features_to_enable, 1, &bma);
+  if (ret != BMA4_OK)
+    return;
+
+  // The interrupt map is needed for the interrupt flag to be set
+  if (deviceType == DeviceTypes::BMA425) {
+    ret = bma423_map_interrupt(BMA4_INTR1_MAP, BMA423_WRIST_WEAR_INT, BMA4_ENABLE, &bma);
+    if (ret != BMA4_OK)
+      return;
+  }
 
   isOk = true;
 }
@@ -100,24 +124,45 @@ void Bma421::Write(uint8_t registerAddress, const uint8_t* data, size_t size) {
 }
 
 Bma421::Values Bma421::Process() {
-  if (not isOk)
+  if (not isOk) {
     return {};
-  struct bma4_accel data;
+  }
+  struct bma4_accel data {};
   bma4_read_accel_xyz(&data, &bma);
 
   uint32_t steps = 0;
   bma423_step_counter_output(&steps, &bma);
 
-  int32_t temperature;
+  int32_t temperature = 0;
   bma4_get_temperature(&temperature, BMA4_DEG, &bma);
   temperature = temperature / 1000;
 
   uint8_t activity = 0;
   bma423_activity_output(&activity, &bma);
 
-  // X and Y axis are swapped because of the way the sensor is mounted in the PineTime
-  return {steps, data.y, data.x, data.z};
+  if (deviceType == DeviceTypes::BMA425) {
+    uint16_t status = 0;
+
+    // bma4_read_int_status_0 clears all the interrupts, if any other interrupts are needed, this will have to be refactored
+    bma423_read_int_status(&status, &bma);
+    if (((status & BMA423_WRIST_WEAR_INT) != 0) && !wristTiltInterrupt) {
+      wristTiltInterrupt = true;
+    }
+  }
+
+  // Format the data for remapping
+  int16_t accel_data[3];
+  accel_data[0] = data.x;
+  accel_data[1] = data.y;
+  accel_data[2] = data.z;
+
+  // Use the remap data to remap the axes and remap the signs
+  return {steps,
+          static_cast<int16_t>(accel_data[remap_data.x_axis] * (-1 * remap_data.x_axis_sign)),
+          static_cast<int16_t>(accel_data[remap_data.y_axis] * (-1 * remap_data.x_axis_sign)),
+          static_cast<int16_t>(accel_data[remap_data.z_axis] * (-1 * remap_data.x_axis_sign))};
 }
+
 bool Bma421::IsOk() const {
   return isOk;
 }

--- a/src/drivers/Bma421.h
+++ b/src/drivers/Bma421.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <drivers/Bma421_C/bma4_defs.h>
+#include <drivers/Bma421_C/bma423.h>
 
 namespace Pinetime {
   namespace Drivers {
@@ -32,15 +33,28 @@ namespace Pinetime {
       bool IsOk() const;
       DeviceTypes DeviceType() const;
 
+      bool getAndClearWristTiltInterrupt() {
+        bool tmp = wristTiltInterrupt;
+        wristTiltInterrupt = false;
+        return tmp;
+      }
+
+      void clearWristTiltInterrupt() {
+        wristTiltInterrupt = false;
+      }
+
     private:
       void Reset();
 
       TwiMaster& twiMaster;
       uint8_t deviceAddress = 0x18;
-      struct bma4_dev bma;
+      struct bma4_dev bma {};
       bool isOk = false;
       bool isResetOk = false;
+      bool wristTiltInterrupt = false;
       DeviceTypes deviceType = DeviceTypes::Unknown;
+      // Default mapping
+      bma423_axes_remap remap_data = {0, 1, 2, 0, 0, 0};
     };
   }
 }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -157,7 +157,7 @@ void SystemTask::Work() {
   twiMaster.Init();
 
   motionSensor.Init();
-  motionController.Init(motionSensor.DeviceType());
+  motionController.Init(motionSensor.DeviceType(), &motionSensor);
   settingsController.Init();
 
   displayApp.Register(this);
@@ -488,7 +488,7 @@ void SystemTask::UpdateMotion() {
 
   if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep) {
     if ((settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist) &&
-         motionController.Should_RaiseWake(state == SystemTaskState::Sleeping)) ||
+         motionController.shouldRaiseWake()) ||
         (settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::Shake) &&
          motionController.Should_ShakeWake(settingsController.GetShakeThreshold()))) {
       GoToRunning();


### PR DESCRIPTION
This pull request is for adding support for the BMA425's wrist-tilt or raise-to-wake functionality. I have tested this on a PineTime Dev kit and have found no issues to far. The code will automatically use the interrupt if the device has a BMA425, and have no change for a BMA421 (untested). This behavior can be changed pretty easily with a checkbox/toggle. The software fallback for the raise-to-wake and shake-to-wake are still working with the fix mentioned above. 

I have not tested this code on a sealed device, or even on my wrist, but from what I can tell should work fine. 
I understand this will probably interfere with other efforts to improve the BMA421's code (such as #826).

------

Code breaking change
> The axes were remapped in the BMA425, and driver code.
> I have updated the software raise-to-wake and shake-to-wake to use the proper axes.
> The quick fix for using the remapped axes, it just to invert the sign. (Use -x, -y, & -z instead of x, y, & z)


### Change log:
SystemTask.cpp
- Added motionSensor as an argument to motionController's Init()
- Call shouldRaiseWake instead of Should_RaiseWake when deciding to wake up

Bma421.cpp and .h
- Fixed clang-format and initialization issues
- Added wristTiltInterrupt flag for raise-to-wake functionality
- Refactored Bma421::Init() to better match Bosch's example code.
  - Removed redundant step_detector_enable call. Step counting functionality appears to still be working.
  - Refactored all bma423_feature_enable calls to 1 function call
- Remapped BMA425's axes for proper raise-to-wake functionality.
  - Also remapped the axes in driver-space
  - The remap can be done in runtime, which allows for remapping of the right and left hand.
- Enabled BMA425's wrist-tilt feature and interrupt for raise-to-wake functionality

MotionController.cpp and .h
- Fixed clang-format errors
- Added shouldRaiseWake which executes a callback function for the desired raise-to-wake algorithm.
  - This was done so that the call back can be changed transparently in the driver during runtime.
- Added a reference to Drivers::BMA421 in the constructor
  - I believe MotionController should completely encapsulate the BMA421 object. This can be discussed later.
- Created separate function for software raise-to-wake and the BMA425's interrupt
- Updated the software raise-to-wake and shake-to-wake to use the correct axes since they are now remapped.