### PR TITLE
Refactoring of CheckBoxList : remove dependency to SettingController

### DIFF
--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -52,6 +52,11 @@ namespace Pinetime {
 
       Settings(Pinetime::Controllers::FS& fs);
 
+      Settings(const Settings&) = delete;
+      Settings& operator=(const Settings&) = delete;
+      Settings(Settings&&) = delete;
+      Settings& operator=(Settings&&) = delete;
+
       void Init();
       void SaveSettings();
 
@@ -133,14 +138,6 @@ namespace Pinetime {
 
       void SetAppMenu(uint8_t menu) {
         appMenu = menu;
-      };
-
-      void SetWatchfacesMenu(uint8_t menu) {
-        watchFacesMenu = menu;
-      };
-
-      uint8_t GetWatchfacesMenu() const {
-        return watchFacesMenu;
       };
 
       uint8_t GetAppMenu() const {

--- a/src/displayapp/screens/CheckboxList.cpp
+++ b/src/displayapp/screens/CheckboxList.cpp
@@ -17,12 +17,9 @@ CheckboxList::CheckboxList(const uint8_t screenID,
                            const char* optionsTitle,
                            const char* optionsSymbol,
                            uint32_t originalValue,
-                           std::function<void(uint32_t)>OnValueChanged,
+                           std::function<void(uint32_t)> OnValueChanged,
                            std::array<const char*, MaxItems> options)
-  : Screen(app),
-    screenID {screenID},
-    OnValueChanged{std::move(OnValueChanged)},
-    options {options}, value {originalValue} {
+  : Screen(app), screenID {screenID}, OnValueChanged {std::move(OnValueChanged)}, options {options}, value {originalValue} {
   // Set the background to Black
   lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
 

--- a/src/displayapp/screens/CheckboxList.cpp
+++ b/src/displayapp/screens/CheckboxList.cpp
@@ -22,8 +22,7 @@ CheckboxList::CheckboxList(const uint8_t screenID,
   : Screen(app),
     screenID {screenID},
     OnValueChanged{std::move(OnValueChanged)},
-    options {options},
-    newValue{originalValue} {
+    options {options}, value {originalValue} {
   // Set the background to Black
   lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
 
@@ -92,7 +91,7 @@ CheckboxList::CheckboxList(const uint8_t screenID,
 
 CheckboxList::~CheckboxList() {
   lv_obj_clean(lv_scr_act());
-  OnValueChanged(newValue);
+  OnValueChanged(value);
 }
 
 void CheckboxList::UpdateSelected(lv_obj_t* object, lv_event_t event) {
@@ -101,7 +100,7 @@ void CheckboxList::UpdateSelected(lv_obj_t* object, lv_event_t event) {
       if (strcmp(options[i], "")) {
         if (object == cbOption[i]) {
           lv_checkbox_set_checked(cbOption[i], true);
-          newValue = MaxItems * screenID + i;
+          value = MaxItems * screenID + i;
         } else {
           lv_checkbox_set_checked(cbOption[i], false);
         }

--- a/src/displayapp/screens/CheckboxList.h
+++ b/src/displayapp/screens/CheckboxList.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <lvgl/lvgl.h>
-#include <cstdint>
-#include <memory>
-#include <array>
-#include "displayapp/screens/Screen.h"
 #include "displayapp/Apps.h"
-#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <lvgl/lvgl.h>
+#include <memory>
 
 namespace Pinetime {
   namespace Applications {
@@ -14,34 +14,27 @@ namespace Pinetime {
       class CheckboxList : public Screen {
       public:
         static constexpr size_t MaxItems = 4;
-
         CheckboxList(const uint8_t screenID,
                      const uint8_t numScreens,
                      DisplayApp* app,
-                     Controllers::Settings& settingsController,
                      const char* optionsTitle,
                      const char* optionsSymbol,
-                     void (Controllers::Settings::*SetOptionIndex)(uint8_t),
-                     uint8_t (Controllers::Settings::*GetOptionIndex)() const,
+                     uint32_t originalValue,
+                     std::function<void(uint32_t)>OnValueChanged,
                      std::array<const char*, MaxItems> options);
-
         ~CheckboxList() override;
-
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
         const uint8_t screenID;
-        Controllers::Settings& settingsController;
-        const char* optionsTitle;
-        const char* optionsSymbol;
-        void (Controllers::Settings::*SetOptionIndex)(uint8_t);
-        uint8_t (Controllers::Settings::*GetOptionIndex)() const;
+        std::function<void(uint32_t)>OnValueChanged;
         std::array<const char*, MaxItems> options;
         std::array<lv_obj_t*, MaxItems> cbOption;
         std::array<lv_point_t, 2> pageIndicatorBasePoints;
         std::array<lv_point_t, 2> pageIndicatorPoints;
         lv_obj_t* pageIndicatorBase;
         lv_obj_t* pageIndicator;
+        uint32_t newValue;
       };
     }
   }

--- a/src/displayapp/screens/CheckboxList.h
+++ b/src/displayapp/screens/CheckboxList.h
@@ -20,14 +20,14 @@ namespace Pinetime {
                      const char* optionsTitle,
                      const char* optionsSymbol,
                      uint32_t originalValue,
-                     std::function<void(uint32_t)>OnValueChanged,
+                     std::function<void(uint32_t)> OnValueChanged,
                      std::array<const char*, MaxItems> options);
         ~CheckboxList() override;
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
         const uint8_t screenID;
-        std::function<void(uint32_t)>OnValueChanged;
+        std::function<void(uint32_t)> OnValueChanged;
         std::array<const char*, MaxItems> options;
         std::array<lv_obj_t*, MaxItems> cbOption;
         std::array<lv_point_t, 2> pageIndicatorBasePoints;

--- a/src/displayapp/screens/CheckboxList.h
+++ b/src/displayapp/screens/CheckboxList.h
@@ -34,7 +34,7 @@ namespace Pinetime {
         std::array<lv_point_t, 2> pageIndicatorPoints;
         lv_obj_t* pageIndicatorBase;
         lv_obj_t* pageIndicator;
-        uint32_t newValue;
+        uint32_t value;
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -34,30 +34,32 @@ bool SettingWatchFace::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
 
 std::unique_ptr<Screen> SettingWatchFace::CreateScreen1() {
   std::array<const char*, 4> watchfaces {"Digital face", "Analog face", "PineTimeStyle", "Terminal"};
-  return std::make_unique<Screens::CheckboxList>(0,
-                                                 2,
-                                                 app,
-                                                 title,
-                                                 symbol,
-                                                 settingsController.GetClockFace(),
-                                                 [&settings = settingsController](uint32_t clockFace) {
-                                                   settings.SetClockFace(clockFace);
-                                                   settings.SaveSettings();
-                                                 },
-                                                 watchfaces);
+  return std::make_unique<Screens::CheckboxList>(
+    0,
+    2,
+    app,
+    title,
+    symbol,
+    settingsController.GetClockFace(),
+    [&settings = settingsController](uint32_t clockFace) {
+      settings.SetClockFace(clockFace);
+      settings.SaveSettings();
+    },
+    watchfaces);
 }
 
 std::unique_ptr<Screen> SettingWatchFace::CreateScreen2() {
   std::array<const char*, 4> watchfaces {"Infineat face", "Casio G7710", "", ""};
-  return std::make_unique<Screens::CheckboxList>(1,
-                                                 2,
-                                                 app,
-                                                 title,
-                                                 symbol,
-                                                 settingsController.GetClockFace(),
-                                                 [&settings = settingsController](uint32_t clockFace) {
-                                                   settings.SetClockFace(clockFace);
-                                                   settings.SaveSettings();
-                                                 },
-                                                 watchfaces);
+  return std::make_unique<Screens::CheckboxList>(
+    1,
+    2,
+    app,
+    title,
+    symbol,
+    settingsController.GetClockFace(),
+    [&settings = settingsController](uint32_t clockFace) {
+      settings.SetClockFace(clockFace);
+      settings.SaveSettings();
+    },
+    watchfaces);
 }

--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -3,8 +3,6 @@
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/CheckboxList.h"
 #include "displayapp/screens/Screen.h"
-#include "displayapp/screens/Styles.h"
-#include "displayapp/screens/Symbols.h"
 #include "components/settings/Settings.h"
 
 using namespace Pinetime::Applications::Screens;
@@ -16,7 +14,7 @@ SettingWatchFace::SettingWatchFace(Pinetime::Applications::DisplayApp* app, Pine
   : Screen(app),
     settingsController {settingsController},
     screens {app,
-             settingsController.GetWatchfacesMenu(),
+             0,
              {[this]() -> std::unique_ptr<Screen> {
                 return CreateScreen1();
               },
@@ -28,7 +26,6 @@ SettingWatchFace::SettingWatchFace(Pinetime::Applications::DisplayApp* app, Pine
 
 SettingWatchFace::~SettingWatchFace() {
   lv_obj_clean(lv_scr_act());
-  settingsController.SaveSettings();
 }
 
 bool SettingWatchFace::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
@@ -40,11 +37,13 @@ std::unique_ptr<Screen> SettingWatchFace::CreateScreen1() {
   return std::make_unique<Screens::CheckboxList>(0,
                                                  2,
                                                  app,
-                                                 settingsController,
                                                  title,
                                                  symbol,
-                                                 &Controllers::Settings::SetClockFace,
-                                                 &Controllers::Settings::GetClockFace,
+                                                 settingsController.GetClockFace(),
+                                                 [&settings = settingsController](uint32_t clockFace) {
+                                                   settings.SetClockFace(clockFace);
+                                                   settings.SaveSettings();
+                                                 },
                                                  watchfaces);
 }
 
@@ -53,10 +52,12 @@ std::unique_ptr<Screen> SettingWatchFace::CreateScreen2() {
   return std::make_unique<Screens::CheckboxList>(1,
                                                  2,
                                                  app,
-                                                 settingsController,
                                                  title,
                                                  symbol,
-                                                 &Controllers::Settings::SetClockFace,
-                                                 &Controllers::Settings::GetClockFace,
+                                                 settingsController.GetClockFace(),
+                                                 [&settings = settingsController](uint32_t clockFace) {
+                                                   settings.SetClockFace(clockFace);
+                                                   settings.SaveSettings();
+                                                 },
                                                  watchfaces);
 }


### PR DESCRIPTION
I'm not completely satisfied of the design of CheckBoxList. It currently depends on SettingsController and receives pointers to function to get and set the setting.

CheckBoxList is a UI component that we should be able to use anywhere. But the current implementation limit the usage of this class to settings that are handled by the `Settings` controller.

I tried to refactor this class : it now receives the `originalValue` (which is used to select the corresponding checkbox) and a `std::function` that is called when the value changes. This allows to completely de-couple `CheckBoxList` from `Settings`.

Now, I know that lambda with capture and std::function can have a big overhead (heap allocation, binary size and execution time). I couldn't find any in this specific case, but I wouldn't mind someone cross-checking this!

Any feedback about this refactoring?