### PR TITLE
Metronome: Make the BPM estimate a moving average

### DIFF
--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -108,7 +108,7 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
       if (obj == bpmTap) {
         TickType_t delta = xTaskGetTickCount() - tappedTime;
         if (tappedTime != 0 && delta < configTICK_RATE_HZ * 3) {
-          bpm = configTICK_RATE_HZ * 60 / delta;
+          bpm = getMovingAverageBpm(configTICK_RATE_HZ * 60 / delta);
           lv_arc_set_value(bpmArc, bpm);
           lv_label_set_text_fmt(bpmValue, "%03d", bpm);
         }
@@ -149,4 +149,15 @@ bool Metronome::OnTouchEvent(TouchEvents event) {
     return true;
   }
   return false;
+}
+
+int16_t Metronome::getMovingAverageBpm(int16_t currentMeasurement) {
+  bpmHistory[bpmHistoryIndex++] = currentMeasurement;
+  if (bpmHistoryIndex == BPM_WINDOW_SIZE)
+    bpmHistoryIndex = 0;
+  uint8_t i = 0;
+  uint16_t bpm = 0;
+  for (; i < BPM_WINDOW_SIZE && bpmHistory[i] != 0; i++)
+    bpm += bpmHistory[i];
+  return bpm / i;
 }

--- a/src/displayapp/screens/Metronome.h
+++ b/src/displayapp/screens/Metronome.h
@@ -4,6 +4,8 @@
 #include "components/motor/MotorController.h"
 #include "displayapp/screens/Screen.h"
 
+static constexpr uint8_t BPM_WINDOW_SIZE = 3;
+
 namespace Pinetime {
   namespace Applications {
     namespace Screens {
@@ -21,7 +23,12 @@ namespace Pinetime {
         TickType_t tappedTime = 0;
         Controllers::MotorController& motorController;
         System::SystemTask& systemTask;
+
         int16_t bpm = 120;
+        int16_t bpmHistory[BPM_WINDOW_SIZE];
+        uint8_t bpmHistoryIndex = 0;
+        int16_t getMovingAverageBpm(int16_t currentMeasurement);
+
         uint8_t bpb = 4;
         uint8_t counter = 1;
 


### PR DESCRIPTION
## Moving Average BPM estimation

It is already possible to tap on the number in the metronome app to estimate the bpm of tapping.

However, I found this estimate to be a bit jumpy, so I made it a moving average over the last three measurements.  
This way, there is some smoothing applied by considering the history and not only the instantaneous measurement.
The displayed value is always the average of the last three measurements.
This  also reduces the measurement inaccuracy for tapping along constant tempo pieces.

It has the side effect, that a change in tapping speed will lead to a 3 tap ramp-up/down until the new estimation is reached.

### Possible changes

There is nothing special about the number three, one could make the history longer, which would further improve the measurement accuracy for constant tapping, but would also increase the ramp time for a change in tapping speed.  

The ramping could be counteracted by comparing the instantaneous measurement to the last estimation and dropping the history if it differs significantly (say 20%). 