### PR TITLE
PineTimeStyle: use "" for our includes

### DIFF
--- a/src/displayapp/screens/WatchFacePineTimeStyle.h
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.h
@@ -5,10 +5,10 @@
 #include <cstdint>
 #include <memory>
 #include "displayapp/screens/Screen.h"
+#include "displayapp/screens/BatteryIcon.h"
 #include "displayapp/Colors.h"
 #include "components/datetime/DateTimeController.h"
 #include "components/ble/BleController.h"
-#include <displayapp/screens/BatteryIcon.h>
 
 namespace Pinetime {
   namespace Controllers {


### PR DESCRIPTION
Small fix to be consistent: use "" for our includes and <> for system includes or packages by others.