### PR TITLE
BLE CTS: fixed signedness of timezone

### DIFF
--- a/src/components/ble/CurrentTimeService.h
+++ b/src/components/ble/CurrentTimeService.h
@@ -47,8 +47,8 @@ namespace Pinetime {
       } CtsCurrentTimeData;
 
       typedef struct __attribute__((packed)) {
-        uint8_t timezone;
-        uint8_t dst;
+        int8_t timezone;
+        int8_t dst;
       } CtsLocalTimeData;
 
       DateTime& m_dateTimeController;

--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -51,7 +51,7 @@ void DateTime::SetTime(uint16_t year,
   systemTask->PushMessage(System::Messages::OnNewTime);
 }
 
-void DateTime::SetTimeZone(uint8_t timezone, uint8_t dst) {
+void DateTime::SetTimeZone(int8_t timezone, int8_t dst) {
   tzOffset = timezone;
   dstOffset = dst;
 }

--- a/src/components/datetime/DateTimeController.h
+++ b/src/components/datetime/DateTimeController.h
@@ -48,7 +48,7 @@ namespace Pinetime {
        * timezone is expected to be constant over DST which will be reported in
        * dst field.
        */
-      void SetTimeZone(uint8_t timezone, uint8_t dst);
+      void SetTimeZone(int8_t timezone, int8_t dst);
 
       void UpdateTime(uint32_t systickCounter);
       uint16_t Year() const {
@@ -80,7 +80,7 @@ namespace Pinetime {
        * supports the BLE CTS Local Time Characteristic. Expect it to be 0
        * if not.
        */
-      uint8_t UtcOffset() const {
+      int8_t UtcOffset() const {
         return tzOffset + dstOffset;
       }
 
@@ -92,7 +92,7 @@ namespace Pinetime {
        * supports the BLE CTS Local Time Characteristic. Expect it to be 0
        * if not.
        */
-      uint8_t TzOffset() const {
+      int8_t TzOffset() const {
         return tzOffset;
       }
 
@@ -105,7 +105,7 @@ namespace Pinetime {
        * supports the BLE CTS Local Time Characteristic. Expect it to be 0
        * if not.
        */
-      uint8_t DstOffset() const {
+      int8_t DstOffset() const {
         return dstOffset;
       }
 
@@ -136,8 +136,8 @@ namespace Pinetime {
       uint8_t hour = 0;
       uint8_t minute = 0;
       uint8_t second = 0;
-      uint8_t tzOffset = 0;
-      uint8_t dstOffset = 0;
+      int8_t tzOffset = 0;
+      int8_t dstOffset = 0;
 
       uint32_t previousSystickCounter = 0;
       std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> currentDateTime;


### PR DESCRIPTION
This is a hotfix for  #1161.

I am afraid I got misled by the BLE spec, which specified the timezone fields as `uint8`. But, to be able to express negative timezones, they need to be signed.