### PR TITLE
Setting to disable step counter recording

### DIFF
--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -202,6 +202,15 @@ namespace Pinetime {
         return settings.stepsGoal;
       };
 
+      void SetStepCountEnabled(bool enabled) {
+        settingsChanged = settings.stepCountEnabled != enabled;
+        settings.stepCountEnabled = enabled;
+      };
+
+      bool IsStepCountEnabled() {
+        return settings.stepCountEnabled;
+      }
+
       void SetBleRadioEnabled(bool enabled) {
         bleRadioEnabled = enabled;
       };
@@ -230,6 +239,8 @@ namespace Pinetime {
         std::bitset<4> wakeUpMode {0};
         uint16_t shakeWakeThreshold = 150;
         Controllers::BrightnessController::Levels brightLevel = Controllers::BrightnessController::Levels::Medium;
+
+        bool stepCountEnabled = true;
       };
 
       SettingsData settings;

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -61,15 +61,17 @@ WatchFaceDigital::WatchFaceDigital(DisplayApp* app,
   lv_label_set_text_static(heartbeatValue, "");
   lv_obj_align(heartbeatValue, heartbeatIcon, LV_ALIGN_OUT_RIGHT_MID, 5, 0);
 
-  stepValue = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(stepValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FFE7));
-  lv_label_set_text_static(stepValue, "0");
-  lv_obj_align(stepValue, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
+  if (settingsController.IsStepCountEnabled()) {
+    stepValue = lv_label_create(lv_scr_act(), nullptr);
+    lv_obj_set_style_local_text_color(stepValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FFE7));
+    lv_label_set_text_static(stepValue, "0");
+    lv_obj_align(stepValue, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
 
-  stepIcon = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(stepIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FFE7));
-  lv_label_set_text_static(stepIcon, Symbols::shoe);
-  lv_obj_align(stepIcon, stepValue, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+    stepIcon = lv_label_create(lv_scr_act(), nullptr);
+    lv_obj_set_style_local_text_color(stepIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x00FFE7));
+    lv_label_set_text_static(stepIcon, Symbols::shoe);
+    lv_obj_align(stepIcon, stepValue, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+  }
 
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
   Refresh();
@@ -168,11 +170,13 @@ void WatchFaceDigital::Refresh() {
     lv_obj_realign(heartbeatValue);
   }
 
-  stepCount = motionController.NbSteps();
-  motionSensorOk = motionController.IsSensorOk();
-  if (stepCount.IsUpdated() || motionSensorOk.IsUpdated()) {
-    lv_label_set_text_fmt(stepValue, "%lu", stepCount.Get());
-    lv_obj_realign(stepValue);
-    lv_obj_realign(stepIcon);
+  if (settingsController.IsStepCountEnabled()) {
+    stepCount = motionController.NbSteps();
+    motionSensorOk = motionController.IsSensorOk();
+    if (stepCount.IsUpdated() || motionSensorOk.IsUpdated()) {
+      lv_label_set_text_fmt(stepValue, "%lu", stepCount.Get());
+      lv_obj_realign(stepValue);
+      lv_obj_realign(stepIcon);
+    }
   }
 }

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -164,32 +164,34 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_label_set_text_static(dateMonth, "MAR");
   lv_obj_align(dateMonth, sidebar, LV_ALIGN_CENTER, 0, 32);
 
-  // Step count gauge
-  if (settingsController.GetPTSColorBar() == Pinetime::Controllers::Settings::Colors::White) {
-    needle_colors[0] = LV_COLOR_BLACK;
-  } else {
-    needle_colors[0] = LV_COLOR_WHITE;
-  }
-  stepGauge = lv_gauge_create(lv_scr_act(), nullptr);
-  lv_gauge_set_needle_count(stepGauge, 1, needle_colors);
-  lv_obj_set_size(stepGauge, 40, 40);
-  lv_obj_align(stepGauge, sidebar, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
-  lv_gauge_set_scale(stepGauge, 360, 11, 0);
-  lv_gauge_set_angle_offset(stepGauge, 180);
-  lv_gauge_set_critical_value(stepGauge, 100);
-  lv_gauge_set_range(stepGauge, 0, 100);
-  lv_gauge_set_value(stepGauge, 0, 0);
+  if (settingsController.IsStepCountEnabled()) {
+    // Step count gauge
+    if (settingsController.GetPTSColorBar() == Pinetime::Controllers::Settings::Colors::White) {
+      needle_colors[0] = LV_COLOR_BLACK;
+    } else {
+      needle_colors[0] = LV_COLOR_WHITE;
+    }
+    stepGauge = lv_gauge_create(lv_scr_act(), nullptr);
+    lv_gauge_set_needle_count(stepGauge, 1, needle_colors);
+    lv_obj_set_size(stepGauge, 40, 40);
+    lv_obj_align(stepGauge, sidebar, LV_ALIGN_IN_BOTTOM_MID, 0, 0);
+    lv_gauge_set_scale(stepGauge, 360, 11, 0);
+    lv_gauge_set_angle_offset(stepGauge, 180);
+    lv_gauge_set_critical_value(stepGauge, 100);
+    lv_gauge_set_range(stepGauge, 0, 100);
+    lv_gauge_set_value(stepGauge, 0, 0);
 
-  lv_obj_set_style_local_pad_right(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, 3);
-  lv_obj_set_style_local_pad_left(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, 3);
-  lv_obj_set_style_local_pad_bottom(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, 3);
-  lv_obj_set_style_local_line_opa(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_COVER);
-  lv_obj_set_style_local_scale_width(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, 4);
-  lv_obj_set_style_local_line_width(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, 4);
-  lv_obj_set_style_local_line_color(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
-  lv_obj_set_style_local_line_opa(stepGauge, LV_GAUGE_PART_NEEDLE, LV_STATE_DEFAULT, LV_OPA_COVER);
-  lv_obj_set_style_local_line_width(stepGauge, LV_GAUGE_PART_NEEDLE, LV_STATE_DEFAULT, 3);
-  lv_obj_set_style_local_pad_inner(stepGauge, LV_GAUGE_PART_NEEDLE, LV_STATE_DEFAULT, 4);
+    lv_obj_set_style_local_pad_right(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, 3);
+    lv_obj_set_style_local_pad_left(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, 3);
+    lv_obj_set_style_local_pad_bottom(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, 3);
+    lv_obj_set_style_local_line_opa(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_COVER);
+    lv_obj_set_style_local_scale_width(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, 4);
+    lv_obj_set_style_local_line_width(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, 4);
+    lv_obj_set_style_local_line_color(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+    lv_obj_set_style_local_line_opa(stepGauge, LV_GAUGE_PART_NEEDLE, LV_STATE_DEFAULT, LV_OPA_COVER);
+    lv_obj_set_style_local_line_width(stepGauge, LV_GAUGE_PART_NEEDLE, LV_STATE_DEFAULT, 3);
+    lv_obj_set_style_local_pad_inner(stepGauge, LV_GAUGE_PART_NEEDLE, LV_STATE_DEFAULT, 4);
+  }
 
   btnNextTime = lv_btn_create(lv_scr_act(), nullptr);
   btnNextTime->user_data = this;
@@ -437,14 +439,16 @@ void WatchFacePineTimeStyle::Refresh() {
     }
   }
 
-  stepCount = motionController.NbSteps();
-  motionSensorOk = motionController.IsSensorOk();
-  if (stepCount.IsUpdated() || motionSensorOk.IsUpdated()) {
-    lv_gauge_set_value(stepGauge, 0, (stepCount.Get() / (settingsController.GetStepsGoal() / 100)));
-    lv_obj_realign(stepGauge);
-    if (stepCount.Get() > settingsController.GetStepsGoal()) {
-      lv_obj_set_style_local_line_color(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
-      lv_obj_set_style_local_scale_grad_color(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+  if (settingsController.IsStepCountEnabled()) {
+    stepCount = motionController.NbSteps();
+    motionSensorOk = motionController.IsSensorOk();
+    if (stepCount.IsUpdated() || motionSensorOk.IsUpdated()) {
+      lv_gauge_set_value(stepGauge, 0, (stepCount.Get() / (settingsController.GetStepsGoal() / 100)));
+      lv_obj_realign(stepGauge);
+      if (stepCount.Get() > settingsController.GetStepsGoal()) {
+        lv_obj_set_style_local_line_color(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+        lv_obj_set_style_local_scale_grad_color(stepGauge, LV_GAUGE_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+      }
     }
   }
   if (!lv_obj_get_hidden(btnSet)) {

--- a/src/displayapp/screens/WatchFaceTerminal.cpp
+++ b/src/displayapp/screens/WatchFaceTerminal.cpp
@@ -168,9 +168,13 @@ void WatchFaceTerminal::Refresh() {
     }
   }
 
-  stepCount = motionController.NbSteps();
-  motionSensorOk = motionController.IsSensorOk();
-  if (stepCount.IsUpdated() || motionSensorOk.IsUpdated()) {
-    lv_label_set_text_fmt(stepValue, "[STEP]#ee3377 %lu steps#", stepCount.Get());
+  if (settingsController.IsStepCountEnabled()) {
+    stepCount = motionController.NbSteps();
+    motionSensorOk = motionController.IsSensorOk();
+    if (stepCount.IsUpdated() || motionSensorOk.IsUpdated()) {
+      lv_label_set_text_fmt(stepValue, "[STEP]#ee3377 %lu steps#", stepCount.Get());
+    }
+  } else {
+    lv_label_set_text_fmt(stepValue, "[STEP]#ee3377 ---#");
   }
 }

--- a/src/displayapp/screens/settings/SettingSteps.cpp
+++ b/src/displayapp/screens/settings/SettingSteps.cpp
@@ -42,12 +42,12 @@ SettingSteps::SettingSteps(Pinetime::Applications::DisplayApp* app, Pinetime::Co
   lv_obj_set_style_local_text_font(stepValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
   lv_label_set_text_fmt(stepValue, "%lu", settingsController.GetStepsGoal());
   lv_label_set_align(stepValue, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(stepValue, lv_scr_act(), LV_ALIGN_CENTER, 0, -10);
+  lv_obj_align(stepValue, lv_scr_act(), LV_ALIGN_CENTER, 0, -40);
 
   btnPlus = lv_btn_create(lv_scr_act(), nullptr);
   btnPlus->user_data = this;
   lv_obj_set_size(btnPlus, 80, 50);
-  lv_obj_align(btnPlus, lv_scr_act(), LV_ALIGN_CENTER, 55, 80);
+  lv_obj_align(btnPlus, lv_scr_act(), LV_ALIGN_CENTER, 55, 30);
   lv_obj_t* lblPlus = lv_label_create(btnPlus, nullptr);
   lv_label_set_text_static(lblPlus, "+");
   lv_obj_set_event_cb(btnPlus, event_handler);
@@ -56,9 +56,22 @@ SettingSteps::SettingSteps(Pinetime::Applications::DisplayApp* app, Pinetime::Co
   btnMinus->user_data = this;
   lv_obj_set_size(btnMinus, 80, 50);
   lv_obj_set_event_cb(btnMinus, event_handler);
-  lv_obj_align(btnMinus, lv_scr_act(), LV_ALIGN_CENTER, -55, 80);
+  lv_obj_align(btnMinus, lv_scr_act(), LV_ALIGN_CENTER, -55, 30);
   lv_obj_t* lblMinus = lv_label_create(btnMinus, nullptr);
   lv_label_set_text_static(lblMinus, "-");
+
+  enableSwitch = lv_switch_create(lv_scr_act(), nullptr);
+  enableSwitch->user_data = this;
+  if (settingsController.IsStepCountEnabled()) {
+    lv_switch_on(enableSwitch, LV_ANIM_OFF);
+  }
+  lv_obj_set_event_cb(enableSwitch, event_handler);
+  lv_obj_set_size(enableSwitch, 50, 25);
+  lv_obj_align(enableSwitch, lv_scr_act(), LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
+
+  enableText = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(enableText, "enable counter");
+  lv_obj_align(enableText, enableSwitch, LV_ALIGN_OUT_RIGHT_MID, 6, 0);
 }
 
 SettingSteps::~SettingSteps() {
@@ -73,7 +86,7 @@ void SettingSteps::UpdateSelected(lv_obj_t* object, lv_event_t event) {
     if (value <= 500000) {
       settingsController.SetStepsGoal(value);
       lv_label_set_text_fmt(stepValue, "%lu", settingsController.GetStepsGoal());
-      lv_obj_align(stepValue, lv_scr_act(), LV_ALIGN_CENTER, 0, -10);
+      lv_obj_realign(stepValue);
     }
   }
 
@@ -82,7 +95,11 @@ void SettingSteps::UpdateSelected(lv_obj_t* object, lv_event_t event) {
     if (value >= 1000) {
       settingsController.SetStepsGoal(value);
       lv_label_set_text_fmt(stepValue, "%lu", settingsController.GetStepsGoal());
-      lv_obj_align(stepValue, lv_scr_act(), LV_ALIGN_CENTER, 0, -10);
+      lv_obj_realign(stepValue);
     }
+  }
+
+  if (object == enableSwitch && (event == LV_EVENT_VALUE_CHANGED)) {
+    settingsController.SetStepCountEnabled(lv_switch_get_state(enableSwitch));
   }
 }

--- a/src/displayapp/screens/settings/SettingSteps.h
+++ b/src/displayapp/screens/settings/SettingSteps.h
@@ -23,6 +23,8 @@ namespace Pinetime {
         lv_obj_t* stepValue;
         lv_obj_t* btnPlus;
         lv_obj_t* btnMinus;
+        lv_obj_t* enableSwitch;
+        lv_obj_t* enableText;
       };
     }
   }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -482,9 +482,10 @@ void SystemTask::UpdateMotion() {
   }
 
   auto motionValues = motionSensor.Process();
+  uint32_t steps = settingsController.IsStepCountEnabled() ? motionValues.steps : 0;
 
   motionController.IsSensorOk(motionSensor.IsOk());
-  motionController.Update(motionValues.x, motionValues.y, motionValues.z, motionValues.steps);
+  motionController.Update(motionValues.x, motionValues.y, motionValues.z, steps);
 
   if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep) {
     if ((settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist) &&


### PR DESCRIPTION
Fixes #1308 

I think many people want to use InfiniTime although they are not interested in a step counter. 
This is not possible since you're being reminded about your steps on most watch faces and inside of your companion app. 

This PR adds a setting that makes it possible to almost completely disable step counter functionality.
It aims to only have light changes and not add bloat. (Most of the changed lines is white space)
