### PR TITLE
Add a simple low pass filter for battery voltage

### DIFF
--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <drivers/include/nrfx_saadc.h>
 #include <systemtask/SystemTask.h>
+#include "components/utility/SimpleLowPassFilter.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -38,6 +39,7 @@ namespace Pinetime {
     private:
       static Battery* instance;
       nrf_saadc_value_t saadc_value;
+      Utility::SimpleLowPassFilter<uint16_t, 5> filter;
 
       static constexpr nrf_saadc_input_t batteryVoltageAdcInput = NRF_SAADC_INPUT_AIN7;
       uint16_t voltage = 0;

--- a/src/components/utility/SimpleLowPassFilter.h
+++ b/src/components/utility/SimpleLowPassFilter.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace Pinetime {
+  namespace Utility {
+
+    // See https://en.wikipedia.org/wiki/Low-pass_filter
+    template <typename Value, Value k = 2> class SimpleLowPassFilter {
+    public:
+      SimpleLowPassFilter() = default;
+
+      SimpleLowPassFilter(Value start) : prev {start} {
+      }
+
+      Value GetValue(Value current) {
+        return prev += (current - prev) / k;
+      }
+
+      void Reset(Value start) {
+        prev = start;
+      }
+
+    private:
+      Value prev;
+    };
+  }
+}


### PR DESCRIPTION
Sometimes I noticed that battery percentage might drops to 5-10%, then stay at the same level during a full day. During a little investigation I found that this behavior is related to noise in voltage measuring data. This PR should improve showing battery percentage by using low pass filter for battery voltage.

There is some data which I measured and used for comparing old and a new versions:
Clear plot:
![image](https://user-images.githubusercontent.com/3096462/210737555-80df829a-8733-45aa-bfbb-e9e854a665c4.png)
Findings:
![image](https://user-images.githubusercontent.com/3096462/210735225-d025f449-ad7a-4d00-8822-22e20342d421.png)
Source data: [battery.csv](https://github.com/InfiniTimeOrg/InfiniTime/files/10350577/battery_04.01.22.csv)

On the plot you can see blue line is old data and orange line is a new data.

Summary of improvements:
1. Battery discharge curve looks more stable without significant drops
2. The start of the percentage drop is a little slow to make it more stable and match the rest of the discharge time
3. 0% battery is when the watch stops working or about 1-2 hours after that.