### PR TITLE
I made a Life Point counter app for Magic The Gathering

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -407,6 +407,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/Styles.cpp
         displayapp/Colors.cpp
         displayapp/widgets/Counter.cpp
+        displayapp/widgets/2DigitCounter.cpp
         displayapp/widgets/PageIndicator.cpp
         displayapp/widgets/StatusIcons.cpp
 
@@ -617,6 +618,7 @@ set(INCLUDE_FILES
 	displayapp/screens/MTGLifePoints.h
         displayapp/Colors.h
         displayapp/widgets/Counter.h
+        displayapp/widgets/2DigitCounter.h
         displayapp/widgets/PageIndicator.h
         displayapp/widgets/StatusIcons.h
         drivers/St7789.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -407,7 +407,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/Styles.cpp
         displayapp/Colors.cpp
         displayapp/widgets/Counter.cpp
-        displayapp/widgets/2DigitCounter.cpp
+        displayapp/widgets/TwoDigitCounter.cpp
         displayapp/widgets/PageIndicator.cpp
         displayapp/widgets/StatusIcons.cpp
 
@@ -618,7 +618,7 @@ set(INCLUDE_FILES
 	displayapp/screens/MTGLifePoints.h
         displayapp/Colors.h
         displayapp/widgets/Counter.h
-        displayapp/widgets/2DigitCounter.h
+        displayapp/widgets/TwoDigitCounter.h
         displayapp/widgets/PageIndicator.h
         displayapp/widgets/StatusIcons.h
         drivers/St7789.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -403,6 +403,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/PassKey.cpp
         displayapp/screens/Error.cpp
         displayapp/screens/Alarm.cpp
+	displayapp/screens/MTGLifePoints.cpp
         displayapp/screens/Styles.cpp
         displayapp/Colors.cpp
         displayapp/widgets/Counter.cpp
@@ -613,6 +614,7 @@ set(INCLUDE_FILES
         displayapp/screens/Motion.h
         displayapp/screens/Timer.h
         displayapp/screens/Alarm.h
+	displayapp/screens/MTGLifePoints.h
         displayapp/Colors.h
         displayapp/widgets/Counter.h
         displayapp/widgets/PageIndicator.h

--- a/src/displayapp/Apps.h
+++ b/src/displayapp/Apps.h
@@ -39,7 +39,8 @@ namespace Pinetime {
       SettingChimes,
       SettingShakeThreshold,
       SettingBluetooth,
-      Error
+      Error,
+      MTGLifePoints
     };
   }
 }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -29,6 +29,7 @@
 #include "displayapp/screens/Steps.h"
 #include "displayapp/screens/PassKey.h"
 #include "displayapp/screens/Error.h"
+#include "displayapp/screens/MTGLifePoints.h"
 
 #include "drivers/Cst816s.h"
 #include "drivers/St7789.h"
@@ -373,7 +374,9 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
     case Apps::Alarm:
       currentScreen = std::make_unique<Screens::Alarm>(this, alarmController, settingsController.GetClockType(), *systemTask);
       break;
-
+    case Apps::MTGLifePoints:
+      currentScreen = std::make_unique<Screens::MTGLifePoints>(this);
+      break;
     // Settings
     case Apps::QuickSettings:
       currentScreen = std::make_unique<Screens::QuickSettings>(this,

--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -36,7 +36,7 @@ namespace Pinetime {
         static constexpr int appsPerScreen = 6;
 
         // Increment this when more space is needed
-        static constexpr int nScreens = 3;
+        static constexpr int nScreens = 2;
 
         static constexpr std::array<Tile::Applications, appsPerScreen * nScreens> applications {{
           {Symbols::stopWatch, Apps::StopWatch},
@@ -52,8 +52,6 @@ namespace Pinetime {
           {Symbols::chartLine, Apps::Motion},
           {Symbols::drum, Apps::Metronome},
           {Symbols::map, Apps::Navigation},
-
-          {Symbols::map, Apps::MTGLifePoints}
         }};
         ScreenList<nScreens> screens;
       };

--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -36,7 +36,7 @@ namespace Pinetime {
         static constexpr int appsPerScreen = 6;
 
         // Increment this when more space is needed
-        static constexpr int nScreens = 2;
+        static constexpr int nScreens = 3;
 
         static constexpr std::array<Tile::Applications, appsPerScreen * nScreens> applications {{
           {Symbols::stopWatch, Apps::StopWatch},
@@ -52,6 +52,8 @@ namespace Pinetime {
           {Symbols::chartLine, Apps::Motion},
           {Symbols::drum, Apps::Metronome},
           {Symbols::map, Apps::Navigation},
+
+          {Symbols::map, Apps::MTGLifePoints}
         }};
         ScreenList<nScreens> screens;
       };

--- a/src/displayapp/screens/MTGLifePoints.cpp
+++ b/src/displayapp/screens/MTGLifePoints.cpp
@@ -5,9 +5,12 @@ using namespace Pinetime::Applications::Screens;
 
 MTGLifePoints::MTGLifePoints(DisplayApp* app) : Screen(app) {
   lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_static(title, "My test application");
+  lv_label_set_text_static(title, "Life Points:");
   lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(title, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
+  lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 0);
+
+  twoDigitCounter.Create();
+  lv_obj_align(twoDigitCounter.GetObject(), nullptr, LV_ALIGN_CENTER, 0, 0);
 }
 
 MTGLifePoints::~MTGLifePoints() {

--- a/src/displayapp/screens/MTGLifePoints.cpp
+++ b/src/displayapp/screens/MTGLifePoints.cpp
@@ -1,0 +1,15 @@
+#include "displayapp/screens/MTGLifePoints.h"
+#include "displayapp/DisplayApp.h"
+
+using namespace Pinetime::Applications::Screens;
+
+MTGLifePoints::MTGLifePoints(DisplayApp* app) : Screen(app) {
+  lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(title, "My test application");
+  lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(title, lv_scr_act(), LV_ALIGN_CENTER, 0, 0);
+}
+
+MTGLifePoints::~MTGLifePoints() {
+  lv_obj_clean(lv_scr_act());
+}

--- a/src/displayapp/screens/MTGLifePoints.h
+++ b/src/displayapp/screens/MTGLifePoints.h
@@ -2,15 +2,21 @@
 
 #include "displayapp/screens/Screen.h"
 #include <lvgl/lvgl.h>
+#include "displayapp/widgets/TwoDigitCounter.h"
 
 namespace Pinetime {
   namespace Applications {
     namespace Screens {
       class MTGLifePoints : public Screen {
+      
       public:
         MTGLifePoints(DisplayApp* app);
         ~MTGLifePoints() override;
+
+      private:
+        Widgets::TwoDigitCounter twoDigitCounter = Widgets::TwoDigitCounter(0, 59, jetbrains_mono_76);
       };
+      
     }
   }
 }

--- a/src/displayapp/screens/MTGLifePoints.h
+++ b/src/displayapp/screens/MTGLifePoints.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "displayapp/screens/Screen.h"
+#include <lvgl/lvgl.h>
+
+namespace Pinetime {
+  namespace Applications {
+    namespace Screens {
+      class MTGLifePoints : public Screen {
+      public:
+        MTGLifePoints(DisplayApp* app);
+        ~MTGLifePoints() override;
+      };
+    }
+  }
+}

--- a/src/displayapp/widgets/TwoDigitCounter.cpp
+++ b/src/displayapp/widgets/TwoDigitCounter.cpp
@@ -1,0 +1,189 @@
+#include "displayapp/widgets/TwoDigitCounter.h"
+#include "displayapp/InfiniTimeTheme.h"
+#include <algorithm>
+
+using namespace Pinetime::Applications::Widgets;
+
+namespace {
+
+    void tensUpBtnEventHandler(lv_obj_t* obj, lv_event_t event) {
+        auto* widget = static_cast<TwoDigitCounter*>(obj->user_data);
+        if (event == LV_EVENT_SHORT_CLICKED) {
+            widget->UpBtnPressed(true);
+        } else if (event == LV_EVENT_LONG_PRESSED_REPEAT) {
+            widget->resetTotal();
+        }
+    }
+
+    void tensDownBtnEventHandler(lv_obj_t* obj, lv_event_t event) {
+        auto* widget = static_cast<TwoDigitCounter*>(obj->user_data);
+        if (event == LV_EVENT_SHORT_CLICKED || event == LV_EVENT_LONG_PRESSED_REPEAT) {
+            widget->DownBtnPressed(true);
+        }
+    }
+
+    void upBtnEventHandler(lv_obj_t* obj, lv_event_t event) {
+        auto* widget = static_cast<TwoDigitCounter*>(obj->user_data);
+        if (event == LV_EVENT_SHORT_CLICKED || event == LV_EVENT_LONG_PRESSED_REPEAT) {
+            widget->UpBtnPressed(false);
+        }
+    }
+
+    void downBtnEventHandler(lv_obj_t* obj, lv_event_t event) {
+        auto* widget = static_cast<TwoDigitCounter*>(obj->user_data);
+        if (event == LV_EVENT_SHORT_CLICKED || event == LV_EVENT_LONG_PRESSED_REPEAT) {
+            widget->DownBtnPressed(false);
+        }
+    }
+}
+
+TwoDigitCounter::TwoDigitCounter(int min, int max, lv_font_t& font) 
+: min {min}, max {max}, font {font} {
+}
+
+void TwoDigitCounter::resetTotal() {
+    value = 40;
+    UpdateLabel();
+}
+
+void TwoDigitCounter::UpBtnPressed(bool isTens) {
+    if (isTens) {
+        value = value + 10;
+    } else {
+        value++;
+    }
+    UpdateLabel();
+
+    if (ValueChangedHandler != nullptr) {
+        ValueChangedHandler(userData);
+    }
+};
+
+void TwoDigitCounter::DownBtnPressed(bool isTens) {
+    if (isTens) {
+        value = value - 10;
+    } else {
+        value--;
+    }
+    if (value <= 0) {
+        value = 0;
+    }
+    UpdateLabel();
+
+    if (ValueChangedHandler != nullptr) {
+        ValueChangedHandler(userData);
+    }
+};
+
+void TwoDigitCounter::UpdateLabel() {
+    if ( value <= 0 ) {
+        lv_label_set_text(number, "#FF1414 0#");
+    } else if ( value < 5 ) {
+        lv_label_set_text_fmt(number, "#FF1414  %.*i#", 0, value);
+    } else if ( value < 12 ) {
+        lv_label_set_text_fmt(number, "#FF1694  %.*i#", 0, value);
+    }  else if ( value < 25 ) {
+        lv_label_set_text_fmt(number, "#FDCE2A  %.*i#", 0, value);
+    } 
+    else {
+        lv_label_set_text_fmt(number, "#00FF7F %.*i#", 0, value);
+    }
+}
+
+void TwoDigitCounter::SetValueChangedEventCallback(void* userData, void (*handler)(void* userData)) {
+  this->userData = userData;
+  this->ValueChangedHandler = handler;
+}
+
+void TwoDigitCounter::Create() {
+  counterContainer = lv_obj_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_bg_color(counterContainer, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Colors::bgAlt);
+
+  number = lv_label_create(counterContainer, nullptr);
+  lv_obj_set_style_local_text_font(number, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &font);
+  lv_obj_align(number, nullptr, LV_ALIGN_CENTER, 0, 0);
+  lv_label_set_recolor(number, true);
+  lv_obj_set_auto_realign(number, true);
+
+  static constexpr uint8_t padding = 5;
+  const uint8_t width = std::max(lv_obj_get_width(number) + padding * 2, 58);
+  static constexpr uint8_t btnHeight = 50;
+  const uint8_t containerHeight = btnHeight * 2 + lv_obj_get_height(number) + padding * 2;
+
+  lv_obj_set_size(counterContainer, width * 3, containerHeight);
+
+  UpdateLabel();
+
+  tensUpBtn = lv_btn_create(counterContainer, nullptr);
+  lv_obj_set_style_local_bg_color(tensUpBtn, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Colors::bgAlt);
+  lv_obj_set_size(tensUpBtn, width, btnHeight);
+  lv_obj_align(tensUpBtn, nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 0);
+  tensUpBtn->user_data = this;
+  lv_obj_set_event_cb(tensUpBtn, tensUpBtnEventHandler);
+
+  lv_obj_t* tensUpLabel = lv_label_create(tensUpBtn, nullptr);
+  lv_obj_set_style_local_text_font(tensUpLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_label_set_text_static(tensUpLabel, "+");
+  lv_obj_align(tensUpLabel, nullptr, LV_ALIGN_CENTER, 0, 0);
+
+  upBtn = lv_btn_create(counterContainer, nullptr);
+  lv_obj_set_style_local_bg_color(upBtn, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Colors::bgAlt);
+  lv_obj_set_size(upBtn, width, btnHeight);
+  lv_obj_align(upBtn, nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
+  upBtn->user_data = this;
+  lv_obj_set_event_cb(upBtn, upBtnEventHandler);
+
+  lv_obj_t* upLabel = lv_label_create(upBtn, nullptr);
+  lv_obj_set_style_local_text_font(upLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_label_set_text_static(upLabel, "+");
+  lv_obj_align(upLabel, nullptr, LV_ALIGN_CENTER, 0, 0);
+
+
+  tensDownBtn = lv_btn_create(counterContainer, nullptr);
+  lv_obj_set_style_local_bg_color(tensDownBtn, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Colors::bgAlt);
+  lv_obj_set_size(tensDownBtn, width, btnHeight);
+  lv_obj_align(tensDownBtn, nullptr, LV_ALIGN_IN_BOTTOM_LEFT, 0, 0);
+  tensDownBtn->user_data = this;
+  lv_obj_set_event_cb(tensDownBtn, tensDownBtnEventHandler);
+
+  lv_obj_t* tensDownLabel = lv_label_create(tensDownBtn, nullptr);
+  lv_obj_set_style_local_text_font(tensDownLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_label_set_text_static(tensDownLabel, "-");
+  lv_obj_align(tensDownLabel, nullptr, LV_ALIGN_CENTER, 0, 0);
+
+  downBtn = lv_btn_create(counterContainer, nullptr);
+  lv_obj_set_style_local_bg_color(downBtn, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Colors::bgAlt);
+  lv_obj_set_size(downBtn, width, btnHeight);
+  lv_obj_align(downBtn, nullptr, LV_ALIGN_IN_BOTTOM_RIGHT, 0, 0);
+  downBtn->user_data = this;
+  lv_obj_set_event_cb(downBtn, downBtnEventHandler);
+
+  lv_obj_t* downLabel = lv_label_create(downBtn, nullptr);
+  lv_obj_set_style_local_text_font(downLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+  lv_label_set_text_static(downLabel, "-");
+  lv_obj_align(downLabel, nullptr, LV_ALIGN_CENTER, 0, 0);
+
+  linePoints[0] = {0, 0};
+  linePoints[1] = {width, 0};
+
+  auto LineCreate = [&]() {
+    lv_obj_t* line = lv_line_create(counterContainer, nullptr);
+    lv_line_set_points(line, linePoints, 2);
+    lv_obj_set_style_local_line_width(line, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, 1);
+    lv_obj_set_style_local_line_color(line, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
+    lv_obj_set_style_local_line_opa(line, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_20);
+    return line;
+  };
+
+  tensUpperLine = LineCreate();
+  lv_obj_align(tensUpperLine, tensUpBtn, LV_ALIGN_OUT_BOTTOM_MID, 0, 0);
+
+  tensLowerLine = LineCreate();
+  lv_obj_align(tensLowerLine, tensDownBtn, LV_ALIGN_OUT_TOP_MID, 0, -1);
+
+  upperLine = LineCreate();
+  lv_obj_align(upperLine, upBtn, LV_ALIGN_OUT_BOTTOM_MID, 0, 0);
+
+  lowerLine = LineCreate();
+  lv_obj_align(lowerLine, downBtn, LV_ALIGN_OUT_TOP_MID, 0, -1);
+}

--- a/src/displayapp/widgets/TwoDigitCounter.h
+++ b/src/displayapp/widgets/TwoDigitCounter.h
@@ -45,7 +45,7 @@ namespace Pinetime {
                     
                     int min;
                     int max;
-                    static inline int value = 40;
+                    static inline int value = 40; //initially set to 40, as this is the starting life total in Commander, the MTG format I play.
                     lv_font_t& font;
 
                     void* userData = nullptr;

--- a/src/displayapp/widgets/TwoDigitCounter.h
+++ b/src/displayapp/widgets/TwoDigitCounter.h
@@ -1,0 +1,55 @@
+#pragma once
+#include <lvgl/lvgl.h>
+
+namespace Pinetime {
+    namespace Applications {
+        namespace Widgets {
+            class TwoDigitCounter {
+                public:
+                    TwoDigitCounter(int min, int max, lv_font_t& font);
+
+                    void Create();
+                    void resetTotal();
+                    void UpBtnPressed(bool isTens);
+                    void DownBtnPressed(bool isTens);
+
+                    void SetValueChangedEventCallback(void* userData, void (*handler)(void* userData));
+
+                    lv_obj_t* GetObject() const {
+                        return counterContainer;
+                    };
+
+                    int getValue() {
+                        return value;
+                    }
+
+                    void setValue(int newValue) {
+                        value =  newValue;
+                    }
+                    
+                private:
+                    void UpdateLabel();
+                    void (*ValueChangedHandler)(void* userData) = nullptr;
+
+                    lv_obj_t* counterContainer;
+                    lv_obj_t* tensUpBtn;
+                    lv_obj_t* tensDownBtn;
+                    lv_obj_t* upBtn;
+                    lv_obj_t* downBtn;
+                    lv_obj_t* number;
+                    lv_obj_t* tensUpperLine;
+                    lv_obj_t* tensLowerLine;
+                    lv_obj_t* upperLine;
+                    lv_obj_t* lowerLine;
+                    lv_point_t linePoints[2];
+                    
+                    int min;
+                    int max;
+                    static inline int value = 40;
+                    lv_font_t& font;
+
+                    void* userData = nullptr;
+            };
+        }
+    }
+}


### PR DESCRIPTION
I couldn't figure out how to get the simulator working, so I don't have screenshots to share. But, as referenced in #1382 I made an MTG life counter app. I also implemented a new 2 digit counter widget that could be useful. It has 2 plus buttons on the top, and 2 minus buttons on the bottom. These add and subtract either 10 or 1 from the total. The number displayed changes color as your life goes down, as a warning(i.e. it goes red when it's really low).

Holding the top left plus button will reset the counter to '40' the default starting value I gave it, for Commander games. I probably should refactor the app to have a dedicated reset button.

One thing I could use some feedback on is, how to make the app persist my life points upon closing the app. Currently, I just made the value of the counter, a static variable, which was advice given to me in the matrix dev room, I'm not sure if this was the best way to do that though. The relevant line of code is [here.](https://github.com/Derek52/InfiniTime/blob/048d7f7594da355502554b56b9eabdb6efc55e78/src/displayapp/widgets/TwoDigitCounter.h#L48)