### PR TITLE
Alarm persist to flash

### DIFF
--- a/src/components/alarm/AlarmController.cpp
+++ b/src/components/alarm/AlarmController.cpp
@@ -169,6 +169,7 @@ void AlarmController::SaveSettingsToFile() const {
   if (fs.DirOpen("/.system", &systemDir) != LFS_ERR_OK) {
     fs.DirCreate("/.system");
   }
+  fs.DirClose(&systemDir);
   lfs_file_t alarmFile;
   if (fs.FileOpen(&alarmFile, "/.system/alarm.dat", LFS_O_WRONLY | LFS_O_CREAT) != LFS_ERR_OK) {
     NRF_LOG_WARNING("[AlarmController] Failed to open alarm data file for saving");

--- a/src/components/alarm/AlarmController.cpp
+++ b/src/components/alarm/AlarmController.cpp
@@ -19,11 +19,13 @@
 #include "systemtask/SystemTask.h"
 #include "task.h"
 #include <chrono>
+#include <libraries/log/nrf_log.h>
 
 using namespace Pinetime::Controllers;
 using namespace std::chrono_literals;
 
-AlarmController::AlarmController(Controllers::DateTime& dateTimeController) : dateTimeController {dateTimeController} {
+AlarmController::AlarmController(Controllers::DateTime& dateTimeController, Controllers::FS& fs)
+  : dateTimeController {dateTimeController}, fs {fs} {
 }
 
 namespace {
@@ -36,11 +38,28 @@ namespace {
 void AlarmController::Init(System::SystemTask* systemTask) {
   this->systemTask = systemTask;
   alarmTimer = xTimerCreate("Alarm", 1, pdFALSE, this, SetOffAlarm);
+  LoadSettingsFromFile();
+  if (alarm.isEnabled) {
+    NRF_LOG_INFO("[AlarmController] Loaded alarm was enabled, scheduling");
+    ScheduleAlarm();
+  }
+}
+
+void AlarmController::SaveAlarm() {
+  // verify if it is necessary to save
+  if (alarmChanged) {
+    SaveSettingsToFile();
+  }
+  alarmChanged = false;
 }
 
 void AlarmController::SetAlarmTime(uint8_t alarmHr, uint8_t alarmMin) {
-  hours = alarmHr;
-  minutes = alarmMin;
+  if (alarm.hours == alarmHr && alarm.minutes == alarmMin) {
+    return;
+  }
+  alarm.hours = alarmHr;
+  alarm.minutes = alarmMin;
+  alarmChanged = true;
 }
 
 void AlarmController::ScheduleAlarm() {
@@ -53,18 +72,19 @@ void AlarmController::ScheduleAlarm() {
   tm* tmAlarmTime = std::localtime(&ttAlarmTime);
 
   // If the time being set has already passed today,the alarm should be set for tomorrow
-  if (hours < dateTimeController.Hours() || (hours == dateTimeController.Hours() && minutes <= dateTimeController.Minutes())) {
+  if (alarm.hours < dateTimeController.Hours() ||
+      (alarm.hours == dateTimeController.Hours() && alarm.minutes <= dateTimeController.Minutes())) {
     tmAlarmTime->tm_mday += 1;
     // tm_wday doesn't update automatically
     tmAlarmTime->tm_wday = (tmAlarmTime->tm_wday + 1) % 7;
   }
 
-  tmAlarmTime->tm_hour = hours;
-  tmAlarmTime->tm_min = minutes;
+  tmAlarmTime->tm_hour = alarm.hours;
+  tmAlarmTime->tm_min = alarm.minutes;
   tmAlarmTime->tm_sec = 0;
 
   // if alarm is in weekday-only mode, make sure it shifts to the next weekday
-  if (recurrence == RecurType::Weekdays) {
+  if (alarm.recurrence == RecurType::Weekdays) {
     if (tmAlarmTime->tm_wday == 0) { // Sunday, shift 1 day
       tmAlarmTime->tm_mday += 1;
     } else if (tmAlarmTime->tm_wday == 6) { // Saturday, shift 2 days
@@ -79,7 +99,10 @@ void AlarmController::ScheduleAlarm() {
   xTimerChangePeriod(alarmTimer, secondsToAlarm * configTICK_RATE_HZ, 0);
   xTimerStart(alarmTimer, 0);
 
-  state = AlarmState::Set;
+  if (!alarm.isEnabled) {
+    alarm.isEnabled = true;
+    alarmChanged = true;
+  }
 }
 
 uint32_t AlarmController::SecondsToAlarm() const {
@@ -88,20 +111,71 @@ uint32_t AlarmController::SecondsToAlarm() const {
 
 void AlarmController::DisableAlarm() {
   xTimerStop(alarmTimer, 0);
-  state = AlarmState::Not_Set;
+  isAlerting = false;
+  if (alarm.isEnabled) {
+    alarm.isEnabled = false;
+    alarmChanged = true;
+  }
 }
 
 void AlarmController::SetOffAlarmNow() {
-  state = AlarmState::Alerting;
+  isAlerting = true;
   systemTask->PushMessage(System::Messages::SetOffAlarm);
 }
 
 void AlarmController::StopAlerting() {
-  // Alarm state is off unless this is a recurring alarm
-  if (recurrence == RecurType::None) {
-    state = AlarmState::Not_Set;
+  isAlerting = false;
+  // Disable alarm unless it is recurring
+  if (alarm.recurrence == RecurType::None) {
+    alarm.isEnabled = false;
+    alarmChanged = true;
   } else {
     // set next instance
     ScheduleAlarm();
   }
+}
+
+void AlarmController::SetRecurrence(RecurType recurrence) {
+  if (alarm.recurrence != recurrence) {
+    alarm.recurrence = recurrence;
+    alarmChanged = true;
+  }
+}
+
+void AlarmController::LoadSettingsFromFile() {
+  lfs_file_t alarmFile;
+  AlarmSettings alarmBuffer;
+
+  if (fs.FileOpen(&alarmFile, "/.system/alarm.dat", LFS_O_RDONLY) != LFS_ERR_OK) {
+    NRF_LOG_WARNING("[AlarmController] Failed to open alarm data file");
+    return;
+  }
+
+  fs.FileRead(&alarmFile, reinterpret_cast<uint8_t*>(&alarmBuffer), sizeof(alarmBuffer));
+  fs.FileClose(&alarmFile);
+  if (alarmBuffer.version != alarmFormatVersion) {
+    NRF_LOG_WARNING("[AlarmController] Loaded alarm settings has version %u instead of %u, discarding",
+                    alarmBuffer.version,
+                    alarmFormatVersion);
+    return;
+  }
+
+  alarm = alarmBuffer;
+  NRF_LOG_INFO("[AlarmController] Loaded alarm settings from file");
+}
+
+void AlarmController::SaveSettingsToFile() const {
+  lfs_dir systemDir;
+  if (fs.DirOpen("/.system", &systemDir) != LFS_ERR_OK) {
+    fs.DirCreate("/.system");
+  }
+  lfs_file_t alarmFile;
+  if (fs.FileOpen(&alarmFile, "/.system/alarm.dat", LFS_O_WRONLY | LFS_O_CREAT) != LFS_ERR_OK) {
+    NRF_LOG_WARNING("[AlarmController] Failed to open alarm data file for saving");
+    return;
+  }
+
+  fs.FileWrite(&alarmFile, reinterpret_cast<const uint8_t*>(&alarm), sizeof(alarm));
+  fs.FileClose(&alarmFile);
+  NRF_LOG_INFO("[AlarmController] Saved alarm settings with format version %u to file", alarm.version);
 }

--- a/src/components/alarm/AlarmController.h
+++ b/src/components/alarm/AlarmController.h
@@ -30,47 +30,65 @@ namespace Pinetime {
   namespace Controllers {
     class AlarmController {
     public:
-      AlarmController(Controllers::DateTime& dateTimeController);
+      AlarmController(Controllers::DateTime& dateTimeController, Controllers::FS& fs);
 
       void Init(System::SystemTask* systemTask);
+      void SaveAlarm();
       void SetAlarmTime(uint8_t alarmHr, uint8_t alarmMin);
       void ScheduleAlarm();
       void DisableAlarm();
       void SetOffAlarmNow();
       uint32_t SecondsToAlarm() const;
       void StopAlerting();
-      enum class AlarmState { Not_Set, Set, Alerting };
       enum class RecurType { None, Daily, Weekdays };
 
       uint8_t Hours() const {
-        return hours;
+        return alarm.hours;
       }
 
       uint8_t Minutes() const {
-        return minutes;
+        return alarm.minutes;
       }
 
-      AlarmState State() const {
-        return state;
+      bool IsAlerting() const {
+        return isAlerting;
+      }
+
+      bool IsEnabled() const {
+        return alarm.isEnabled;
       }
 
       RecurType Recurrence() const {
-        return recurrence;
+        return alarm.recurrence;
       }
 
-      void SetRecurrence(RecurType recurType) {
-        recurrence = recurType;
-      }
+      void SetRecurrence(RecurType recurrence);
 
     private:
+      // Versions 255 is reserved for now, so the version field can be made
+      // bigger, should it ever be needed.
+      static constexpr uint8_t alarmFormatVersion = 1;
+
+      struct AlarmSettings {
+        uint8_t version = alarmFormatVersion;
+        uint8_t hours = 7;
+        uint8_t minutes = 0;
+        RecurType recurrence = RecurType::None;
+        bool isEnabled = false;
+      };
+
+      bool isAlerting = false;
+      bool alarmChanged = false;
+
       Controllers::DateTime& dateTimeController;
+      Controllers::FS& fs;
       System::SystemTask* systemTask = nullptr;
       TimerHandle_t alarmTimer;
-      uint8_t hours = 7;
-      uint8_t minutes = 0;
+      AlarmSettings alarm;
       std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> alarmTime;
-      AlarmState state = AlarmState::Not_Set;
-      RecurType recurrence = RecurType::None;
+
+      void LoadSettingsFromFile();
+      void SaveSettingsToFile() const;
     };
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,7 +104,7 @@ Pinetime::Controllers::DateTime dateTimeController {settingsController};
 Pinetime::Drivers::Watchdog watchdog;
 Pinetime::Controllers::NotificationManager notificationManager;
 Pinetime::Controllers::MotionController motionController;
-Pinetime::Controllers::AlarmController alarmController {dateTimeController};
+Pinetime::Controllers::AlarmController alarmController {dateTimeController, fs};
 Pinetime::Controllers::TouchHandler touchHandler;
 Pinetime::Controllers::ButtonHandler buttonHandler;
 Pinetime::Controllers::BrightnessController brightnessController {};

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -216,7 +216,7 @@ void SystemTask::Work() {
           GoToSleep();
           break;
         case Messages::OnNewTime:
-          if (alarmController.State() == Controllers::AlarmController::AlarmState::Set) {
+          if (alarmController.IsEnabled()) {
             alarmController.ScheduleAlarm();
           }
           break;
@@ -317,8 +317,7 @@ void SystemTask::Work() {
         case Messages::OnNewHour:
           using Pinetime::Controllers::AlarmController;
           if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep &&
-              settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::Hours &&
-              alarmController.State() != AlarmController::AlarmState::Alerting) {
+              settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::Hours && !alarmController.IsAlerting()) {
             GoToRunning();
             displayApp.PushMessage(Pinetime::Applications::Display::Messages::Chime);
           }
@@ -326,8 +325,7 @@ void SystemTask::Work() {
         case Messages::OnNewHalfHour:
           using Pinetime::Controllers::AlarmController;
           if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep &&
-              settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::HalfHours &&
-              alarmController.State() != AlarmController::AlarmState::Alerting) {
+              settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::HalfHours && !alarmController.IsAlerting()) {
             GoToRunning();
             displayApp.PushMessage(Pinetime::Applications::Display::Messages::Chime);
           }


### PR DESCRIPTION
rebase of https://github.com/InfiniTimeOrg/InfiniTime/pull/1333 with additional `SaveAlarm()` function as described below

---

Save the set alarm time to the SPI NOR flash, so it does not reset to
the default value when the watch resets, e.g. due to watchdog timeout
or a firmware update

Introduce `SaveAlarm()` member function which saves to file only if the
alarm setting is changed.
The `alarmChanged` boolean flag mimics the behavior of `settingsChanged`
flag from `Settings.h`

Also mark the ~~`SaveAlarmToFile()`~~ ~~`Save()`~~ `SaveSettingsToFile` function const, as it doesn't change
anything in the `AlarmController` object.

---

This PR needs https://github.com/InfiniTimeOrg/InfiniSim/pull/67 to work on `InfiniSim`

--- 

Fixes: https://github.com/InfiniTimeOrg/InfiniTime/issues/1330