### PR TITLE
Vibration scheduler

### DIFF
--- a/src/components/alarm/AlarmController.cpp
+++ b/src/components/alarm/AlarmController.cpp
@@ -104,5 +104,5 @@ void AlarmController::StopAlerting() {
     // set next instance
     ScheduleAlarm();
   }
-  systemTask->PushMessage(System::Messages::StopRinging);
+  systemTask->PushMessage(System::Messages::StopAlarm);
 }

--- a/src/components/motor/MotorController.cpp
+++ b/src/components/motor/MotorController.cpp
@@ -42,11 +42,12 @@ void MotorController::StopRinging() {
 }
 
 void MotorController::StopMotor(TimerHandle_t xTimer) {
+  auto* motorController = static_cast<MotorController*>(pvTimerGetTimerID(xTimer));
   nrf_gpio_pin_set(PinMap::Motor);
-  isShortVibrating = false;
-  if (!IsVibrating()) {
+  motorController->isShortVibrating = false;
+  if (!motorController->IsVibrating()) {
     // current vibration pattern is over, so check for next one
-    Update();
+    motorController->Update();
   }
 }
 

--- a/src/components/motor/MotorController.cpp
+++ b/src/components/motor/MotorController.cpp
@@ -9,7 +9,7 @@ void MotorController::Init() {
   nrf_gpio_cfg_output(PinMap::Motor);
   nrf_gpio_pin_set(PinMap::Motor);
 
-  shortVib = xTimerCreate("shortVib", 1, pdFALSE, nullptr, StopMotor);
+  shortVib = xTimerCreate("shortVib", 1, pdFALSE, this, StopMotor);
   longVib = xTimerCreate("longVib", pdMS_TO_TICKS(1000), pdTRUE, this, Ring);
 }
 
@@ -20,11 +20,13 @@ void MotorController::Ring(TimerHandle_t xTimer) {
 
 void MotorController::RunForDuration(uint8_t motorDuration) {
   if (xTimerChangePeriod(shortVib, pdMS_TO_TICKS(motorDuration), 0) == pdPASS && xTimerStart(shortVib, 0) == pdPASS) {
+    isShortVibrating = true;
     nrf_gpio_pin_clear(PinMap::Motor);
   }
 }
 
 void MotorController::StartRinging() {
+  isLongVibrating = true;
   RunForDuration(50);
   xTimerStart(longVib, 0);
 }
@@ -32,8 +34,75 @@ void MotorController::StartRinging() {
 void MotorController::StopRinging() {
   xTimerStop(longVib, 0);
   nrf_gpio_pin_set(PinMap::Motor);
+  isLongVibrating = false;
+  if (!IsVibrating()) {
+    // current vibration pattern is over, so check for next one
+    Update();
+  }
 }
 
 void MotorController::StopMotor(TimerHandle_t xTimer) {
   nrf_gpio_pin_set(PinMap::Motor);
+  isShortVibrating = false;
+  if (!IsVibrating()) {
+    // current vibration pattern is over, so check for next one
+    Update();
+  }
 }
+
+void MotorController::Update() {
+  if (IsVibrating())
+    return;
+
+  if (phoneCallIsActive) {
+    // ring phone call
+
+  } else if (timerIsActive) {
+    // ring timer
+  } else if (alarmIsActive) {
+    // ring alarm
+  } else if (notificationIsActive) {
+    // ring notification
+  }
+}
+
+void MotorController::SingleVibration(uint8_t Duration) {
+  if (IsVibrating()) {
+    return;
+  }
+  RunForDuration(Duration);
+}
+
+void MotorController::ActivatePhoneCall() {
+  phoneCallIsActive = true;
+  Update();
+};
+
+void MotorController::ActivateTimer() {
+  timerIsActive = true;
+  Update();
+};
+
+void MotorController::ActivateAlarm() {
+  alarmIsActive = true;
+  Update();
+};
+
+void MotorController::ActivateNotification() {
+  notificationIsActive = true;
+  Update();
+};
+
+void MotorController::DeactivatePhoneCall() {
+  phoneCallIsActive = false;
+  Update();
+};
+void MotorController::DeactivateTimer() {
+  timerIsActive = false;
+  Update();
+};
+
+void MotorController::DeactivateAlarm() {
+  alarmIsActive = false;
+  Update();
+};

--- a/src/components/motor/MotorController.h
+++ b/src/components/motor/MotorController.h
@@ -12,15 +12,40 @@ namespace Pinetime {
       MotorController() = default;
 
       void Init();
+
+      void SingleVibration(uint8_t Duration);
+
+      bool IsVibrating() {
+        return isShortVibrating || isLongVibrating;
+      };
+
+      void ActivatePhoneCall();
+      void ActivateTimer();
+      void ActivateAlarm();
+      void ActivateNotification();
+
+      void DeactivatePhoneCall();
+      void DeactivateTimer();
+      void DeactivateAlarm();
+
+    private:
+      void Update();
       void RunForDuration(uint8_t motorDuration);
       void StartRinging();
       void StopRinging();
-
-    private:
+      
       static void Ring(TimerHandle_t xTimer);
       static void StopMotor(TimerHandle_t xTimer);
       TimerHandle_t shortVib;
       TimerHandle_t longVib;
+
+      bool isShortVibrating = false;
+      bool isLongVibrating = false;
+      
+      bool phoneCallIsActive = false;
+      bool timerIsActive = false;
+      bool alarmIsActive = false;
+      bool notificationIsActive = false;
     };
   }
 }

--- a/src/displayapp/screens/InfiniPaint.cpp
+++ b/src/displayapp/screens/InfiniPaint.cpp
@@ -54,7 +54,7 @@ bool InfiniPaint::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
       }
 
       std::fill(b, b + bufferSize, selectColor);
-      motor.RunForDuration(35);
+      motor.SingleVibration(35);
       return true;
     default:
       return true;

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -82,9 +82,9 @@ void Metronome::Refresh() {
       counter--;
       if (counter == 0) {
         counter = bpb;
-        motorController.RunForDuration(90);
+        motorController.SingleVibration(90);
       } else {
-        motorController.RunForDuration(30);
+        motorController.SingleVibration(30);
       }
     }
   }

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -42,9 +42,9 @@ Notifications::Notifications(DisplayApp* app,
   if (mode == Modes::Preview) {
     systemTask.PushMessage(System::Messages::DisableSleeping);
     if (notification.category == Controllers::NotificationManager::Categories::IncomingCall) {
-      motorController.StartRinging();
+      motorController.ActivatePhoneCall();
     } else {
-      motorController.RunForDuration(35);
+      motorController.ActivateNotification();
     }
 
     timeoutLine = lv_line_create(lv_scr_act(), nullptr);
@@ -63,8 +63,6 @@ Notifications::Notifications(DisplayApp* app,
 
 Notifications::~Notifications() {
   lv_task_del(taskRefresh);
-  // make sure we stop any vibrations before exiting
-  motorController.StopRinging();
   systemTask.PushMessage(System::Messages::EnableSleeping);
   lv_obj_clean(lv_scr_act());
 }
@@ -119,7 +117,6 @@ void Notifications::Refresh() {
 
 void Notifications::OnPreviewInteraction() {
   systemTask.PushMessage(System::Messages::EnableSleeping);
-  motorController.StopRinging();
   if (timeoutLine != nullptr) {
     lv_obj_del(timeoutLine);
     timeoutLine = nullptr;
@@ -343,7 +340,7 @@ void Notifications::NotificationItem::OnCallButtonEvent(lv_obj_t* obj, lv_event_
     return;
   }
 
-  motorController.StopRinging();
+  motorController.DeactivatePhoneCall();
 
   if (obj == bt_accept) {
     alertNotificationService.AcceptIncomingCall();

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -158,7 +158,7 @@ void QuickSettings::OnButtonEvent(lv_obj_t* object) {
       settingsController.SetNotificationStatus(Controllers::Settings::Notification::On);
       lv_label_set_text_static(btn3_lvl, Symbols::notificationsOn);
       lv_obj_set_state(btn3, static_cast<lv_state_t>(ButtonState::NotificationsOn));
-      motorController.RunForDuration(35);
+      motorController.SingleVibration(35);
     }
 
   } else if (object == btn4) {

--- a/src/systemtask/Messages.h
+++ b/src/systemtask/Messages.h
@@ -26,7 +26,7 @@ namespace Pinetime {
       OnChargingEvent,
       OnPairing,
       SetOffAlarm,
-      StopRinging,
+      StopAlarm,
       MeasureBatteryTimerExpired,
       BatteryPercentageUpdated,
       StartFileTransfer,

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -294,18 +294,18 @@ void SystemTask::Work() {
           if (state == SystemTaskState::Sleeping) {
             GoToRunning();
           }
-          motorController.RunForDuration(35);
+          motorController.ActivateTimer();
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::TimerDone);
           break;
         case Messages::SetOffAlarm:
           if (state == SystemTaskState::Sleeping) {
             GoToRunning();
           }
-          motorController.StartRinging();
+          motorController.ActivateAlarm();
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::AlarmTriggered);
           break;
-        case Messages::StopRinging:
-          motorController.StopRinging();
+        case Messages::StopAlarm:
+          motorController.DeactivateAlarm();
           break;
         case Messages::BleConnected:
           ReloadIdleTimer();
@@ -396,7 +396,7 @@ void SystemTask::Work() {
               GoToRunning();
               displayApp.PushMessage(Pinetime::Applications::Display::Messages::Clock);
             }
-            motorController.RunForDuration(35);
+            motorController.SingleVibration(35);
           }
           break;
         case Messages::OnNewHalfHour:
@@ -408,12 +408,12 @@ void SystemTask::Work() {
               GoToRunning();
               displayApp.PushMessage(Pinetime::Applications::Display::Messages::Clock);
             }
-            motorController.RunForDuration(35);
+            motorController.SingleVibration(35);
           }
           break;
         case Messages::OnChargingEvent:
           batteryController.ReadPowerState();
-          motorController.RunForDuration(15);
+          motorController.SingleVibration(15);
           ReloadIdleTimer();
           if (state == SystemTaskState::Sleeping) {
             GoToRunning();
@@ -429,7 +429,7 @@ void SystemTask::Work() {
           if (state == SystemTaskState::Sleeping) {
             GoToRunning();
           }
-          motorController.RunForDuration(35);
+          motorController.SingleVibration(35);
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::ShowPairingKey);
           break;
         case Messages::BleRadioEnableToggle:


### PR DESCRIPTION
This PR aims to solve #1223 .
It implements intermediate logic between the motor controller and the rest of the system.
The main goal is to prevent simutaneously activation of vibrations.
The side effects of the old behaviour seem to be weird strong vibrations and vibrations cancelling themselves out.

This implementations exposes the following API on the `MotorController`:
`ActivatePhoneCall`, `ActivateTimer`, `ActivateAlarm`, `ActivateNotification` to mark the different vibrations as something that has to happen.
`DeactivatePhoneCall`, `DeactivateTimer`, `DeactivateAlarm` to mark the vibrations as being over.
`SingleVibration` to trigger a vibration for in-app use (eg. metronome). The single vibration is skipped, when another vibration is already happening.

The activated vibrations are handles according to their priority. The priorities from high to low are:
1. phone call
2. timer
3. alarm
4. notification

The active one with the highest priority is run. When it is over, the next highest one is run afterwards. This ensures that none of them is lost.

In the `Update` function, we can also define custom durations/pattern for each of the vibrations, such that they can be easier distinguished.

TODO:
- [] Are chimes as single vibration ok?
- [] Test this code.