### PR TITLE
Remove not needed SetClockFace from terminal watch face constructor

### DIFF
--- a/src/displayapp/screens/WatchFaceTerminal.cpp
+++ b/src/displayapp/screens/WatchFaceTerminal.cpp
@@ -30,8 +30,6 @@ WatchFaceTerminal::WatchFaceTerminal(DisplayApp* app,
     settingsController {settingsController},
     heartRateController {heartRateController},
     motionController {motionController} {
-  settingsController.SetClockFace(3);
-
   batteryValue = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_recolor(batteryValue, true);
   lv_obj_align(batteryValue, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, -20);


### PR DESCRIPTION
Based on @NeroBurner's comment in #1339 I factored this quick fix out.
There is a leftover(?) line in TerminalWatchFace that does not seem to serve a purpose.