### PR TITLE
Change clang-format to block indent

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 ---
 Language: Cpp
 AccessModifierOffset: -2
-AlignAfterOpenBracket: Align
+AlignAfterOpenBracket: BlockIndent
 AlignConsecutiveMacros: true
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false


### PR DESCRIPTION
This PR changes the `AlignAfterOpenBracket` option to `BlockIndent`. See [here](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) for all options available. 

Instead of 
```
a_very_long_function_name_that_reaches_far_to_the_right(arg1,
                                                        arg2,
                                                        arg3
);
```
the new format would look like
```
a_very_long_function_name_that_reaches_far_to_the_right(
  arg1,
  arg2,
  arg3
);
```

I like the second option more because it removes the big blocks that are sometimes shifted far to the right side. On a smaller screen or a split-screen setup the code is not easily visible like that. Diffs do not look as good as well, because of the amount of whitespace.
