### PR TITLE
Update clang-{format,tidy} to 14

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -60,6 +60,7 @@ DeriveLineEnding: false
 DerivePointerAlignment: false
 DisableFormat: false
 EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: true
 FixNamespaceComments: false
 ForEachMacros:
@@ -113,6 +114,7 @@ SpaceAfterCStyleCast: true
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: true
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true

--- a/.clang-format
+++ b/.clang-format
@@ -59,6 +59,7 @@ Cpp11BracedListStyle: true
 DeriveLineEnding: false
 DerivePointerAlignment: false
 DisableFormat: false
+EmptyLineAfterAccessModifier: Never
 ExperimentalAutoDetectBinPacking: true
 FixNamespaceComments: false
 ForEachMacros:
@@ -78,6 +79,7 @@ IncludeCategories:
     SortPriority: 0
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
 IndentCaseLabels: true
 IndentGotoLabels: true
 IndentPPDirectives: BeforeHash
@@ -92,6 +94,7 @@ MacroBlockBegin: ''
 MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
+PackConstructorInitializers: NextLine
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
@@ -101,7 +104,9 @@ PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
+ReferenceAlignment: Pointer
 ReflowComments: true
+SeparateDefinitionBlocks: Always
 SortIncludes: false
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: true
@@ -123,7 +128,7 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
-# Needs new Clang: SpaceAroundPointerQualifiers: After
+SpaceAroundPointerQualifiers: Default
 Standard: Latest
 StatementMacros:
   - Q_UNUSED

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install clang-format
         run: |
           sudo apt-get update
-          sudo apt-get -y install clang-format-12
+          sudo apt-get -y install clang-format-14
 
       - name: Check formatting
         run: tests/test-format.sh
@@ -55,7 +55,7 @@ jobs:
     - name: Install clang-tidy
       run: |
         apt-get update
-        apt-get -y install clang-tidy-12
+        apt-get -y install clang-tidy-14
     - name: Prepare environment
       shell: bash
       env:

--- a/src/components/ble/BatteryInformationService.cpp
+++ b/src/components/ble/BatteryInformationService.cpp
@@ -49,6 +49,7 @@ int BatteryInformationService::OnBatteryServiceRequested(uint16_t connectionHand
   }
   return 0;
 }
+
 void BatteryInformationService::NotifyBatteryLevel(uint16_t connectionHandle, uint8_t level) {
   auto* om = ble_hs_mbuf_from_flat(&level, 1);
   ble_gattc_notify_custom(connectionHandle, batteryLevelHandle, om);

--- a/src/components/ble/MotionService.cpp
+++ b/src/components/ble/MotionService.cpp
@@ -90,6 +90,7 @@ void MotionService::OnNewStepCountValue(uint32_t stepCount) {
 
   ble_gattc_notify_custom(connectionHandle, stepCountHandle, om);
 }
+
 void MotionService::OnNewMotionValues(int16_t x, int16_t y, int16_t z) {
   if (!motionValuesNoficationEnabled)
     return;

--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -142,6 +142,7 @@ void DateTime::Register(Pinetime::System::SystemTask* systemTask) {
 }
 
 using ClockType = Pinetime::Controllers::Settings::ClockType;
+
 std::string DateTime::FormattedTime() {
   // Return time as a string in 12- or 24-hour format
   char buff[9];

--- a/src/components/fs/FS.cpp
+++ b/src/components/fs/FS.cpp
@@ -89,18 +89,23 @@ int FS::DirClose(lfs_dir_t* lfs_dir) {
 int FS::DirRead(lfs_dir_t* dir, lfs_info* info) {
   return lfs_dir_read(&lfs, dir, info);
 }
+
 int FS::DirRewind(lfs_dir_t* dir) {
   return lfs_dir_rewind(&lfs, dir);
 }
+
 int FS::DirCreate(const char* path) {
   return lfs_mkdir(&lfs, path);
 }
+
 int FS::Rename(const char* oldPath, const char* newPath) {
   return lfs_rename(&lfs, oldPath, newPath);
 }
+
 int FS::Stat(const char* path, lfs_info* info) {
   return lfs_stat(&lfs, path, info);
 }
+
 lfs_ssize_t FS::GetFSSize() {
   return lfs_fs_size(&lfs);
 }

--- a/src/components/motion/MotionController.cpp
+++ b/src/components/motion/MotionController.cpp
@@ -61,6 +61,7 @@ bool MotionController::Should_ShakeWake(uint16_t thresh) {
   lastZForShake = z;
   return wake;
 }
+
 int32_t MotionController::currentShakeSpeed() {
   return accumulatedspeed;
 }
@@ -68,6 +69,7 @@ int32_t MotionController::currentShakeSpeed() {
 void MotionController::IsSensorOk(bool isOk) {
   isSensorOk = isOk;
 }
+
 void MotionController::Init(Pinetime::Drivers::Bma421::DeviceTypes types) {
   switch (types) {
     case Drivers::Bma421::DeviceTypes::BMA421:
@@ -81,6 +83,7 @@ void MotionController::Init(Pinetime::Drivers::Bma421::DeviceTypes types) {
       break;
   }
 }
+
 void MotionController::SetService(Pinetime::Controllers::MotionService* service) {
   this->service = service;
 }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -529,6 +529,7 @@ void DisplayApp::PushMessageToSystemTask(Pinetime::System::Messages message) {
 void DisplayApp::Register(Pinetime::System::SystemTask* systemTask) {
   this->systemTask = systemTask;
 }
+
 void DisplayApp::ApplyBrightness() {
   auto brightness = settingsController.GetBrightness();
   if (brightness != Controllers::BrightnessController::Levels::Low && brightness != Controllers::BrightnessController::Levels::Medium &&

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -333,6 +333,7 @@ void WatchFaceCasioStyleG7710::Refresh() {
     lv_obj_realign(stepIcon);
   }
 }
+
 bool WatchFaceCasioStyleG7710::IsAvailable(Pinetime::Controllers::FS& filesystem) {
   lfs_file file = {};
 

--- a/src/displayapp/screens/settings/SettingSetTime.cpp
+++ b/src/displayapp/screens/settings/SettingSetTime.cpp
@@ -18,6 +18,7 @@ namespace {
       screen->SetTime();
     }
   }
+
   void ValueChangedHandler(void* userData) {
     auto* screen = static_cast<SettingSetTime*>(userData);
     screen->UpdateScreen();

--- a/src/displayapp/widgets/Counter.cpp
+++ b/src/displayapp/widgets/Counter.cpp
@@ -18,6 +18,7 @@ namespace {
       widget->DownBtnPressed();
     }
   }
+
   constexpr int digitCount(int number) {
     int digitCount = 0;
     while (number > 0) {
@@ -67,6 +68,7 @@ void Counter::HideControls() {
   lv_obj_set_hidden(lowerLine, true);
   lv_obj_set_style_local_bg_opa(counterContainer, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
 }
+
 void Counter::ShowControls() {
   lv_obj_set_hidden(upBtn, false);
   lv_obj_set_hidden(downBtn, false);

--- a/src/drivers/Bma421.cpp
+++ b/src/drivers/Bma421.cpp
@@ -118,6 +118,7 @@ Bma421::Values Bma421::Process() {
   // X and Y axis are swapped because of the way the sensor is mounted in the PineTime
   return {steps, data.y, data.x, data.z};
 }
+
 bool Bma421::IsOk() const {
   return isOk;
 }
@@ -133,6 +134,7 @@ void Bma421::SoftReset() {
     nrf_delay_ms(1);
   }
 }
+
 Bma421::DeviceTypes Bma421::DeviceType() const {
   return deviceType;
 }

--- a/src/drivers/DebugPins.cpp
+++ b/src/drivers/DebugPins.cpp
@@ -18,6 +18,7 @@ void debugpins_init() {
   nrf_gpio_cfg_output(DebugPin4);
   nrf_gpio_pin_clear(DebugPin4);
 }
+
 void debugpins_set(debugpins_pins pin) {
   nrf_gpio_pin_set(static_cast<uint32_t>(pin));
 }
@@ -33,6 +34,7 @@ void debugpins_pulse(debugpins_pins pin) {
 #else
 void debugpins_init() {
 }
+
 void debugpins_set(debugpins_pins pin) {
 }
 

--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -13,6 +13,7 @@
 #include <nrf_log.h>
 
 using namespace Pinetime::Drivers;
+
 /** Driver for the HRS3300 heart rate sensor.
  * Original implementation from wasp-os : https://github.com/daniel-thompson/wasp-os/blob/master/wasp/drivers/hrs3300.py
  */

--- a/src/recoveryLoader.cpp
+++ b/src/recoveryLoader.cpp
@@ -81,6 +81,7 @@ void RefreshWatchdog() {
 }
 
 uint8_t displayBuffer[displayWidth * bytesPerPixel];
+
 void Process(void* instance) {
   RefreshWatchdog();
   APP_GPIOTE_INIT(2);

--- a/tests/test-format.sh
+++ b/tests/test-format.sh
@@ -20,7 +20,7 @@ do
   *.cpp|*.h)
     echo Checking "$file"
     PATCH="$(basename "$file").patch"
-    git clang-format-12 -q --style file --diff "$GITHUB_BASE_REF" "$file" > "$PATCH"
+    git clang-format-14 -q --style file --diff "$GITHUB_BASE_REF" "$file" > "$PATCH"
     if [ -s "$PATCH" ]
     then
       printf "\033[31mError:\033[0m Formatting error in %s\n" "$file"

--- a/tests/test-tidy.sh
+++ b/tests/test-tidy.sh
@@ -17,7 +17,7 @@ do
   src/libs/*|src/FreeRTOS/*) continue ;;
   *.cpp|*.h)
     echo "::group::$file"
-    clang-tidy-12 -p build "$file" || true
+    clang-tidy-14 -p build "$file" || true
     echo "::endgroup::"
   esac
 done


### PR DESCRIPTION
Now that the GH Actions VMs have updated to Ubuntu 22.04, clang can be updated to 14 over 12. I've looked through all the clang-format options that have been added in 13 and 14, and added the ones I believe fit our coding style. These options are: `EmptyLineAfterAccessModifier: Never`, `IndentAccessModifiers: false`, `PackConstructorInitializers: Default`, `ReferenceAlignment: Pointer` and `SeparateDefinitionBlocks: Always`. All of these except the last one don't actually change the formatting at all, just prevent any incorrect formatting in the future. The last one adds some new lines between definition blocks in some cases.

This change fixes a compiler error in the clang-tidy check, about the `-fstack-usage` flag.