### PR TITLE
feat(Notifications): Adjust alert layout to show more text

### DIFF
--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -269,7 +269,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
   lv_cont_set_fit(subject_container, LV_FIT_NONE);
 
   lv_obj_t* alert_count = lv_label_create(container, nullptr);
-  lv_label_set_text_fmt(alert_count, "%i/%i", notifNr, notifNb);
+  lv_label_set_text_fmt(alert_count, "|%i/%i", notifNr, notifNb);
   lv_obj_align(alert_count, NULL, LV_ALIGN_IN_TOP_RIGHT, 0, 16);
 
   lv_obj_t* alert_type = lv_label_create(container, nullptr);
@@ -287,7 +287,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
     lv_label_refr_text(alert_type);
   }
   lv_label_set_long_mode(alert_type, LV_LABEL_LONG_SROLL_CIRC);
-  lv_obj_set_width(alert_type, 180);
+  lv_obj_set_width(alert_type, 197);
   lv_obj_align(alert_type, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 16);
 
   lv_obj_t* alert_subject = lv_label_create(subject_container, nullptr);


### PR DESCRIPTION
Original: https://github.com/InfiniTimeOrg/InfiniTime/pull/1348

To make better use of the space available in the header, it makes sense to increase the width of the `alert_type`.

To avoid confusion with the `alert_counter`, a `｜` will separate the `alert_counter` from the `alert_type`.

I do have a ![branch](https://github.com/FrazerClews/InfiniTime/commit/e10bbcf6e951a89aa137be3a43b333393fb25b4c) ready which furthers this PR by making better use of the height of the header space as there is a lot of space. This allows more text in the subject content, but this may cause accessibility issues.

![before](https://user-images.githubusercontent.com/23621844/193325008-429e8b9d-2ad2-45e7-ac7e-40eef5402224.png)
![after](https://user-images.githubusercontent.com/23621844/193325004-d16dd272-c644-4f59-b5aa-ebb2a68e1568.png)