### PR TITLE
clang-format: Always break template declarations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,7 +20,7 @@ AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false
 BraceWrapping:

--- a/src/StaticStack.h
+++ b/src/StaticStack.h
@@ -1,7 +1,8 @@
 #include <array>
 #include <cstddef>
 
-template <typename T, size_t N> class StaticStack {
+template <typename T, size_t N>
+class StaticStack {
 public:
   T Pop();
   void Push(T element);
@@ -15,24 +16,28 @@ private:
 };
 
 // Returns random data when popping from empty array.
-template <typename T, size_t N> T StaticStack<T, N>::Pop() {
+template <typename T, size_t N>
+T StaticStack<T, N>::Pop() {
   if (stackPointer > 0) {
     stackPointer--;
   }
   return elementArray[stackPointer];
 }
 
-template <typename T, size_t N> void StaticStack<T, N>::Push(T element) {
+template <typename T, size_t N>
+void StaticStack<T, N>::Push(T element) {
   if (stackPointer < elementArray.size()) {
     elementArray[stackPointer] = element;
     stackPointer++;
   }
 }
 
-template <typename T, size_t N> void StaticStack<T, N>::Reset() {
+template <typename T, size_t N>
+void StaticStack<T, N>::Reset() {
   stackPointer = 0;
 }
 
-template <typename T, size_t N> T StaticStack<T, N>::Top() {
+template <typename T, size_t N>
+T StaticStack<T, N>::Top() {
   return elementArray[stackPointer - 1];
 }

--- a/src/components/utility/LinearApproximation.h
+++ b/src/components/utility/LinearApproximation.h
@@ -7,7 +7,8 @@ namespace Pinetime {
   namespace Utility {
 
     // based on: https://github.com/SHristov92/LinearApproximation/blob/main/Linear.h
-    template <typename Key, typename Value, std::size_t Size> class LinearApproximation {
+    template <typename Key, typename Value, std::size_t Size>
+    class LinearApproximation {
       using Point = struct {
         Key key;
         Value value;

--- a/src/displayapp/screens/Screen.h
+++ b/src/displayapp/screens/Screen.h
@@ -10,7 +10,8 @@ namespace Pinetime {
 
     namespace Screens {
 
-      template <class T> class DirtyValue {
+      template <class T>
+      class DirtyValue {
       public:
         DirtyValue() = default; // Use NSDMI
 

--- a/src/displayapp/screens/ScreenList.h
+++ b/src/displayapp/screens/ScreenList.h
@@ -12,7 +12,8 @@ namespace Pinetime {
 
       enum class ScreenListModes { UpDown, RightLeft, LongPress };
 
-      template <size_t N> class ScreenList : public Screen {
+      template <size_t N>
+      class ScreenList : public Screen {
       public:
         ScreenList(DisplayApp* app,
                    uint8_t initScreen,


### PR DESCRIPTION
I find this format easier to read, because the definitions are at the expected indentation, making it easier to find what I'm looking for.