### PR TITLE
Use checkboxlist in Bluetooth and Chimes settings

### DIFF
--- a/src/displayapp/screens/settings/SettingBluetooth.cpp
+++ b/src/displayapp/screens/settings/SettingBluetooth.cpp
@@ -9,84 +9,52 @@
 using namespace Pinetime::Applications::Screens;
 
 namespace {
-  void OnBluetoothDisabledEvent(lv_obj_t* obj, lv_event_t event) {
-    auto* screen = static_cast<SettingBluetooth*>(obj->user_data);
-    screen->OnBluetoothDisabled(event);
-  }
+  struct Option {
+    const char* name;
+    bool radioEnabled;
+  };
 
-  void OnBluetoothEnabledEvent(lv_obj_t* obj, lv_event_t event) {
-    auto* screen = static_cast<SettingBluetooth*>(obj->user_data);
-    screen->OnBluetoothEnabled(event);
-  }
+  constexpr std::array<Option, 2> options = {{
+    {"Enabled", true},
+    {"Disabled", false},
+  }};
+
+  std::array<CheckboxList::Item, CheckboxList::MaxItems> CreateOptionArray() {
+    std::array<Pinetime::Applications::Screens::CheckboxList::Item, CheckboxList::MaxItems> optionArray;
+    for (size_t i = 0; i < CheckboxList::MaxItems; i++) {
+      if (i >= options.size()) {
+        optionArray[i].name = "";
+        optionArray[i].enabled = false;
+      } else {
+        optionArray[i].name = options[i].name;
+        optionArray[i].enabled = true;
+      }
+    }
+    return optionArray;
+  };
 }
 
 SettingBluetooth::SettingBluetooth(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
-  : Screen(app), settingsController {settingsController} {
-
-  lv_obj_t* container1 = lv_cont_create(lv_scr_act(), nullptr);
-
-  lv_obj_set_style_local_bg_opa(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
-  lv_obj_set_style_local_pad_all(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
-  lv_obj_set_style_local_pad_inner(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
-  lv_obj_set_style_local_border_width(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
-
-  lv_obj_set_pos(container1, 10, 60);
-  lv_obj_set_width(container1, LV_HOR_RES - 20);
-  lv_obj_set_height(container1, LV_VER_RES - 50);
-  lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
-
-  lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_static(title, "Bluetooth");
-  lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 15, 15);
-
-  lv_obj_t* icon = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(icon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
-  lv_label_set_text_static(icon, Symbols::bluetooth);
-  lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
-
-  cbEnabled = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text(cbEnabled, " Enabled");
-  cbEnabled->user_data = this;
-  lv_obj_set_event_cb(cbEnabled, OnBluetoothEnabledEvent);
-  SetRadioButtonStyle(cbEnabled);
-
-  cbDisabled = lv_checkbox_create(container1, nullptr);
-  lv_checkbox_set_text(cbDisabled, " Disabled");
-  cbDisabled->user_data = this;
-  lv_obj_set_event_cb(cbDisabled, OnBluetoothDisabledEvent);
-  SetRadioButtonStyle(cbDisabled);
-
-  if (settingsController.GetBleRadioEnabled()) {
-    lv_checkbox_set_checked(cbEnabled, true);
-    priorMode = true;
-  } else {
-    lv_checkbox_set_checked(cbDisabled, true);
-    priorMode = false;
-  }
+  : Screen(app),
+    checkboxList(
+      0,
+      1,
+      app,
+      "Bluetooth",
+      Symbols::bluetooth,
+      settingsController.GetBleRadioEnabled() ? 0 : 1,
+      [&settings = settingsController](uint32_t index) {
+        const bool priorMode = settings.GetBleRadioEnabled();
+        const bool newMode = options[index].radioEnabled;
+        if (newMode != priorMode) {
+          settings.SetBleRadioEnabled(newMode);
+        }
+      },
+      CreateOptionArray()) {
 }
 
 SettingBluetooth::~SettingBluetooth() {
   lv_obj_clean(lv_scr_act());
-  // Do not call SaveSettings - see src/components/settings/Settings.h
-  if (priorMode != settingsController.GetBleRadioEnabled()) {
-    app->PushMessage(Pinetime::Applications::Display::Messages::BleRadioEnableToggle);
-  }
-}
-
-void SettingBluetooth::OnBluetoothDisabled(lv_event_t event) {
-  if (event == LV_EVENT_VALUE_CHANGED) {
-    lv_checkbox_set_checked(cbEnabled, false);
-    lv_checkbox_set_checked(cbDisabled, true);
-    settingsController.SetBleRadioEnabled(false);
-  }
-}
-
-void SettingBluetooth::OnBluetoothEnabled(lv_event_t event) {
-  if (event == LV_EVENT_VALUE_CHANGED) {
-    lv_checkbox_set_checked(cbEnabled, true);
-    lv_checkbox_set_checked(cbDisabled, false);
-    settingsController.SetBleRadioEnabled(true);
-  }
+  // Pushing the message in the OnValueChanged function causes a freeze?
+  app->PushMessage(Pinetime::Applications::Display::Messages::BleRadioEnableToggle);
 }

--- a/src/displayapp/screens/settings/SettingBluetooth.h
+++ b/src/displayapp/screens/settings/SettingBluetooth.h
@@ -6,6 +6,7 @@
 
 #include "components/settings/Settings.h"
 #include "displayapp/screens/Screen.h"
+#include "displayapp/screens/CheckboxList.h"
 
 namespace Pinetime {
 
@@ -17,14 +18,8 @@ namespace Pinetime {
         SettingBluetooth(DisplayApp* app, Pinetime::Controllers::Settings& settingsController);
         ~SettingBluetooth() override;
 
-        void OnBluetoothEnabled(lv_event_t event);
-        void OnBluetoothDisabled(lv_event_t event);
-
       private:
-        Controllers::Settings& settingsController;
-        lv_obj_t* cbEnabled;
-        lv_obj_t* cbDisabled;
-        bool priorMode;
+        CheckboxList checkboxList;
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingChimes.cpp
+++ b/src/displayapp/screens/settings/SettingChimes.cpp
@@ -4,70 +4,62 @@
 #include "displayapp/screens/Styles.h"
 #include "displayapp/screens/Screen.h"
 #include "displayapp/screens/Symbols.h"
+#include <array>
 
 using namespace Pinetime::Applications::Screens;
 
 namespace {
-  void event_handler(lv_obj_t* obj, lv_event_t event) {
-    auto* screen = static_cast<SettingChimes*>(obj->user_data);
-    screen->UpdateSelected(obj, event);
+  struct Option {
+    Pinetime::Controllers::Settings::ChimesOption chimesOption;
+    const char* name;
+  };
+
+  constexpr std::array<Option, 3> options = {{
+    {Pinetime::Controllers::Settings::ChimesOption::None, "Off"},
+    {Pinetime::Controllers::Settings::ChimesOption::Hours, "Every hour"},
+    {Pinetime::Controllers::Settings::ChimesOption::HalfHours, "Every 30 mins"},
+  }};
+
+  std::array<CheckboxList::Item, CheckboxList::MaxItems> CreateOptionArray() {
+    std::array<Pinetime::Applications::Screens::CheckboxList::Item, CheckboxList::MaxItems> optionArray;
+    for (size_t i = 0; i < CheckboxList::MaxItems; i++) {
+      if (i >= options.size()) {
+        optionArray[i].name = "";
+        optionArray[i].enabled = false;
+      } else {
+        optionArray[i].name = options[i].name;
+        optionArray[i].enabled = true;
+      }
+    }
+    return optionArray;
+  }
+
+  uint32_t GetDefaultOption(Pinetime::Controllers::Settings::ChimesOption currentOption) {
+    for (size_t i = 0; i < options.size(); i++) {
+      if (options[i].chimesOption == currentOption) {
+        return i;
+      }
+    }
+    return 0;
   }
 }
 
-constexpr std::array<SettingChimes::Option, 3> SettingChimes::options;
-
 SettingChimes::SettingChimes(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
-  : Screen(app), settingsController {settingsController} {
-
-  lv_obj_t* container1 = lv_cont_create(lv_scr_act(), nullptr);
-
-  lv_obj_set_style_local_bg_opa(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
-  lv_obj_set_style_local_pad_all(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
-  lv_obj_set_style_local_pad_inner(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 5);
-  lv_obj_set_style_local_border_width(container1, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
-
-  lv_obj_set_pos(container1, 10, 60);
-  lv_obj_set_width(container1, LV_HOR_RES - 20);
-  lv_obj_set_height(container1, LV_VER_RES - 50);
-  lv_cont_set_layout(container1, LV_LAYOUT_COLUMN_LEFT);
-
-  lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_static(title, "Chimes");
-  lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 10, 15);
-
-  lv_obj_t* icon = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(icon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
-  lv_label_set_text_static(icon, Symbols::clock);
-  lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
-
-  for (unsigned int i = 0; i < options.size(); i++) {
-    cbOption[i] = lv_checkbox_create(container1, nullptr);
-    lv_checkbox_set_text(cbOption[i], options[i].name);
-    if (settingsController.GetChimeOption() == options[i].chimesOption) {
-      lv_checkbox_set_checked(cbOption[i], true);
-    }
-    cbOption[i]->user_data = this;
-    lv_obj_set_event_cb(cbOption[i], event_handler);
-    SetRadioButtonStyle(cbOption[i]);
-  }
+  : Screen(app),
+    checkboxList(
+      0,
+      1,
+      app,
+      "Chimes",
+      Symbols::clock,
+      GetDefaultOption(settingsController.GetChimeOption()),
+      [&settings = settingsController](uint32_t index) {
+        settings.SetChimeOption(options[index].chimesOption);
+        settings.SaveSettings();
+      },
+      CreateOptionArray()) {
 }
 
 SettingChimes::~SettingChimes() {
   lv_obj_clean(lv_scr_act());
-  settingsController.SaveSettings();
-}
-
-void SettingChimes::UpdateSelected(lv_obj_t* object, lv_event_t event) {
-  if (event == LV_EVENT_VALUE_CHANGED) {
-    for (uint8_t i = 0; i < options.size(); i++) {
-      if (object == cbOption[i]) {
-        lv_checkbox_set_checked(cbOption[i], true);
-        settingsController.SetChimeOption(options[i].chimesOption);
-      } else {
-        lv_checkbox_set_checked(cbOption[i], false);
-      }
-    }
-  }
 }

--- a/src/displayapp/screens/settings/SettingChimes.h
+++ b/src/displayapp/screens/settings/SettingChimes.h
@@ -2,9 +2,10 @@
 
 #include <cstdint>
 #include <lvgl/lvgl.h>
+
 #include "components/settings/Settings.h"
 #include "displayapp/screens/Screen.h"
-#include <array>
+#include "displayapp/screens/CheckboxList.h"
 
 namespace Pinetime {
 
@@ -19,18 +20,7 @@ namespace Pinetime {
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
       private:
-        struct Option {
-          Controllers::Settings::ChimesOption chimesOption;
-          const char* name;
-        };
-
-        static constexpr std::array<Option, 3> options = {{{Controllers::Settings::ChimesOption::None, "Off"},
-                                                           {Controllers::Settings::ChimesOption::Hours, "Every hour"},
-                                                           {Controllers::Settings::ChimesOption::HalfHours, "Every 30 mins"}}};
-
-        std::array<lv_obj_t*, options.size()> cbOption;
-
-        Controllers::Settings& settingsController;
+        CheckboxList checkboxList;
       };
     }
   }


### PR DESCRIPTION
Only timeout and wakeup screens left, which will require changes in CheckboxList.