### PR TITLE
Notification preview interaction

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -165,11 +165,18 @@ void DisplayApp::Refresh() {
           brightnessController.Lower();
           vTaskDelay(100);
         }
+
         PushMessageToSystemTask(Pinetime::System::Messages::OnDisplayTaskSleeping);
         state = States::Idle;
         break;
       case Messages::GoToRunning:
         ApplyBrightness();
+
+        // reload main display app if we are notifications or quicksettings or app menu
+        if(currentApp == Apps::Launcher || currentApp == Apps::Notifications || currentApp == Apps::QuickSettings){
+          LoadApp(Apps::Clock, DisplayApp::FullRefreshDirections::Up);
+        }
+
         state = States::Running;
         break;
       case Messages::UpdateTimeOut:
@@ -302,6 +309,7 @@ void DisplayApp::ReturnApp(Apps app, DisplayApp::FullRefreshDirections direction
 }
 
 void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) {
+  NRF_LOG_INFO("Loading app...")
   touchHandler.CancelTap();
   ApplyBrightness();
 
@@ -319,6 +327,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       break;
     case Apps::None:
     case Apps::Clock:
+      NRF_LOG_INFO("Loading clock")
       currentScreen = std::make_unique<Screens::Clock>(this,
                                                        dateTimeController,
                                                        batteryController,
@@ -328,6 +337,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
                                                        heartRateController,
                                                        motionController,
                                                        filesystem);
+      ReturnApp(Apps::Clock, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
 
     case Apps::Error:
@@ -480,6 +490,7 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       currentScreen = std::make_unique<Screens::Steps>(this, motionController, settingsController);
       break;
   }
+  NRF_LOG_INFO("DONE")
   currentApp = app;
 }
 

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -165,18 +165,11 @@ void DisplayApp::Refresh() {
           brightnessController.Lower();
           vTaskDelay(100);
         }
-
         PushMessageToSystemTask(Pinetime::System::Messages::OnDisplayTaskSleeping);
         state = States::Idle;
         break;
       case Messages::GoToRunning:
         ApplyBrightness();
-
-        // reload main display app if we are notifications or quicksettings or app menu
-        if(currentApp == Apps::Launcher || currentApp == Apps::Notifications || currentApp == Apps::QuickSettings){
-          LoadApp(Apps::Clock, DisplayApp::FullRefreshDirections::Up);
-        }
-
         state = States::Running;
         break;
       case Messages::UpdateTimeOut:
@@ -309,7 +302,6 @@ void DisplayApp::ReturnApp(Apps app, DisplayApp::FullRefreshDirections direction
 }
 
 void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) {
-  NRF_LOG_INFO("Loading app...")
   touchHandler.CancelTap();
   ApplyBrightness();
 
@@ -327,7 +319,6 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       break;
     case Apps::None:
     case Apps::Clock:
-      NRF_LOG_INFO("Loading clock")
       currentScreen = std::make_unique<Screens::Clock>(this,
                                                        dateTimeController,
                                                        batteryController,
@@ -337,7 +328,6 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
                                                        heartRateController,
                                                        motionController,
                                                        filesystem);
-      ReturnApp(Apps::Clock, FullRefreshDirections::Down, TouchEvents::SwipeDown);
       break;
 
     case Apps::Error:
@@ -490,7 +480,6 @@ void DisplayApp::LoadApp(Apps app, DisplayApp::FullRefreshDirections direction) 
       currentScreen = std::make_unique<Screens::Steps>(this, motionController, settingsController);
       break;
   }
-  NRF_LOG_INFO("DONE")
   currentApp = app;
 }
 

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -180,7 +180,7 @@ void DisplayApp::Refresh() {
         //        Screens::Clock::BleConnectionStates::NotConnected);
         break;
       case Messages::NewNotification:
-        LoadApp(Apps::NotificationsPreview, DisplayApp::FullRefreshDirections::Down);
+        LoadApp(Apps::NotificationsPreview, DisplayApp::FullRefreshDirections::Up);
         break;
       case Messages::TimerDone:
         if (currentApp == Apps::Timer) {

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -79,6 +79,12 @@ void Notifications::Refresh() {
       timeoutLinePoints[1].x = pos;
       lv_line_set_points(timeoutLine, timeoutLinePoints, 2);
     }
+
+    if(!this->scrolling && tick >= timeoutTickCountStart + timeoutStartScrolling){
+        this->scrolling = true;
+        lv_label_set_long_mode(currentItem->alert_type, LV_LABEL_LONG_SROLL_CIRC);
+    }
+
   }
 
   if (dismissingNotification) {
@@ -127,13 +133,18 @@ void Notifications::OnPreviewInteraction() {
 }
 
 bool Notifications::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
-  if (mode != Modes::Normal) {
+  /*if (mode != Modes::Normal) {
     if (!interacted && event == TouchEvents::Tap) {
       interacted = true;
       OnPreviewInteraction();
       return true;
     }
     return false;
+  }*/
+
+  if(mode == Modes::Preview){
+    interacted=true;
+    OnPreviewInteraction();
   }
 
   switch (event) {
@@ -272,7 +283,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
   lv_label_set_text_fmt(alert_count, "%i/%i", notifNr, notifNb);
   lv_obj_align(alert_count, NULL, LV_ALIGN_IN_TOP_RIGHT, 0, 16);
 
-  lv_obj_t* alert_type = lv_label_create(container, nullptr);
+  alert_type = lv_label_create(container, nullptr);
   lv_obj_set_style_local_text_color(alert_type, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::orange);
   if (title == nullptr) {
     lv_label_set_text_static(alert_type, "Notification");
@@ -286,7 +297,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
     }
     lv_label_refr_text(alert_type);
   }
-  lv_label_set_long_mode(alert_type, LV_LABEL_LONG_SROLL_CIRC);
+  lv_label_set_long_mode(alert_type, LV_LABEL_LONG_CROP);
   lv_obj_set_width(alert_type, 180);
   lv_obj_align(alert_type, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 16);
 

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -79,12 +79,6 @@ void Notifications::Refresh() {
       timeoutLinePoints[1].x = pos;
       lv_line_set_points(timeoutLine, timeoutLinePoints, 2);
     }
-
-    if(!this->scrolling && tick >= timeoutTickCountStart + timeoutStartScrolling){
-        this->scrolling = true;
-        lv_label_set_long_mode(currentItem->alert_type, LV_LABEL_LONG_SROLL_CIRC);
-    }
-
   }
 
   if (dismissingNotification) {
@@ -133,15 +127,6 @@ void Notifications::OnPreviewInteraction() {
 }
 
 bool Notifications::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
-  /*if (mode != Modes::Normal) {
-    if (!interacted && event == TouchEvents::Tap) {
-      interacted = true;
-      OnPreviewInteraction();
-      return true;
-    }
-    return false;
-  }*/
-
   if(mode == Modes::Preview){
     interacted=true;
     OnPreviewInteraction();
@@ -283,7 +268,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
   lv_label_set_text_fmt(alert_count, "%i/%i", notifNr, notifNb);
   lv_obj_align(alert_count, NULL, LV_ALIGN_IN_TOP_RIGHT, 0, 16);
 
-  alert_type = lv_label_create(container, nullptr);
+  lv_obj_t* alert_type = lv_label_create(container, nullptr);
   lv_obj_set_style_local_text_color(alert_type, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::orange);
   if (title == nullptr) {
     lv_label_set_text_static(alert_type, "Notification");
@@ -297,7 +282,7 @@ Notifications::NotificationItem::NotificationItem(const char* title,
     }
     lv_label_refr_text(alert_type);
   }
-  lv_label_set_long_mode(alert_type, LV_LABEL_LONG_CROP);
+  lv_label_set_long_mode(alert_type, LV_LABEL_LONG_SROLL_CIRC);
   lv_obj_set_width(alert_type, 180);
   lv_obj_align(alert_type, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 16);
 

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -47,7 +47,6 @@ namespace Pinetime {
             return running;
           }
           void OnCallButtonEvent(lv_obj_t*, lv_event_t event);
-          lv_obj_t *alert_type;
 
         private:
           lv_obj_t* container;
@@ -58,7 +57,6 @@ namespace Pinetime {
           lv_obj_t* label_accept;
           lv_obj_t* label_mute;
           lv_obj_t* label_reject;
-          
           Pinetime::Controllers::AlertNotificationService& alertNotificationService;
           Pinetime::Controllers::MotorController& motorController;
 
@@ -81,9 +79,7 @@ namespace Pinetime {
         TickType_t timeoutTickCountStart;
 
         static const TickType_t timeoutLength = pdMS_TO_TICKS(7000);
-        static const TickType_t timeoutStartScrolling = pdMS_TO_TICKS(1000);
         bool interacted = true;
-        bool scrolling = false;
 
         bool dismissingNotification = false;
 

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -47,6 +47,7 @@ namespace Pinetime {
             return running;
           }
           void OnCallButtonEvent(lv_obj_t*, lv_event_t event);
+          lv_obj_t *alert_type;
 
         private:
           lv_obj_t* container;
@@ -57,6 +58,7 @@ namespace Pinetime {
           lv_obj_t* label_accept;
           lv_obj_t* label_mute;
           lv_obj_t* label_reject;
+          
           Pinetime::Controllers::AlertNotificationService& alertNotificationService;
           Pinetime::Controllers::MotorController& motorController;
 
@@ -79,7 +81,9 @@ namespace Pinetime {
         TickType_t timeoutTickCountStart;
 
         static const TickType_t timeoutLength = pdMS_TO_TICKS(7000);
+        static const TickType_t timeoutStartScrolling = pdMS_TO_TICKS(1000);
         bool interacted = true;
+        bool scrolling = false;
 
         bool dismissingNotification = false;
 


### PR DESCRIPTION
Thi pr proposes to make the new notifications to feel more natural in two ways:
- new notification (i.e. previews) are interactive. It is possible to scroll down to see older notifications, right to delete it and up to get back to the clock,
- the animation is more natural with respect to the previous behaviour, indeed the notification comes from down to up, as if it was piling with the others.