### PR TITLE
Proper battery percentage

### DIFF
--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -61,7 +61,7 @@ void Battery::SaadcInit() {
 }
 
 void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
-  static const Utility::LinearApproximation<uint16_t, uint8_t, 6> aprox{{{
+  static const Utility::LinearApproximation<uint16_t, uint8_t, 6> aprox {{{
     {3500, 0},  // minimum voltage of battery before shutdown ( depends on the battery )
     {3600, 10}, // keen point corresponded to 10% of battery
     {3700, 25},
@@ -85,7 +85,7 @@ void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
     if (isFull) {
       newPercent = 100;
     } else {
-      newPercent = std::min(aprox.GetValue(voltage), (isCharging ? uint8_t{99} : uint8_t{100}));
+      newPercent = std::min(aprox.GetValue(voltage), (isCharging ? uint8_t {99} : uint8_t {100}));
     }
 
     if ((isPowerPresent && newPercent > percentRemaining) || (!isPowerPresent && newPercent < percentRemaining) || firstMeasurement) {

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -61,7 +61,7 @@ void Battery::SaadcInit() {
 }
 
 void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
-  static const Utility::LinearApproximation<uint16_t, uint8_t, 6> aprox {{{
+  static const Utility::LinearApproximation<uint16_t, uint8_t, 6> aprox{{{
     {3200, 0},  // minimum voltage of battery before shutdown ( depends on the battery )
     {3600, 10}, // keen point corresponded to 10% of battery
     {3700, 25},

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -62,7 +62,7 @@ void Battery::SaadcInit() {
 
 void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
   static const Utility::LinearApproximation<uint16_t, uint8_t, 6> aprox{{{
-    {3200, 0},  // minimum voltage of battery before shutdown ( depends on the battery )
+    {3500, 0},  // minimum voltage of battery before shutdown ( depends on the battery )
     {3600, 10}, // keen point corresponded to 10% of battery
     {3700, 25},
     {3750, 50},

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -85,7 +85,7 @@ void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
     if (isFull) {
       newPercent = 100;
     } else {
-      newPercent = std::min(aprox.GetValue(voltage), (isCharging ? uint8_t {99} : uint8_t {100}));
+      newPercent = std::min(aprox.GetValue(voltage), isCharging ? uint8_t {99} : uint8_t {100});
     }
 
     if ((isPowerPresent && newPercent > percentRemaining) || (!isPowerPresent && newPercent < percentRemaining) || firstMeasurement) {

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -62,12 +62,12 @@ void Battery::SaadcInit() {
 
 void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
   static const Utility::LinearApproximation<uint16_t, uint8_t, 6> aprox {{{
-    {3500, 0},  // minimum voltage of battery before shutdown ( depends on the battery )
-    {3600, 10}, // keen point corresponded to 10% of battery
+    {3500, 0},  // Minimum voltage before shutdown (depends on the battery)
+    {3600, 10}, // Keen point that corresponds to 10%
     {3700, 25},
     {3750, 50},
     {3900, 75},
-    {4180, 100} // maximum voltage of battery ( max charging voltage is 4.21 )
+    {4180, 100} // Maximum voltage during charging is 4.21V
   }}};
 
   if (p_event->type == NRFX_SAADC_EVT_DONE) {

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -61,11 +61,12 @@ void Battery::SaadcInit() {
 }
 
 void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
-  static const Utility::LinearApproximation<uint16_t, uint8_t, 5> aprox {{{
+  static const Utility::LinearApproximation<uint16_t, uint8_t, 6> aprox {{{
     {3200, 0},  // minimum voltage of battery before shutdown ( depends on the battery )
     {3600, 10}, // keen point corresponded to 10% of battery
     {3700, 25},
-    {3800, 50},
+    {3750, 50},
+    {3900, 75},
     {4180, 100} // maximum voltage of battery ( max charging voltage is 4.21 )
   }}};
 

--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -1,4 +1,5 @@
 #include "components/battery/BatteryController.h"
+#include "components/utility/LinearApproximation.h"
 #include "drivers/PinMap.h"
 #include <hal/nrf_gpio.h>
 #include <nrfx_saadc.h>
@@ -60,8 +61,13 @@ void Battery::SaadcInit() {
 }
 
 void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
-  const uint16_t battery_max = 4180; // maximum voltage of battery ( max charging voltage is 4.21 )
-  const uint16_t battery_min = 3200; // minimum voltage of battery before shutdown ( depends on the battery )
+  static const Utility::LinearApproximation<uint16_t, uint8_t, 5> aprox {{{
+    {3200, 0},  // minimum voltage of battery before shutdown ( depends on the battery )
+    {3600, 10}, // keen point corresponded to 10% of battery
+    {3700, 25},
+    {3800, 50},
+    {4180, 100} // maximum voltage of battery ( max charging voltage is 4.21 )
+  }}};
 
   if (p_event->type == NRFX_SAADC_EVT_DONE) {
 
@@ -77,10 +83,8 @@ void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
     uint8_t newPercent;
     if (isFull) {
       newPercent = 100;
-    } else if (voltage < battery_min) {
-      newPercent = 0;
     } else {
-      newPercent = std::min((voltage - battery_min) * 100 / (battery_max - battery_min), isCharging ? 99 : 100);
+      newPercent = std::min(aprox.GetValue(voltage), (isCharging ? uint8_t{99} : uint8_t{100}));
     }
 
     if ((isPowerPresent && newPercent > percentRemaining) || (!isPowerPresent && newPercent < percentRemaining) || firstMeasurement) {

--- a/src/components/utility/LinearApproximation.h
+++ b/src/components/utility/LinearApproximation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <array>
 
 namespace Pinetime {
@@ -23,7 +24,7 @@ namespace Pinetime {
           return points[0].value;
         }
 
-        for (size_t i = 1; i < Size; i++) {
+        for (std::size_t i = 1; i < Size; i++) {
           const auto& p = points[i];
           const auto& p_prev = points[i - 1];
 

--- a/src/components/utility/LinearApproximation.h
+++ b/src/components/utility/LinearApproximation.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <array>    // for std::array
+#include <utility>  // for std::pair
+
+namespace Pinetime {
+  namespace Utility {
+
+    // based on: https://github.com/SHristov92/LinearApproximation/blob/main/Linear.h
+    template <typename Key, typename Value, std::size_t Size>
+    class LinearApproximation {
+      using Point = struct {
+        Key key;
+        Value value;
+      };
+
+    public:
+      LinearApproximation(const std::array<Point, Size> &&points)
+        : points{points} {}
+
+      Value GetValue(Key key) const {
+        if (key <= points[0].key) {
+          return points[0].value;
+        }
+
+        for (size_t i = 1; i < Size; i++) {
+          if (key < points[i].key) {
+            return points[i-1].value + (key - points[i-1].key) * (points[i].value - points[i-1].value) / (points[i].key - points[i-1].key);
+          }
+        }
+
+        return points[Size - 1].value;
+      }
+
+    private:
+      std::array<Point, Size> points;
+    };
+  }
+}

--- a/src/components/utility/LinearApproximation.h
+++ b/src/components/utility/LinearApproximation.h
@@ -14,8 +14,9 @@ namespace Pinetime {
       };
 
     public:
-      LinearApproximation(const std::array<Point, Size> &&points)
-        : points{points} {}
+      LinearApproximation(const std::array<Point, Size>&& sorted_points)
+        : points{sorted_points} {
+      }
 
       Value GetValue(Key key) const {
         if (key <= points[0].key) {
@@ -23,8 +24,11 @@ namespace Pinetime {
         }
 
         for (size_t i = 1; i < Size; i++) {
-          if (key < points[i].key) {
-            return points[i-1].value + (key - points[i-1].key) * (points[i].value - points[i-1].value) / (points[i].key - points[i-1].key);
+          const auto& p = points[i];
+          const auto& p_prev = points[i - 1];
+
+          if (key < p.key) {
+            return p_prev.value + (key - p_prev.key) * (p.value - p_prev.value) / (p.key - p_prev.key);
           }
         }
 

--- a/src/components/utility/LinearApproximation.h
+++ b/src/components/utility/LinearApproximation.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <array>    // for std::array
-#include <utility>  // for std::pair
+#include <array>
 
 namespace Pinetime {
   namespace Utility {

--- a/src/components/utility/LinearApproximation.h
+++ b/src/components/utility/LinearApproximation.h
@@ -7,16 +7,14 @@ namespace Pinetime {
   namespace Utility {
 
     // based on: https://github.com/SHristov92/LinearApproximation/blob/main/Linear.h
-    template <typename Key, typename Value, std::size_t Size>
-    class LinearApproximation {
+    template <typename Key, typename Value, std::size_t Size> class LinearApproximation {
       using Point = struct {
         Key key;
         Value value;
       };
 
     public:
-      LinearApproximation(const std::array<Point, Size>&& sorted_points)
-        : points{sorted_points} {
+      LinearApproximation(const std::array<Point, Size>&& sorted_points) : points {sorted_points} {
       }
 
       Value GetValue(Key key) const {


### PR DESCRIPTION
This PR adds linear approximation util and use it for making battery discharge curve more linear.

These changes were done independently on https://github.com/InfiniTimeOrg/InfiniTime/pull/585, I guess my solution is more generic. The main idea of my PR is adding linear approximation which might be used in any other feature including this old PR.
I used my own measurements of battery, not sure if they accurate enough, so you are welcome to update my digits:
```C
  static const Utility::LinearApproximation<uint16_t, uint8_t, 5> aprox {{{
    {3200, 0},  // minimum voltage of battery before shutdown ( depends on the battery )
    {3600, 10}, // keen point corresponded to 10% of battery
    {3700, 25},
    {3800, 50},
    {4180, 100} // maximum voltage of battery ( max charging voltage is 4.21 )
  }}};
``` 
My measurements:

![image](https://user-images.githubusercontent.com/3096462/198750327-c3409136-aef2-4b10-863f-e6033affb23b.png)
blue - measured voltage
red - measured percentage (using 1.9.0)
orange - filtered voltage (I'm working on adding filter in another branch)
green - expected percentage using this algorithm (actually data is filtered, but it shows trade line of approximation)

I can share my data by request.