### PR TITLE
Fix PTS steps style button label

### DIFF
--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -327,7 +327,8 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(DisplayApp* app,
   lv_obj_set_size(btnSteps, 160, 60);
   lv_obj_align(btnSteps, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_local_bg_opa(btnSteps, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_set_style_local_value_str(btnSteps, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, "Steps style");
+  lv_obj_t* lblSteps = lv_label_create(btnSteps, nullptr);
+  lv_label_set_text_static(lblSteps, "Steps style");
   lv_obj_set_event_cb(btnSteps, event_handler);
   lv_obj_set_hidden(btnSteps, true);
 


### PR DESCRIPTION
Building current develop results in the new PTS 'Steps style' button having a blank/missing label. I think this is due to a conflict with #1273 and is fixed by this change.

edit: this problem may also affect Infineat watchface buttons