### PR TITLE
workflows: Fix build size comparison workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - 'doc/**'
       - '**.md'
-  pull_request:
+  pull_request_target:
     branches: [ develop ]
     paths-ignore:
       - 'doc/**'
@@ -99,7 +99,7 @@ jobs:
         path: build_lv_sim/infinisim
 
   get-base-ref-size:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-22.04
     container:
       image: infinitime/infinitime-build
@@ -139,7 +139,7 @@ jobs:
         .github/workflows/getSize.sh "$BUILD_DIR"/src/pinetime-app-*.out >> $GITHUB_OUTPUT
 
   leave-build-size-comment:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     needs: [build-firmware, get-base-ref-size]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
In public repositories, create-or-update-comment action doesn't work in workflows triggered by the pull_request event, due to restrictions in GitHub Actions. Use pull_request_target event instead.

Let's see if this works.