### PR TITLE
Update workflow dependencies

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       USERNAME: infinitime
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Workaround permission issues
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout source files
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Build
@@ -55,11 +55,8 @@ jobs:
           path: ./build/output/infinitime-resources-*.zip
 
   build-simulator:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-    - name: Install cmake
-      uses: lukka/get-cmake@v3.18.3
-
     - name: Install SDL2 development package
       run:  |
         sudo apt-get update
@@ -70,7 +67,7 @@ jobs:
         npm i -g lv_font_conv@1.5.2
 
     - name: Checkout source files
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,10 @@ jobs:
         sudo apt-get update
         sudo apt-get -y install libsdl2-dev
 
+    - name: Install Ninja
+      run:  |
+        sudo apt-get -y install ninja-build
+
     - name: Install lv_font_conv
       run:
         npm i -g lv_font_conv@1.5.2


### PR DESCRIPTION
ubuntu-latest vm has been updated from 20.04 to 22.04. To avoid sudden issues, use 22.04 explicitly.
CMake doesn't need to be updated on 22.04.
actions/checkout@v2 uses deprecated Node.js 12. Update to v3 which uses 16

Fixes warnings in builds. https://github.com/InfiniTimeOrg/InfiniTime/actions/runs/3811961913