### PR TITLE
AlarmController: add const to SecondsToAlarm() function

### DIFF
--- a/src/components/alarm/AlarmController.cpp
+++ b/src/components/alarm/AlarmController.cpp
@@ -82,7 +82,7 @@ void AlarmController::ScheduleAlarm() {
   state = AlarmState::Set;
 }
 
-uint32_t AlarmController::SecondsToAlarm() {
+uint32_t AlarmController::SecondsToAlarm() const {
   return std::chrono::duration_cast<std::chrono::seconds>(alarmTime - dateTimeController.CurrentDateTime()).count();
 }
 

--- a/src/components/alarm/AlarmController.h
+++ b/src/components/alarm/AlarmController.h
@@ -36,7 +36,7 @@ namespace Pinetime {
       void ScheduleAlarm();
       void DisableAlarm();
       void SetOffAlarmNow();
-      uint32_t SecondsToAlarm();
+      uint32_t SecondsToAlarm() const;
       void StopAlerting();
       enum class AlarmState { Not_Set, Set, Alerting };
       enum class RecurType { None, Daily, Weekdays };


### PR DESCRIPTION
A small trivial change for correctness. No functional change.

The function `SecondsToAlarm()` doesn't change anything in the `AlarmController` object. Mark the function `const` to show this property.