### PR TITLE
Improve discharge curve values

### DIFF
--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -61,14 +61,8 @@ void Battery::SaadcInit() {
 }
 
 void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
-  static const Utility::LinearApproximation<uint16_t, uint8_t, 6> aprox {{{
-    {3500, 0},  // Minimum voltage before shutdown (depends on the battery)
-    {3600, 10}, // Keen point that corresponds to 10%
-    {3700, 25},
-    {3750, 50},
-    {3900, 75},
-    {4180, 100} // Maximum voltage during charging is 4.21V
-  }}};
+  static const Utility::LinearApproximation<uint16_t, uint8_t, 6> approx {
+    {{{3500, 0}, {3616, 3}, {3723, 22}, {3776, 48}, {3979, 79}, {4180, 100}}}};
 
   if (p_event->type == NRFX_SAADC_EVT_DONE) {
 
@@ -83,7 +77,8 @@ void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
 
     uint8_t newPercent = 100;
     if (!isFull) {
-      newPercent = std::min(aprox.GetValue(voltage), isCharging ? uint8_t {99} : uint8_t {100});
+      // max. voltage while charging is higher than when discharging
+      newPercent = std::min(approx.GetValue(voltage), isCharging ? uint8_t {99} : uint8_t {100});
     }
 
     if (isPowerPresent) {


### PR DESCRIPTION
This pull request modifies the values of the discharge curve to slightly more accurately estimate the battery discharge. To calculate these values, I have run different tests on my 3 PineTimes, and then used some code to find the best fit. I can provide the raw data from the watches as well as the code I used on request.

![fit](https://user-images.githubusercontent.com/52415484/209573989-7d3cad50-4a0a-426e-a6ed-43dc6c3928e7.png)

![straight](https://user-images.githubusercontent.com/52415484/209572794-3c2e9551-f2e9-4c7b-ae6f-ad5b05ce4866.png)

In this last graph, the blue line is the original linear algorithm, the red line is with AlexXZero's values, and the yellow line is with my values.