### PR TITLE
Add a link to the "Ideas" (feature requests) Discussions board in the Github contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: true
 contact_links:
+  - name: Feature request
+    url: https://github.com/InfiniTimeOrg/InfiniTime/discussions/categories/ideas
+    about: Request a feature or share your ideas
   - name: PineTime community chat (Matrix)
     url: https://app.element.io/#/room/#pinetime:matrix.org
     about: Please ask questions about PineTime here.


### PR DESCRIPTION
This PR goes together with #1267 where we removed the feature request template. 
In this PR, we suggest the users to file their feature requests in the Discussions board.