### PR TITLE
Fix Apps documentation DisplayApp method name

### DIFF
--- a/doc/code/Apps.md
+++ b/doc/code/Apps.md
@@ -95,7 +95,7 @@ in the compilation by adding it to [CMakeLists.txt](/CMakeLists.txt).
 The next step to making it launchable is to give your app an id.
 To do this, add an entry in the enum class `Pinetime::Applications::Apps` ([displayapp/Apps.h](/src/displayapp/Apps.h)).
 Name this entry after your app. Add `#include "displayapp/screens/MyApp.h"` to the file [displayapp/DisplayApp.cpp](/src/displayapp/DisplayApp.cpp).
-Now, go to the function `DisplayApp::LoadApp` and add another case to the switch statement.
+Now, go to the function `DisplayApp::LoadScreen` and add another case to the switch statement.
 The case will be the id you gave your app earlier.
 If your app needs any additional arguments, this is the place to pass them.
 


### PR DESCRIPTION
This fixes Apps creation documentation old and no longer correct `DisplayApp::LoadApp`, it was at some point replaced/renamed to `DisplayApp::LoadScreen`.

As a beginner myself it was confusing first time setting up, correct information here would be more inviting to new people :)