### PR TITLE
AlarmController: Add saving alarm time to file

### DIFF
--- a/src/components/alarm/AlarmController.cpp
+++ b/src/components/alarm/AlarmController.cpp
@@ -136,33 +136,35 @@ void AlarmController::SetRecurrence(RecurType recurrence) {
 }
 
 void AlarmController::LoadAlarmFromFile() {
-  lfs_file_t file;
-  AlarmData buffer;
+  lfs_file_t alarmFile;
+  AlarmData alarmBuffer;
 
-  if (fs.FileOpen(&file, "/alarm.dat", LFS_O_RDONLY) != LFS_ERR_OK) {
+  if (fs.FileOpen(&alarmFile, "/alarm.dat", LFS_O_RDONLY) != LFS_ERR_OK) {
     NRF_LOG_WARNING("[AlarmController] Failed to open alarm data file");
     return;
   }
 
-  fs.FileRead(&file, reinterpret_cast<uint8_t*>(&buffer), sizeof buffer);
-  fs.FileClose(&file);
-  if (buffer.version != alarmFormatVersion) {
-    NRF_LOG_WARNING("[AlarmController] Loaded alarm data has version %u instead of %u, discarding", buffer.version, alarmFormatVersion);
+  fs.FileRead(&alarmFile, reinterpret_cast<uint8_t*>(&alarmBuffer), sizeof(alarmBuffer));
+  fs.FileClose(&alarmFile);
+  if (alarmBuffer.version != alarmFormatVersion) {
+    NRF_LOG_WARNING("[AlarmController] Loaded alarm data has version %u instead of %u, discarding",
+                    alarmBuffer.version,
+                    alarmFormatVersion);
     return;
   }
 
-  alarm = buffer;
+  alarm = alarmBuffer;
   NRF_LOG_INFO("[AlarmController] Loaded alarm data from file");
 }
 
 void AlarmController::SaveAlarmToFile() {
-  lfs_file_t file;
-  if (fs.FileOpen(&file, "/alarm.dat", LFS_O_WRONLY | LFS_O_CREAT) != LFS_ERR_OK) {
+  lfs_file_t alarmFile;
+  if (fs.FileOpen(&alarmFile, "/alarm.dat", LFS_O_WRONLY | LFS_O_CREAT) != LFS_ERR_OK) {
     NRF_LOG_WARNING("[AlarmController] Failed to open alarm data file for saving");
     return;
   }
 
-  fs.FileWrite(&file, reinterpret_cast<uint8_t*>(&alarm), sizeof alarm);
-  fs.FileClose(&file);
+  fs.FileWrite(&alarmFile, reinterpret_cast<uint8_t*>(&alarm), sizeof(alarm));
+  fs.FileClose(&alarmFile);
   NRF_LOG_INFO("[AlarmController] Saved alarm data with format version %u to file", alarm.version);
 }

--- a/src/components/alarm/AlarmController.cpp
+++ b/src/components/alarm/AlarmController.cpp
@@ -37,13 +37,20 @@ namespace {
 
 void AlarmController::Init(System::SystemTask* systemTask) {
   this->systemTask = systemTask;
-  LoadAlarmFromFile();
   alarmTimer = xTimerCreate("Alarm", 1, pdFALSE, this, SetOffAlarm);
+  LoadAlarmFromFile();
+  if (alarm.isEnabled) {
+    NRF_LOG_INFO("[AlarmController] Loaded alarm was enabled, scheduling");
+    ScheduleAlarm();
+  }
 }
 
 void AlarmController::SetAlarmTime(uint8_t alarmHr, uint8_t alarmMin) {
-  hours = alarmHr;
-  minutes = alarmMin;
+  if (alarm.hours == alarmHr && alarm.minutes == alarmMin) {
+    return;
+  }
+  alarm.hours = alarmHr;
+  alarm.minutes = alarmMin;
   SaveAlarmToFile();
 }
 
@@ -57,18 +64,19 @@ void AlarmController::ScheduleAlarm() {
   tm* tmAlarmTime = std::localtime(&ttAlarmTime);
 
   // If the time being set has already passed today,the alarm should be set for tomorrow
-  if (hours < dateTimeController.Hours() || (hours == dateTimeController.Hours() && minutes <= dateTimeController.Minutes())) {
+  if (alarm.hours < dateTimeController.Hours() ||
+      (alarm.hours == dateTimeController.Hours() && alarm.minutes <= dateTimeController.Minutes())) {
     tmAlarmTime->tm_mday += 1;
     // tm_wday doesn't update automatically
     tmAlarmTime->tm_wday = (tmAlarmTime->tm_wday + 1) % 7;
   }
 
-  tmAlarmTime->tm_hour = hours;
-  tmAlarmTime->tm_min = minutes;
+  tmAlarmTime->tm_hour = alarm.hours;
+  tmAlarmTime->tm_min = alarm.minutes;
   tmAlarmTime->tm_sec = 0;
 
   // if alarm is in weekday-only mode, make sure it shifts to the next weekday
-  if (recurrence == RecurType::Weekdays) {
+  if (alarm.recurrence == RecurType::Weekdays) {
     if (tmAlarmTime->tm_wday == 0) { // Sunday, shift 1 day
       tmAlarmTime->tm_mday += 1;
     } else if (tmAlarmTime->tm_wday == 6) { // Saturday, shift 2 days
@@ -83,7 +91,10 @@ void AlarmController::ScheduleAlarm() {
   xTimerChangePeriod(alarmTimer, secondsToAlarm * configTICK_RATE_HZ, 0);
   xTimerStart(alarmTimer, 0);
 
-  state = AlarmState::Set;
+  if (!alarm.isEnabled) {
+    alarm.isEnabled = true;
+    SaveAlarmToFile();
+  }
 }
 
 uint32_t AlarmController::SecondsToAlarm() {
@@ -92,23 +103,36 @@ uint32_t AlarmController::SecondsToAlarm() {
 
 void AlarmController::DisableAlarm() {
   xTimerStop(alarmTimer, 0);
-  state = AlarmState::Not_Set;
+  isAlerting = false;
+  if (alarm.isEnabled) {
+    alarm.isEnabled = false;
+    SaveAlarmToFile();
+  }
 }
 
 void AlarmController::SetOffAlarmNow() {
-  state = AlarmState::Alerting;
+  isAlerting = true;
   systemTask->PushMessage(System::Messages::SetOffAlarm);
 }
 
 void AlarmController::StopAlerting() {
-  // Alarm state is off unless this is a recurring alarm
-  if (recurrence == RecurType::None) {
-    state = AlarmState::Not_Set;
+  isAlerting = false;
+  // Disable alarm unless it is recurring
+  if (alarm.recurrence == RecurType::None) {
+    alarm.isEnabled = false;
+    SaveAlarmToFile();
   } else {
     // set next instance
     ScheduleAlarm();
   }
   systemTask->PushMessage(System::Messages::StopRinging);
+}
+
+void AlarmController::SetRecurrence(RecurType recurrence) {
+  if (alarm.recurrence != recurrence) {
+    alarm.recurrence = recurrence;
+    SaveAlarmToFile();
+  }
 }
 
 void AlarmController::LoadAlarmFromFile() {
@@ -127,21 +151,18 @@ void AlarmController::LoadAlarmFromFile() {
     return;
   }
 
-  hours = buffer.hours;
-  minutes = buffer.minutes;
+  alarm = buffer;
   NRF_LOG_INFO("[AlarmController] Loaded alarm data from file");
 }
 
 void AlarmController::SaveAlarmToFile() {
   lfs_file_t file;
-  AlarmData buffer = {.version = alarmFormatVersion, .hours = hours, .minutes = minutes};
-
   if (fs.FileOpen(&file, "/alarm.dat", LFS_O_WRONLY | LFS_O_CREAT) != LFS_ERR_OK) {
     NRF_LOG_WARNING("[AlarmController] Failed to open alarm data file for saving");
     return;
   }
 
-  fs.FileWrite(&file, reinterpret_cast<uint8_t*>(&buffer), sizeof buffer);
+  fs.FileWrite(&file, reinterpret_cast<uint8_t*>(&alarm), sizeof alarm);
   fs.FileClose(&file);
-  NRF_LOG_INFO("[AlarmController] Saved alarm data with format version %u to file", buffer.version);
+  NRF_LOG_INFO("[AlarmController] Saved alarm data with format version %u to file", alarm.version);
 }

--- a/src/components/alarm/AlarmController.h
+++ b/src/components/alarm/AlarmController.h
@@ -38,23 +38,23 @@ namespace Pinetime {
       void SetOffAlarmNow();
       uint32_t SecondsToAlarm();
       void StopAlerting();
-      enum class AlarmState { Not_Set, Set, Alerting };
       enum class RecurType { None, Daily, Weekdays };
       uint8_t Hours() const {
-        return hours;
+        return alarm.hours;
       }
       uint8_t Minutes() const {
-        return minutes;
+        return alarm.minutes;
       }
-      AlarmState State() const {
-        return state;
+      bool IsAlerting() const {
+        return isAlerting;
+      }
+      bool IsEnabled() const {
+        return alarm.isEnabled;
       }
       RecurType Recurrence() const {
-        return recurrence;
+        return alarm.recurrence;
       }
-      void SetRecurrence(RecurType recurType) {
-        recurrence = recurType;
-      }
+      void SetRecurrence(RecurType recurrence);
 
     private:
       static constexpr uint8_t alarmFormatVersion = 1;
@@ -62,17 +62,17 @@ namespace Pinetime {
         uint8_t version = alarmFormatVersion;
         uint8_t hours = 7;
         uint8_t minutes = 0;
+        RecurType recurrence = RecurType::None;
+        bool isEnabled = false;
       };
+      bool isAlerting = false;
 
       Controllers::DateTime& dateTimeController;
       Controllers::FS& fs;
       System::SystemTask* systemTask = nullptr;
       TimerHandle_t alarmTimer;
-      uint8_t hours = 7;
-      uint8_t minutes = 0;
+      AlarmData alarm;
       std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> alarmTime;
-      AlarmState state = AlarmState::Not_Set;
-      RecurType recurrence = RecurType::None;
 
       void LoadAlarmFromFile();
       void SaveAlarmToFile();

--- a/src/components/alarm/AlarmController.h
+++ b/src/components/alarm/AlarmController.h
@@ -57,6 +57,8 @@ namespace Pinetime {
       void SetRecurrence(RecurType recurrence);
 
     private:
+      // Versions 255 is reserved for now, so the version field can be made
+      // bigger, should it ever be needed.
       static constexpr uint8_t alarmFormatVersion = 1;
       struct AlarmData {
         uint8_t version = alarmFormatVersion;

--- a/src/components/alarm/AlarmController.h
+++ b/src/components/alarm/AlarmController.h
@@ -29,7 +29,7 @@ namespace Pinetime {
   namespace Controllers {
     class AlarmController {
     public:
-      AlarmController(Controllers::DateTime& dateTimeController);
+      AlarmController(Controllers::DateTime& dateTimeController, Controllers::FS& fs);
 
       void Init(System::SystemTask* systemTask);
       void SetAlarmTime(uint8_t alarmHr, uint8_t alarmMin);
@@ -57,7 +57,15 @@ namespace Pinetime {
       }
 
     private:
+      static constexpr uint8_t alarmFormatVersion = 1;
+      struct AlarmData {
+        uint8_t version = alarmFormatVersion;
+        uint8_t hours = 7;
+        uint8_t minutes = 0;
+      };
+
       Controllers::DateTime& dateTimeController;
+      Controllers::FS& fs;
       System::SystemTask* systemTask = nullptr;
       TimerHandle_t alarmTimer;
       uint8_t hours = 7;
@@ -65,6 +73,9 @@ namespace Pinetime {
       std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> alarmTime;
       AlarmState state = AlarmState::Not_Set;
       RecurType recurrence = RecurType::None;
+
+      void LoadAlarmFromFile();
+      void SaveAlarmToFile();
     };
   }
 }

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -63,7 +63,6 @@ Alarm::Alarm(DisplayApp* app,
   minuteCounter.Create();
   lv_obj_align(minuteCounter.GetObject(), nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
   minuteCounter.SetValue(alarmController.Minutes());
-
   minuteCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
 
   lv_obj_t* colonLabel = lv_label_create(lv_scr_act(), nullptr);

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -46,6 +46,9 @@ Alarm::Alarm(DisplayApp* app,
              System::SystemTask& systemTask)
   : Screen(app), alarmController {alarmController}, systemTask {systemTask} {
 
+  hours = alarmController.Hours();
+  minutes = alarmController.Minutes();
+
   hourCounter.Create();
   lv_obj_align(hourCounter.GetObject(), nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 0);
   if (clockType == Controllers::Settings::ClockType::H12) {
@@ -57,12 +60,12 @@ Alarm::Alarm(DisplayApp* app,
     lv_label_set_align(lblampm, LV_LABEL_ALIGN_CENTER);
     lv_obj_align(lblampm, lv_scr_act(), LV_ALIGN_CENTER, 0, 30);
   }
-  hourCounter.SetValue(alarmController.Hours());
+  hourCounter.SetValue(hours);
   hourCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
 
   minuteCounter.Create();
   lv_obj_align(minuteCounter.GetObject(), nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
-  minuteCounter.SetValue(alarmController.Minutes());
+  minuteCounter.SetValue(minutes);
   minuteCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
 
   lv_obj_t* colonLabel = lv_label_create(lv_scr_act(), nullptr);
@@ -124,6 +127,7 @@ Alarm::~Alarm() {
   if (alarmController.IsAlerting()) {
     StopAlerting();
   }
+  alarmController.SetAlarmTime(hours, minutes);
   lv_obj_clean(lv_scr_act());
 }
 
@@ -150,6 +154,7 @@ void Alarm::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
     }
     if (obj == enableSwitch) {
       if (lv_switch_get_state(enableSwitch)) {
+        alarmController.SetAlarmTime(hours, minutes);
         alarmController.ScheduleAlarm();
       } else {
         alarmController.DisableAlarm();
@@ -193,7 +198,8 @@ void Alarm::UpdateAlarmTime() {
       lv_label_set_text_static(lblampm, "AM");
     }
   }
-  alarmController.SetAlarmTime(hourCounter.GetValue(), minuteCounter.GetValue());
+  hours = hourCounter.GetValue();
+  minutes = minuteCounter.GetValue();
 }
 
 void Alarm::SetAlerting() {

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -46,6 +46,9 @@ Alarm::Alarm(DisplayApp* app,
              System::SystemTask& systemTask)
   : Screen(app), alarmController {alarmController}, systemTask {systemTask} {
 
+  hours = alarmController.Hours();
+  minutes = alarmController.Minutes();
+
   hourCounter.Create();
   lv_obj_align(hourCounter.GetObject(), nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 0);
   if (clockType == Controllers::Settings::ClockType::H12) {
@@ -57,12 +60,12 @@ Alarm::Alarm(DisplayApp* app,
     lv_label_set_align(lblampm, LV_LABEL_ALIGN_CENTER);
     lv_obj_align(lblampm, lv_scr_act(), LV_ALIGN_CENTER, 0, 30);
   }
-  hourCounter.SetValue(alarmController.Hours());
+  hourCounter.SetValue(hours);
   hourCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
 
   minuteCounter.Create();
   lv_obj_align(minuteCounter.GetObject(), nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
-  minuteCounter.SetValue(alarmController.Minutes());
+  minuteCounter.SetValue(minutes);
   minuteCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
 
   lv_obj_t* colonLabel = lv_label_create(lv_scr_act(), nullptr);
@@ -121,6 +124,7 @@ Alarm::Alarm(DisplayApp* app,
 }
 
 Alarm::~Alarm() {
+  alarmController.SetAlarmTime(hours, minutes);
   if (alarmController.State() == AlarmController::AlarmState::Alerting) {
     StopAlerting();
   }
@@ -150,6 +154,7 @@ void Alarm::OnButtonEvent(lv_obj_t* obj, lv_event_t event) {
     }
     if (obj == enableSwitch) {
       if (lv_switch_get_state(enableSwitch)) {
+        alarmController.SetAlarmTime(hours, minutes);
         alarmController.ScheduleAlarm();
       } else {
         alarmController.DisableAlarm();
@@ -181,6 +186,11 @@ bool Alarm::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
 }
 
 void Alarm::OnValueChanged() {
+  // Watch out when removing the next line! The selected time is only sent
+  // to the AlarmController when enabling the toggle and when closing the
+  // alarm app, to avoid excessive writes to flash. That means when changing
+  // the time and leaving the app open, the AlarmController is not yet aware
+  // of the new time and will ring on the previously set time.
   DisableAlarm();
   UpdateAlarmTime();
 }
@@ -193,7 +203,8 @@ void Alarm::UpdateAlarmTime() {
       lv_label_set_text_static(lblampm, "AM");
     }
   }
-  alarmController.SetAlarmTime(hourCounter.GetValue(), minuteCounter.GetValue());
+  hours = hourCounter.GetValue();
+  minutes = minuteCounter.GetValue();
 }
 
 void Alarm::SetAlerting() {

--- a/src/displayapp/screens/Alarm.h
+++ b/src/displayapp/screens/Alarm.h
@@ -44,6 +44,9 @@ namespace Pinetime {
         Controllers::AlarmController& alarmController;
         System::SystemTask& systemTask;
 
+        uint8_t hours = 0;
+        uint8_t minutes = 0;
+
         lv_obj_t *btnStop, *txtStop, *btnRecur, *txtRecur, *btnInfo, *enableSwitch;
         lv_obj_t* lblampm = nullptr;
         lv_obj_t* txtMessage = nullptr;

--- a/src/displayapp/screens/Alarm.h
+++ b/src/displayapp/screens/Alarm.h
@@ -44,9 +44,6 @@ namespace Pinetime {
         Controllers::AlarmController& alarmController;
         System::SystemTask& systemTask;
 
-        uint8_t hours = 0;
-        uint8_t minutes = 0;
-
         lv_obj_t *btnStop, *txtStop, *btnRecur, *txtRecur, *btnInfo, *enableSwitch;
         lv_obj_t* lblampm = nullptr;
         lv_obj_t* txtMessage = nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,7 +111,7 @@ Pinetime::Drivers::WatchdogView watchdogView(watchdog);
 Pinetime::Controllers::NotificationManager notificationManager;
 Pinetime::Controllers::MotionController motionController;
 Pinetime::Controllers::TimerController timerController;
-Pinetime::Controllers::AlarmController alarmController {dateTimeController};
+Pinetime::Controllers::AlarmController alarmController {dateTimeController, fs};
 Pinetime::Controllers::TouchHandler touchHandler(touchPanel, lvgl);
 Pinetime::Controllers::ButtonHandler buttonHandler;
 Pinetime::Controllers::BrightnessController brightnessController {};

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -276,7 +276,7 @@ void SystemTask::Work() {
         case Messages::OnNewTime:
           ReloadIdleTimer();
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::UpdateDateTime);
-          if (alarmController.State() == Controllers::AlarmController::AlarmState::Set) {
+          if (alarmController.IsEnabled()) {
             alarmController.ScheduleAlarm();
           }
           break;
@@ -390,8 +390,7 @@ void SystemTask::Work() {
         case Messages::OnNewHour:
           using Pinetime::Controllers::AlarmController;
           if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep &&
-              settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::Hours &&
-              alarmController.State() != AlarmController::AlarmState::Alerting) {
+              settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::Hours && !alarmController.IsAlerting()) {
             if (state == SystemTaskState::Sleeping) {
               GoToRunning();
               displayApp.PushMessage(Pinetime::Applications::Display::Messages::Clock);
@@ -402,8 +401,7 @@ void SystemTask::Work() {
         case Messages::OnNewHalfHour:
           using Pinetime::Controllers::AlarmController;
           if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep &&
-              settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::HalfHours &&
-              alarmController.State() != AlarmController::AlarmState::Alerting) {
+              settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::HalfHours && !alarmController.IsAlerting()) {
             if (state == SystemTaskState::Sleeping) {
               GoToRunning();
               displayApp.PushMessage(Pinetime::Applications::Display::Messages::Clock);


### PR DESCRIPTION
Save the set alarm time to the SPI NOR flash, so it does not reset to the default value when the watch resets, e.g. due to watchdog timeout.

Fixes #1330

Size impact: +248 (400332 -> 400580)

- [x] Fix dismissing a ringing alarm
- [x] Test on PineTime