### PR TITLE
Update GCC (in doc and docker) to GCC12

### DIFF
--- a/doc/buildAndProgram.md
+++ b/doc/buildAndProgram.md
@@ -4,7 +4,7 @@
 
 To build this project, you'll need:
 
-- A cross-compiler : [ARM-GCC (10.3-2021.10)](https://developer.arm.com/downloads/-/gnu-rm)
+- A cross-compiler : [ARM-GCC 12.2-Rel1 from December 22, 2022 (AArch32 bare-metal target (arm-none-eabi))](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads)
 - The NRF52 SDK 15.3.0 : [nRF-SDK v15.3.0](https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip)
 - The Python 3 modules `cbor`, `intelhex`, `click` and `cryptography` modules for the `mcuboot` tool (see [requirements.txt](../tools/mcuboot/requirements.txt))
   - To keep the system clean, you can install python modules into a python virtual environment (`venv`)

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -16,13 +16,13 @@ export NPM_DIR="$BUILD_DIR/npm"
 export npm_config_cache="${NPM_DIR}"
 
 export BUILD_TYPE=${BUILD_TYPE:=Release}
-export GCC_ARM_VER=${GCC_ARM_VER:="10.3-2021.10"}
+export GCC_ARM_VER=${GCC_ARM_VER:="12.2.rel1"}
 export NRF_SDK_VER=${NRF_SDK_VER:="nRF5_SDK_15.3.0_59ac345"}
 
 MACHINE="$(uname -m)"
 [[ "$MACHINE" == "arm64" ]] && MACHINE="aarch64"
 
-export GCC_ARM_PATH="gcc-arm-none-eabi-$GCC_ARM_VER"
+export GCC_ARM_PATH="arm-gnu-toolchain-$GCC_ARM_VER-$MACHINE-arm-none-eabi"
 
 main() {
   local target="$1"
@@ -46,7 +46,7 @@ main() {
 }
 
 GetGcc() {
-  wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/$GCC_ARM_VER/$GCC_ARM_PATH-$MACHINE-linux.tar.bz2 -O - | tar -xj -C $TOOLS_DIR/
+  wget -q https://developer.arm.com/-/media/Files/downloads/gnu/$GCC_ARM_VER/binrel/arm-gnu-toolchain-$GCC_ARM_VER-$MACHINE-arm-none-eabi.tar.xz -O - | tar -xJ -C $TOOLS_DIR/
 }
 
 GetMcuBoot() {


### PR DESCRIPTION
Update the documentation and Dockerfile to use GCC12. A newer version of GCC is needed to use features from C++20 like `concepts`. Needed by #1387.