### PR TITLE
Fix #1035 and unreported compiler warning.

### DIFF
--- a/src/displayapp/screens/Weather.cpp
+++ b/src/displayapp/screens/Weather.cpp
@@ -27,7 +27,6 @@ using namespace Pinetime::Applications::Screens;
 
 Weather::Weather(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::WeatherService& weather)
   : Screen(app),
-    dateTimeController {dateTimeController},
     weatherService(weather),
     screens {app,
              0,

--- a/src/displayapp/screens/Weather.h
+++ b/src/displayapp/screens/Weather.h
@@ -25,7 +25,6 @@ namespace Pinetime {
       private:
         bool running = true;
 
-        Pinetime::Controllers::DateTime& dateTimeController;
         Controllers::WeatherService& weatherService;
 
         ScreenList<5> screens;

--- a/src/displayapp/widgets/Counter.cpp
+++ b/src/displayapp/widgets/Counter.cpp
@@ -28,7 +28,7 @@ namespace {
   }
 }
 
-Counter::Counter(int min, int max, lv_font_t& font) : min {min}, max {max}, value {min}, font {font}, leadingZeroCount {digitCount(max)} {
+Counter::Counter(int min, int max, lv_font_t& font) : min {min}, max {max}, value {min}, leadingZeroCount {digitCount(max)}, font {font} {
 }
 
 void Counter::UpBtnPressed() {


### PR DESCRIPTION
* Fixed #1035 by removing unused member (can be added back when needed)
* Reordered member initialization in `Counter.cpp` to remove compiler warning