### PR TITLE
Revert low battery alert. Add low battery indicator.

### DIFF
--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -81,20 +81,10 @@ void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
       newPercent = std::min(approx.GetValue(voltage), isCharging ? uint8_t {99} : uint8_t {100});
     }
 
-    if (isPowerPresent) {
-      batteryLowNotified = false;
-    }
-
     if ((isPowerPresent && newPercent > percentRemaining) || (!isPowerPresent && newPercent < percentRemaining) || firstMeasurement) {
       firstMeasurement = false;
       percentRemaining = newPercent;
       systemTask->PushMessage(System::Messages::BatteryPercentageUpdated);
-
-      // warn about low battery when not charging and below threshold
-      if (BatteryIsLow() && !isPowerPresent && !batteryLowNotified) {
-        systemTask->PushMessage(System::Messages::LowBattery);
-        batteryLowNotified = true;
-      }
     }
 
     nrfx_saadc_uninit();

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -18,10 +18,6 @@ namespace Pinetime {
         return percentRemaining;
       }
 
-      bool BatteryIsLow() const {
-        return percentRemaining <= lowBatteryThreshold;
-      }
-
       uint16_t Voltage() const {
         return voltage;
       }
@@ -43,7 +39,6 @@ namespace Pinetime {
       static constexpr nrf_saadc_input_t batteryVoltageAdcInput = NRF_SAADC_INPUT_AIN7;
       uint16_t voltage = 0;
       uint8_t percentRemaining = 0;
-      bool batteryLowNotified = false;
 
       bool isFull = false;
       bool isCharging = false;
@@ -54,8 +49,6 @@ namespace Pinetime {
 
       void SaadcEventHandler(nrfx_saadc_evt_t const* p_event);
       static void AdcCallbackStatic(nrfx_saadc_evt_t const* event);
-
-      static constexpr uint8_t lowBatteryThreshold {15};
 
       bool isReading = false;
 

--- a/src/displayapp/InfiniTimeTheme.h
+++ b/src/displayapp/InfiniTimeTheme.h
@@ -3,6 +3,7 @@
 #include <lvgl/lvgl.h>
 
 namespace Colors {
+  static constexpr lv_color_t deepOrange = LV_COLOR_MAKE(0xff, 0x40, 0x0);
   static constexpr lv_color_t orange = LV_COLOR_MAKE(0xff, 0xb0, 0x0);
   static constexpr lv_color_t green = LV_COLOR_MAKE(0x0, 0xb0, 0x0);
   static constexpr lv_color_t blue = LV_COLOR_MAKE(0x0, 0x50, 0xff);

--- a/src/displayapp/screens/BatteryIcon.cpp
+++ b/src/displayapp/screens/BatteryIcon.cpp
@@ -2,8 +2,11 @@
 #include <cstdint>
 #include "displayapp/screens/Symbols.h"
 #include "displayapp/icons/battery/batteryicon.c"
+#include "displayapp/InfiniTimeTheme.h"
 
 using namespace Pinetime::Applications::Screens;
+
+BatteryIcon::BatteryIcon(bool colorOnLowBattery) : colorOnLowBattery {colorOnLowBattery} {};
 
 void BatteryIcon::Create(lv_obj_t* parent) {
   batteryImg = lv_img_create(parent, nullptr);
@@ -23,6 +26,17 @@ lv_obj_t* BatteryIcon::GetObject() {
 void BatteryIcon::SetBatteryPercentage(uint8_t percentage) {
   lv_obj_set_height(batteryJuice, percentage * 14 / 100);
   lv_obj_realign(batteryJuice);
+  if (colorOnLowBattery) {
+    static constexpr int lowBatteryThreshold = 15;
+    static constexpr int criticalBatteryThreshold = 5;
+    if (percentage > lowBatteryThreshold) {
+      SetColor(LV_COLOR_WHITE);
+    } else if (percentage > criticalBatteryThreshold) {
+      SetColor(LV_COLOR_ORANGE);
+    } else {
+      SetColor(Colors::deepOrange);
+    }
+  }
 }
 
 void BatteryIcon::SetColor(lv_color_t color) {

--- a/src/displayapp/screens/BatteryIcon.h
+++ b/src/displayapp/screens/BatteryIcon.h
@@ -7,6 +7,7 @@ namespace Pinetime {
     namespace Screens {
       class BatteryIcon {
       public:
+        explicit BatteryIcon(bool colorOnLowBattery);
         void Create(lv_obj_t* parent);
 
         void SetColor(lv_color_t);
@@ -19,6 +20,7 @@ namespace Pinetime {
       private:
         lv_obj_t* batteryImg;
         lv_obj_t* batteryJuice;
+        bool colorOnLowBattery = false;
       };
     }
   }

--- a/src/displayapp/screens/BatteryInfo.cpp
+++ b/src/displayapp/screens/BatteryInfo.cpp
@@ -58,7 +58,7 @@ void BatteryInfo::Refresh() {
   } else if (batteryPercent == 100) {
     lv_obj_set_style_local_bg_color(charging_bar, LV_BAR_PART_INDIC, LV_STATE_DEFAULT, LV_COLOR_BLUE);
     lv_label_set_text_static(status, "Fully charged");
-  } else if (batteryController.BatteryIsLow()) {
+  } else if (batteryPercent < 10) {
     lv_obj_set_style_local_bg_color(charging_bar, LV_BAR_PART_INDIC, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
     lv_label_set_text_static(status, "Battery low");
   } else {

--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -49,6 +49,7 @@ WatchFaceAnalog::WatchFaceAnalog(Controllers::DateTime& dateTimeController,
                                  Controllers::NotificationManager& notificationManager,
                                  Controllers::Settings& settingsController)
   : currentDateTime {{}},
+    batteryIcon(true),
     dateTimeController {dateTimeController},
     batteryController {batteryController},
     bleController {bleController},

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -24,6 +24,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
                                                    Controllers::MotionController& motionController,
                                                    Controllers::FS& filesystem)
   : currentDateTime {{}},
+    batteryIcon(false),
     dateTimeController {dateTimeController},
     batteryController {batteryController},
     bleController {bleController},

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -51,6 +51,7 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(Controllers::DateTime& dateTimeCo
                                                Controllers::Settings& settingsController,
                                                Controllers::MotionController& motionController)
   : currentDateTime {{}},
+    batteryIcon(false),
     dateTimeController {dateTimeController},
     batteryController {batteryController},
     bleController {bleController},

--- a/src/displayapp/widgets/StatusIcons.cpp
+++ b/src/displayapp/widgets/StatusIcons.cpp
@@ -4,7 +4,7 @@
 using namespace Pinetime::Applications::Widgets;
 
 StatusIcons::StatusIcons(const Controllers::Battery& batteryController, const Controllers::Ble& bleController)
-  : batteryController {batteryController}, bleController {bleController} {
+  : batteryIcon(true), batteryController {batteryController}, bleController {bleController} {
 }
 
 void StatusIcons::Create() {

--- a/src/systemtask/Messages.h
+++ b/src/systemtask/Messages.h
@@ -29,7 +29,6 @@ namespace Pinetime {
       SetOffAlarm,
       MeasureBatteryTimerExpired,
       BatteryPercentageUpdated,
-      LowBattery,
       StartFileTransfer,
       StopFileTransfer,
       BleRadioEnableToggle

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -18,8 +18,6 @@
 #include "BootErrors.h"
 
 #include <memory>
-#include <algorithm>
-#include <cstring>
 
 using namespace Pinetime::System;
 
@@ -408,16 +406,6 @@ void SystemTask::Work() {
         case Messages::BatteryPercentageUpdated:
           nimbleController.NotifyBatteryLevel(batteryController.PercentRemaining());
           break;
-        case Messages::LowBattery: {
-          Pinetime::Controllers::NotificationManager::Notification notif;
-          constexpr char message[] = "Low Battery\0Charge your watch to prevent data loss.\0";
-          constexpr size_t messageSize = std::min(sizeof(message), Pinetime::Controllers::NotificationManager::MaximumMessageSize());
-          std::memcpy(notif.message.data(), message, messageSize);
-          notif.size = messageSize;
-          notif.category = Pinetime::Controllers::NotificationManager::Categories::SimpleAlert;
-          notificationManager.Push(std::move(notif));
-          PushMessage(Messages::OnNewNotification);
-        } break;
         case Messages::OnPairing:
           if (state == SystemTaskState::Sleeping) {
             GoToRunning();


### PR DESCRIPTION
This reverts PR https://github.com/InfiniTimeOrg/InfiniTime/pull/1352

There's no need to break the focus of the user to alert them that the battery will be empty in 24h, when they can see that the next time they check the watch. I've made the battery icon turn orange at 15, and red at 5, for a stronger warning to charge the watch.

![InfiniSim_2022-12-31_080939](https://user-images.githubusercontent.com/37774658/210130080-8fa07b27-f46f-4320-888b-ef0af905040b.gif)