### PR TITLE
reduce power usage by lowering ble crystal startup time

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -786,7 +786,7 @@ add_definitions(-DNRF52 -DNRF52832 -DNRF52832_XXAA -DNRF52_PAN_74 -DNRF52_PAN_64
 add_definitions(-DFREERTOS)
 add_definitions(-D__STACK_SIZE=1024)
 add_definitions(-D__HEAP_SIZE=4096)
-add_definitions(-DMYNEWT_VAL_BLE_LL_RFMGMT_ENABLE_TIME=1500)
+add_definitions(-DMYNEWT_VAL_BLE_LL_RFMGMT_ENABLE_TIME=400)
 
 # Note: Only use this for debugging
 # Derive the low frequency clock from the main clock (SYNT)


### PR DESCRIPTION
Pull request https://github.com/InfiniTimeOrg/InfiniTime/pull/1052 reduces power usage by powering down ble crystal when in idle. The crystal startup time is set to 1500 (mynewt default)

The nrf52 spec says it should be 360 in section 19.4.2. https://infocenter.nordicsemi.com/pdf/nRF52832_PS_v1.8.pdf

I think we can safely lower it to 400.
I've been using this parameter for several days.
However, I only have a sealed device and cannot verify if this actually saves battery, or, if this parameter even works.

So, I will set this PR as draft for now.