### PR TITLE
block notifications when flashlight is on - first quick try

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -459,7 +459,7 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
                                                             touchPanel);
       break;
     case Apps::FlashLight:
-      currentScreen = std::make_unique<Screens::FlashLight>(this, *systemTask, brightnessController);
+      currentScreen = std::make_unique<Screens::FlashLight>(this, *systemTask, brightnessController, settingsController);
       break;
     case Apps::StopWatch:
       currentScreen = std::make_unique<Screens::StopWatch>(this, *systemTask);

--- a/src/displayapp/screens/FlashLight.cpp
+++ b/src/displayapp/screens/FlashLight.cpp
@@ -16,8 +16,9 @@ namespace {
 
 FlashLight::FlashLight(Pinetime::Applications::DisplayApp* app,
                        System::SystemTask& systemTask,
-                       Controllers::BrightnessController& brightnessController)
-  : Screen(app), systemTask {systemTask}, brightnessController {brightnessController} {
+                       Controllers::BrightnessController& brightnessController,
+                       Pinetime::Controllers::Settings& settingsController)
+  : Screen(app), systemTask {systemTask}, brightnessController {brightnessController}, settingsController {settingsController} {
 
   brightnessController.Set(Controllers::BrightnessController::Levels::Low);
 
@@ -54,6 +55,9 @@ FlashLight::FlashLight(Pinetime::Applications::DisplayApp* app,
 FlashLight::~FlashLight() {
   lv_obj_clean(lv_scr_act());
   lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  if (notificationsStatus) {
+      settingsController.SetNotificationStatus(Controllers::Settings::Notification::On);
+  }
   systemTask.PushMessage(Pinetime::System::Messages::EnableSleeping);
 }
 
@@ -90,7 +94,14 @@ void FlashLight::Toggle() {
   SetColors();
   if (isOn) {
     brightnessController.Set(brightnessLevel);
+    if (settingsController.GetNotificationStatus() == Controllers::Settings::Notification::On) {
+      notificationsStatus = true;
+      settingsController.SetNotificationStatus(Controllers::Settings::Notification::Off);
+    }
   } else {
+    if (notificationsStatus) {
+      settingsController.SetNotificationStatus(Controllers::Settings::Notification::On);
+    }
     brightnessController.Set(Controllers::BrightnessController::Levels::Low);
   }
 }

--- a/src/displayapp/screens/FlashLight.h
+++ b/src/displayapp/screens/FlashLight.h
@@ -2,6 +2,7 @@
 
 #include "displayapp/screens/Screen.h"
 #include "components/brightness/BrightnessController.h"
+#include "components/settings/Settings.h"
 #include "systemtask/SystemTask.h"
 #include <cstdint>
 #include <lvgl/lvgl.h>
@@ -13,7 +14,7 @@ namespace Pinetime {
 
       class FlashLight : public Screen {
       public:
-        FlashLight(DisplayApp* app, System::SystemTask& systemTask, Controllers::BrightnessController& brightness);
+        FlashLight(DisplayApp* app, System::SystemTask& systemTask, Controllers::BrightnessController& brightness, Pinetime::Controllers::Settings& settingsController);
         ~FlashLight() override;
 
         bool OnTouchEvent(Pinetime::Applications::TouchEvents event) override;
@@ -25,6 +26,7 @@ namespace Pinetime {
 
         Pinetime::System::SystemTask& systemTask;
         Controllers::BrightnessController& brightnessController;
+        Controllers::Settings& settingsController;
 
         Controllers::BrightnessController::Levels brightnessLevel = Controllers::BrightnessController::Levels::High;
 
@@ -32,6 +34,7 @@ namespace Pinetime {
         lv_obj_t* backgroundAction;
         lv_obj_t* indicators[3];
         bool isOn = false;
+        bool notificationsStatus = false;
       };
     }
   }


### PR DESCRIPTION
**Premise:** _I don't know if this is the right approach to accomplish this._

Quick (possible) solution to this #1522 issue/enhancement. Made a quick before/after video comparison to demonstrate the solution.

Before:

![before](https://user-images.githubusercontent.com/7011942/212468207-f272c111-719e-483f-bd0f-77d33d28fff8.gif)

After:

![after](https://user-images.githubusercontent.com/7011942/212468213-6931505c-f5b0-45f0-9067-4bcf946de329.gif)

The basic strategy here is to check if  `settingsController.GetNotificationStatus()` is `On` when Flashlight is toggled, then act accordingly keeping track of the previous notification status with `bool notificationsStatus` to be able to revert the setting once Flashlight is off.

