### PR TITLE
Add maintainer's guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ Fast open-source firmware for the [PineTime smartwatch](https://www.pine64.org/p
 - [Tips on designing an app UI](doc/ui_guidelines.md)
 - [Bootloader, OTA and DFU](bootloader/README.md)
 - [External resources](doc/ExternalResources.md)
-- [Versioning](doc/versioning.md)
-- [Project branches](doc/branches.md)
-- [Files included in the release notes](doc/filesInReleaseNotes.md)
-- [Maintainer's guide](doc/maintainer-guide.md)
 
 ### Contributing
 
@@ -60,6 +56,13 @@ Fast open-source firmware for the [PineTime smartwatch](https://www.pine64.org/p
 ### Architecture and technical topics
 
 - [Memory analysis](doc/MemoryAnalysis.md)
+
+### Project management
+
+- [Maintainer's guide](doc/maintainer-guide.md)
+- [Versioning](doc/versioning.md)
+- [Project branches](doc/branches.md)
+- [Files included in the release notes](doc/filesInReleaseNotes.md)
 
 ## Licenses
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Fast open-source firmware for the [PineTime smartwatch](https://www.pine64.org/p
 - [Versioning](doc/versioning.md)
 - [Project branches](doc/branches.md)
 - [Files included in the release notes](doc/filesInReleaseNotes.md)
+- [Maintainer's guide](doc/maintainer-guide.md)
 
 ### Contributing
 

--- a/doc/maintainer-guide.md
+++ b/doc/maintainer-guide.md
@@ -1,0 +1,45 @@
+# Reviewing PRs
+
+Approving a PR means that the reviewer has deemed the PR ready to be merged.
+
+There are two steps to reviewing PRs.
+
+- Review the feature:
+
+  - Consider if the feature aligns with the [InfiniTime vision](InfiniTimeVision.md)
+  - Discuss alternative ideas or implementations
+
+- Review the code:
+
+  - Check the quality of the code and make sure it conforms to the [coding conventions](coding-convention.md)
+  - Consider the maintainability of the code
+  - Test the code with at least InfiniSim or a PineTime
+
+# Merging PRs
+
+Two approvals from core developers is usually required to merge a PR.
+Exceptions include urgent fixes
+and small maintenance PRs by core developers,
+that don't affect the apparent behaviour of the watch in any way.
+
+All but the simulator check must be passed before merging a PR.
+
+PRs are either rebase or squash merged,
+depending on whether the commits satisfy the following requirements:
+
+### Commits
+
+- Commits that fix mistakes from previous commits must be squashed before merging a PR.
+- The title and description of the commit must sufficiently explain the changes in the commit.
+
+If these requirements are not met,
+the PR must be squash merged,
+and the merger must write a satisfactory description.
+
+# Stale PRs
+
+Work-in-Progress PRs shall be marked as draft.
+
+Draft PRs with no activity by the author for 3 months may be closed as stale.
+
+PRs with changes requested, but no activity by the author for 3 months may be closed as stale.


### PR DESCRIPTION
This document clarifies how the maintainers should manage the project.

We should write about using the milestones as well, but I want to discuss that first. I'll open an issue about that. If that doesn't get resolved in time, it can be another PR. EDIT: Here's the issue #1515

I've added new instructions on handling stale PRs. Three months is quite conservative, as it concerns any activity, and can be reduced. Let me know what you think.