### PR TITLE
WeatherService daily min/max temperature fixes

### DIFF
--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -594,7 +594,7 @@ namespace Pinetime {
           }
         }
       }
-      
+
       return result;
     }
 

--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -554,8 +554,7 @@ namespace Pinetime {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       uint64_t currentDayEnd = currentTimestamp + ((24 - dateTimeController.Hours()) * 60 * 60) +
                                ((60 - dateTimeController.Minutes()) * 60) + (60 - dateTimeController.Seconds());
-      uint64_t currentDayStart = currentTimestamp - ((dateTimeController.Hours() * 60 * 60) +
-                               (dateTimeController.Minutes() * 60) + dateTimeController.Seconds());
+      uint64_t currentDayStart = currentDayEnd - 86400;
       int16_t result = -32768;
       for (auto&& header : this->timeline) {
         if (header->eventType == WeatherData::eventtype::Temperature && header->timestamp > currentDayStart &&
@@ -578,8 +577,7 @@ namespace Pinetime {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       uint64_t currentDayEnd = currentTimestamp + ((24 - dateTimeController.Hours()) * 60 * 60) +
                                ((60 - dateTimeController.Minutes()) * 60) + (60 - dateTimeController.Seconds());
-      uint64_t currentDayStart = currentTimestamp - ((dateTimeController.Hours() * 60 * 60) +
-                               (dateTimeController.Minutes() * 60) + dateTimeController.Seconds());
+      uint64_t currentDayStart = currentDayEnd - 86400;
       int16_t result = -32768;
       for (auto&& header : this->timeline) {
         if (header->eventType == WeatherData::eventtype::Temperature && header->timestamp > currentDayStart &&

--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -552,11 +552,13 @@ namespace Pinetime {
 
     int16_t WeatherService::GetTodayMinTemp() const {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      uint64_t currentDayEnd = currentTimestamp - ((24 - dateTimeController.Hours()) * 60 * 60) -
-                               ((60 - dateTimeController.Minutes()) * 60) - (60 - dateTimeController.Seconds());
+      uint64_t currentDayEnd = currentTimestamp + ((24 - dateTimeController.Hours()) * 60 * 60) +
+                               ((60 - dateTimeController.Minutes()) * 60) + (60 - dateTimeController.Seconds());
+      uint64_t currentDayStart = currentTimestamp - ((dateTimeController.Hours() * 60 * 60) +
+                               (dateTimeController.Minutes() * 60) + dateTimeController.Seconds());
       int16_t result = -32768;
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Temperature && IsEventStillValid(header, currentTimestamp) &&
+        if (header->eventType == WeatherData::eventtype::Temperature && header->timestamp > currentDayStart &&
             header->timestamp < currentDayEnd &&
             reinterpret_cast<const std::unique_ptr<WeatherData::Temperature>&>(header)->temperature != -32768) {
           int16_t temperature = reinterpret_cast<const std::unique_ptr<WeatherData::Temperature>&>(header)->temperature;
@@ -569,17 +571,18 @@ namespace Pinetime {
           }
         }
       }
-
       return result;
     }
 
     int16_t WeatherService::GetTodayMaxTemp() const {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      uint64_t currentDayEnd = currentTimestamp - ((24 - dateTimeController.Hours()) * 60 * 60) -
-                               ((60 - dateTimeController.Minutes()) * 60) - (60 - dateTimeController.Seconds());
+      uint64_t currentDayEnd = currentTimestamp + ((24 - dateTimeController.Hours()) * 60 * 60) +
+                               ((60 - dateTimeController.Minutes()) * 60) + (60 - dateTimeController.Seconds());
+      uint64_t currentDayStart = currentTimestamp - ((dateTimeController.Hours() * 60 * 60) +
+                               (dateTimeController.Minutes() * 60) + dateTimeController.Seconds());
       int16_t result = -32768;
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Temperature && IsEventStillValid(header, currentTimestamp) &&
+        if (header->eventType == WeatherData::eventtype::Temperature && header->timestamp > currentDayStart &&
             header->timestamp < currentDayEnd &&
             reinterpret_cast<const std::unique_ptr<WeatherData::Temperature>&>(header)->temperature != -32768) {
           int16_t temperature = reinterpret_cast<const std::unique_ptr<WeatherData::Temperature>&>(header)->temperature;
@@ -592,7 +595,6 @@ namespace Pinetime {
           }
         }
       }
-
       return result;
     }
 

--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -557,7 +557,7 @@ namespace Pinetime {
       uint64_t currentDayStart = currentDayEnd - 86400;
       int16_t result = -32768;
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Temperature && header->timestamp > currentDayStart &&
+        if (header->eventType == WeatherData::eventtype::Temperature && header->timestamp >= currentDayStart &&
             header->timestamp < currentDayEnd &&
             reinterpret_cast<const std::unique_ptr<WeatherData::Temperature>&>(header)->temperature != -32768) {
           int16_t temperature = reinterpret_cast<const std::unique_ptr<WeatherData::Temperature>&>(header)->temperature;
@@ -570,6 +570,7 @@ namespace Pinetime {
           }
         }
       }
+
       return result;
     }
 
@@ -580,7 +581,7 @@ namespace Pinetime {
       uint64_t currentDayStart = currentDayEnd - 86400;
       int16_t result = -32768;
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Temperature && header->timestamp > currentDayStart &&
+        if (header->eventType == WeatherData::eventtype::Temperature && header->timestamp >= currentDayStart &&
             header->timestamp < currentDayEnd &&
             reinterpret_cast<const std::unique_ptr<WeatherData::Temperature>&>(header)->temperature != -32768) {
           int16_t temperature = reinterpret_cast<const std::unique_ptr<WeatherData::Temperature>&>(header)->temperature;
@@ -593,6 +594,7 @@ namespace Pinetime {
           }
         }
       }
+      
       return result;
     }
 


### PR DESCRIPTION
This PR fixes an issue with the WeatherService GetToday[Min:Max]Temp functions which miscalculated the timestamp of the current day end. I also made a change which makes it find all events between day start & day end (instead of only non-expired events before day end) which as far as I can see is reasonable for this function (find highest and lowest values for the current 24h period). Testing will reveal how different weather data providers set expiry time and what that means for us...
