### PR TITLE
Add SettingScreenBase to create a generic checkbox screen

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -412,6 +412,7 @@ list(APPEND SOURCE_FILES
         ## Settings
         displayapp/screens/settings/QuickSettings.cpp
         displayapp/screens/settings/Settings.cpp
+        displayapp/screens/settings/SettingScreenBase.cpp
         displayapp/screens/settings/SettingWatchFace.cpp
         displayapp/screens/settings/SettingTimeFormat.cpp
         displayapp/screens/settings/SettingWakeUp.cpp

--- a/src/displayapp/screens/settings/SettingScreenBase.cpp
+++ b/src/displayapp/screens/settings/SettingScreenBase.cpp
@@ -1,0 +1,67 @@
+#include "displayapp/screens/settings/SettingScreenBase.h"
+#include "displayapp/screens/Styles.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  void RadioButtonEventHandler(lv_obj_t* obj, lv_event_t event) {
+    auto* settingScreen = static_cast<SettingScreenBase*>(obj->user_data);
+    if (event == LV_EVENT_VALUE_CHANGED) {
+      settingScreen->UpdateSelected(obj);
+    }
+  }
+}
+
+SettingScreenBase::SettingScreenBase(const char* title,
+                                     const char* icon,
+                                     Entry entries[],
+                                     size_t nEntries,
+                                     lv_obj_t*(*checkboxObjectArray),
+                                     bool radioButtonStyle)
+  : checkboxObjectArray {checkboxObjectArray}, nEntries {nEntries} {
+  lv_obj_t* container = lv_cont_create(lv_scr_act(), nullptr);
+
+  lv_obj_set_style_local_bg_opa(container, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
+  lv_obj_set_style_local_pad_all(container, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
+  lv_obj_set_style_local_pad_inner(container, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
+  lv_obj_set_style_local_border_width(container, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
+
+  lv_obj_set_pos(container, 10, 60);
+  lv_obj_set_width(container, LV_HOR_RES - 20);
+  lv_obj_set_height(container, LV_VER_RES - 50);
+  lv_cont_set_layout(container, LV_LAYOUT_COLUMN_LEFT);
+
+  lv_obj_t* titleObj = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(titleObj, title);
+  lv_label_set_align(titleObj, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(titleObj, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 15, 15);
+
+  lv_obj_t* iconObj = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(iconObj, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
+  lv_label_set_text_static(iconObj, icon);
+  lv_label_set_align(iconObj, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(iconObj, titleObj, LV_ALIGN_OUT_LEFT_MID, -10, 0);
+
+  for (unsigned int i = 0; i < nEntries; i++) {
+    checkboxObjectArray[i] = lv_checkbox_create(container, nullptr);
+    lv_checkbox_set_text(checkboxObjectArray[i], entries[i].title);
+    checkboxObjectArray[i]->user_data = this;
+    if (radioButtonStyle) {
+      SetRadioButtonStyle(checkboxObjectArray[i]);
+      lv_obj_set_event_cb(checkboxObjectArray[i], RadioButtonEventHandler);
+    }
+    if (entries[i].enabled) {
+      lv_checkbox_set_checked(checkboxObjectArray[i], true);
+    }
+  }
+}
+
+void SettingScreenBase::UpdateSelected(lv_obj_t* object) {
+  for (unsigned int i = 0; i < nEntries; i++) {
+    if (object == checkboxObjectArray[i]) {
+      lv_checkbox_set_checked(checkboxObjectArray[i], true);
+    } else {
+      lv_checkbox_set_checked(checkboxObjectArray[i], false);
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingScreenBase.h
+++ b/src/displayapp/screens/settings/SettingScreenBase.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <lvgl/lvgl.h>
+
+namespace Pinetime {
+  namespace Applications {
+    namespace Screens {
+      class SettingScreenBase {
+      public:
+        struct Entry {
+          const char* title;
+          bool enabled;
+        };
+
+        SettingScreenBase(const char* title,
+                          const char* icon,
+                          Entry entries[],
+                          size_t nEntries,
+                          lv_obj_t*(*checkboxObjectArray),
+                          bool radioButtonStyle);
+
+        void UpdateSelected(lv_obj_t* object);
+
+      private:
+        lv_obj_t*(*checkboxObjectArray);
+        size_t nEntries;
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingTimeFormat.cpp
+++ b/src/displayapp/screens/settings/SettingTimeFormat.cpp
@@ -1,76 +1,26 @@
 #include "displayapp/screens/settings/SettingTimeFormat.h"
 #include <lvgl/lvgl.h>
 #include "displayapp/DisplayApp.h"
-#include "displayapp/screens/Styles.h"
 #include "displayapp/screens/Screen.h"
 #include "displayapp/screens/Symbols.h"
 
 using namespace Pinetime::Applications::Screens;
 
-namespace {
-  void event_handler(lv_obj_t* obj, lv_event_t event) {
-    auto* screen = static_cast<SettingTimeFormat*>(obj->user_data);
-    screen->UpdateSelected(obj, event);
-  }
-}
-
 constexpr std::array<SettingTimeFormat::Option, 2> SettingTimeFormat::options;
 
 SettingTimeFormat::SettingTimeFormat(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
-  : Screen(app), settingsController {settingsController} {
 
-  lv_obj_t* container1 = lv_cont_create(lv_scr_act(), nullptr);
-
-  lv_obj_set_style_local_bg_opa(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
-  lv_obj_set_style_local_pad_all(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
-  lv_obj_set_style_local_pad_inner(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
-  lv_obj_set_style_local_border_width(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
-
-  lv_obj_set_pos(container1, 10, 60);
-  lv_obj_set_width(container1, LV_HOR_RES - 20);
-  lv_obj_set_height(container1, LV_VER_RES - 50);
-  lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
-
-  lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_static(title, "Time format");
-  lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 15, 15);
-
-  lv_obj_t* icon = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(icon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
-  lv_label_set_text_static(icon, Symbols::clock);
-  lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
-
-  for (unsigned int i = 0; i < options.size(); i++) {
-    cbOption[i] = lv_checkbox_create(container1, nullptr);
-    lv_checkbox_set_text(cbOption[i], options[i].name);
-    cbOption[i]->user_data = this;
-    lv_obj_set_event_cb(cbOption[i], event_handler);
-    SetRadioButtonStyle(cbOption[i]);
-  }
-
-  if (settingsController.GetClockType() == Controllers::Settings::ClockType::H12) {
-    lv_checkbox_set_checked(cbOption[0], true);
-  } else if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
-    lv_checkbox_set_checked(cbOption[1], true);
-  }
+  : Screen(app),
+    settingsController {settingsController},
+    settingScreen("Time format", Symbols::clock, entries, nEntries, objectArray, true) {
 }
 
 SettingTimeFormat::~SettingTimeFormat() {
   lv_obj_clean(lv_scr_act());
-  settingsController.SaveSettings();
-}
-
-void SettingTimeFormat::UpdateSelected(lv_obj_t* object, lv_event_t event) {
-  if (event == LV_EVENT_VALUE_CHANGED) {
-    for (unsigned int i = 0; i < options.size(); i++) {
-      if (object == cbOption[i]) {
-        lv_checkbox_set_checked(cbOption[i], true);
-        settingsController.SetClockType(options[i].clockType);
-      } else {
-        lv_checkbox_set_checked(cbOption[i], false);
-      }
+  for (size_t i = 0; i < nEntries; i++) {
+    if (lv_checkbox_is_checked(objectArray[i])) {
+      settingsController.SetClockType(options[i].clockType);
     }
   }
+  settingsController.SaveSettings();
 }

--- a/src/displayapp/screens/settings/SettingTimeFormat.h
+++ b/src/displayapp/screens/settings/SettingTimeFormat.h
@@ -6,6 +6,7 @@
 
 #include "components/settings/Settings.h"
 #include "displayapp/screens/Screen.h"
+#include "displayapp/screens/settings/SettingScreenBase.h"
 
 namespace Pinetime {
 
@@ -20,16 +21,26 @@ namespace Pinetime {
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
+        Controllers::Settings& settingsController;
+
         struct Option {
           Controllers::Settings::ClockType clockType;
           const char* name;
         };
-        static constexpr std::array<Option, 2> options = {{
+
+        static constexpr size_t nEntries = 2;
+
+        static constexpr std::array<Option, nEntries> options = {{
           {Controllers::Settings::ClockType::H12, "12-hour"},
           {Controllers::Settings::ClockType::H24, "24-hour"},
         }};
-        Controllers::Settings& settingsController;
-        lv_obj_t* cbOption[options.size()];
+
+        Pinetime::Applications::Screens::SettingScreenBase::Entry entries[nEntries] = {
+          {options[0].name, settingsController.GetClockType() == Controllers::Settings::ClockType::H12},
+          {options[1].name, settingsController.GetClockType() == Controllers::Settings::ClockType::H24},
+        };
+        lv_obj_t* objectArray[nEntries];
+        SettingScreenBase settingScreen;
       };
     }
   }


### PR DESCRIPTION
This will reduce duplication greatly once applied to other settings screens as well.

The checkbox object array is stored in the class creating the checkbox screen. This is so there can be any number of checkboxes, without using templates.

Do you have ideas for a better name for this class?

Let me know what you think about this approach.