### PR TITLE
CI: disable BUILD_RESOURCES for InfiniSim as already done in firmware

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,8 +80,9 @@ jobs:
         git -C InfiniSim submodule update --init lv_drivers libpng
 
     - name: CMake
+      # disable BUILD_RESOURCES as this is already done when building the firmware
       run:  |
-        cmake -G Ninja -S InfiniSim -B build_lv_sim -DInfiniTime_DIR="${PWD}"
+        cmake -G Ninja -S InfiniSim -B build_lv_sim -DInfiniTime_DIR="${PWD}" -DBUILD_RESOURCES=OFF
 
     - name: Build simulator executable
       run:  |


### PR DESCRIPTION
https://github.com/InfiniTimeOrg/InfiniSim/pull/70 introduces the `BUILD_RESOURCES` cmake configuration option enabled per default.

Disabling it on InfiniTime side for the CI-pipelines from InfiniTime as the `BUILD_RESOURCES` functionality is already tested in the firmware build itself