### PR TITLE
infineat: Create colors at compile time.

### DIFF
--- a/src/displayapp/screens/WatchFaceInfineat.cpp
+++ b/src/displayapp/screens/WatchFaceInfineat.cpp
@@ -17,6 +17,106 @@ namespace {
     auto* screen = static_cast<WatchFaceInfineat*>(obj->user_data);
     screen->UpdateSelected(obj, event);
   }
+
+  enum class colors {
+    orange,
+    blue,
+    green,
+    rainbow,
+    gray,
+    nordBlue,
+    nordGreen,
+  };
+
+  constexpr int nColors = 7; // must match number of colors in InfineatColors
+
+  constexpr int nLines = WatchFaceInfineat::nLines;
+
+  constexpr std::array<lv_color_t, nLines> orangeColors = {LV_COLOR_MAKE(0xfd, 0x87, 0x2b),
+                                                           LV_COLOR_MAKE(0xdb, 0x33, 0x16),
+                                                           LV_COLOR_MAKE(0x6f, 0x10, 0x00),
+                                                           LV_COLOR_MAKE(0xfd, 0x7a, 0x0a),
+                                                           LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                           LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                           LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                           LV_COLOR_MAKE(0xe8, 0x51, 0x02),
+                                                           LV_COLOR_MAKE(0xea, 0x1c, 0x00)};
+  constexpr std::array<lv_color_t, nLines> blueColors = {LV_COLOR_MAKE(0xe7, 0xf8, 0xff),
+                                                         LV_COLOR_MAKE(0x22, 0x32, 0xd0),
+                                                         LV_COLOR_MAKE(0x18, 0x2a, 0x8b),
+                                                         LV_COLOR_MAKE(0xe7, 0xf8, 0xff),
+                                                         LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                         LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                         LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                         LV_COLOR_MAKE(0x59, 0x91, 0xff),
+                                                         LV_COLOR_MAKE(0x16, 0x36, 0xff)};
+  constexpr std::array<lv_color_t, nLines> greenColors = {LV_COLOR_MAKE(0xb8, 0xff, 0x9b),
+                                                          LV_COLOR_MAKE(0x08, 0x86, 0x08),
+                                                          LV_COLOR_MAKE(0x00, 0x4a, 0x00),
+                                                          LV_COLOR_MAKE(0xb8, 0xff, 0x9b),
+                                                          LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                          LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                          LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                          LV_COLOR_MAKE(0x62, 0xd5, 0x15),
+                                                          LV_COLOR_MAKE(0x00, 0x74, 0x00)};
+  constexpr std::array<lv_color_t, nLines> rainbowColors = {LV_COLOR_MAKE(0x2d, 0xa4, 0x00),
+                                                            LV_COLOR_MAKE(0xac, 0x09, 0xc4),
+                                                            LV_COLOR_MAKE(0xfe, 0x03, 0x03),
+                                                            LV_COLOR_MAKE(0x0d, 0x57, 0xff),
+                                                            LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                            LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                            LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                            LV_COLOR_MAKE(0xe0, 0xb9, 0x00),
+                                                            LV_COLOR_MAKE(0xe8, 0x51, 0x02)};
+  constexpr std::array<lv_color_t, nLines> grayColors = {LV_COLOR_MAKE(0xee, 0xee, 0xee),
+                                                         LV_COLOR_MAKE(0x98, 0x95, 0x9b),
+                                                         LV_COLOR_MAKE(0x19, 0x19, 0x19),
+                                                         LV_COLOR_MAKE(0xee, 0xee, 0xee),
+                                                         LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                         LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                         LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                         LV_COLOR_MAKE(0x91, 0x91, 0x91),
+                                                         LV_COLOR_MAKE(0x3a, 0x3a, 0x3a)};
+  constexpr std::array<lv_color_t, nLines> nordBlueColors = {LV_COLOR_MAKE(0xc3, 0xda, 0xf2),
+                                                             LV_COLOR_MAKE(0x4d, 0x78, 0xce),
+                                                             LV_COLOR_MAKE(0x15, 0x34, 0x51),
+                                                             LV_COLOR_MAKE(0xc3, 0xda, 0xf2),
+                                                             LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                             LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                             LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                             LV_COLOR_MAKE(0x5d, 0x8a, 0xd2),
+                                                             LV_COLOR_MAKE(0x21, 0x51, 0x8a)};
+  constexpr std::array<lv_color_t, nLines> nordGreenColors = {LV_COLOR_MAKE(0xd5, 0xf0, 0xe9),
+                                                              LV_COLOR_MAKE(0x23, 0x83, 0x73),
+                                                              LV_COLOR_MAKE(0x1d, 0x41, 0x3f),
+                                                              LV_COLOR_MAKE(0xd5, 0xf0, 0xe9),
+                                                              LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                              LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                              LV_COLOR_MAKE(0xff, 0xff, 0xff),
+                                                              LV_COLOR_MAKE(0x2f, 0xb8, 0xa2),
+                                                              LV_COLOR_MAKE(0x11, 0x70, 0x5a)};
+
+  constexpr const std::array<lv_color_t, nLines>* returnColor(colors color) {
+    if (color == colors::orange) {
+      return &orangeColors;
+    }
+    if (color == colors::blue) {
+      return &blueColors;
+    }
+    if (color == colors::green) {
+      return &greenColors;
+    }
+    if (color == colors::rainbow) {
+      return &rainbowColors;
+    }
+    if (color == colors::gray) {
+      return &grayColors;
+    }
+    if (color == colors::nordBlue) {
+      return &nordBlueColors;
+    }
+    return &nordGreenColors;
+  }
 }
 
 WatchFaceInfineat::WatchFaceInfineat(Controllers::DateTime& dateTimeController,
@@ -57,13 +157,12 @@ WatchFaceInfineat::WatchFaceInfineat(Controllers::DateTime& dateTimeController,
 
   static constexpr lv_style_int_t lineWidths[nLines] = {18, 15, 14, 22, 20, 18, 18, 52, 48};
 
+  const std::array<lv_color_t, nLines>* colors = returnColor(static_cast<enum colors>(settingsController.GetInfineatColorIndex()));
   for (int i = 0; i < nLines; i++) {
     lines[i] = lv_line_create(lv_scr_act(), nullptr);
     lv_obj_set_style_local_line_width(lines[i], LV_LINE_PART_MAIN, LV_STATE_DEFAULT, lineWidths[i]);
-    lv_obj_set_style_local_line_color(lines[i],
-                                      LV_LINE_PART_MAIN,
-                                      LV_STATE_DEFAULT,
-                                      lv_color_hex(infineatColors.orange[settingsController.GetInfineatColorIndex() * nLines + i]));
+    lv_color_t color = (*colors)[i];
+    lv_obj_set_style_local_line_color(lines[i], LV_LINE_PART_MAIN, LV_STATE_DEFAULT, color);
     lv_line_set_points(lines[i], linePoints[i], 2);
   }
 
@@ -73,10 +172,7 @@ WatchFaceInfineat::WatchFaceInfineat(Controllers::DateTime& dateTimeController,
 
   lineBattery = lv_line_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_line_width(lineBattery, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, 24);
-  lv_obj_set_style_local_line_color(lineBattery,
-                                    LV_LINE_PART_MAIN,
-                                    LV_STATE_DEFAULT,
-                                    lv_color_hex(infineatColors.orange[settingsController.GetInfineatColorIndex() * nLines + 4]));
+  lv_obj_set_style_local_line_color(lineBattery, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, (*colors)[4]);
   lv_obj_set_style_local_line_opa(lineBattery, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, 190);
   lineBatteryPoints[0] = {27, 105};
   lineBatteryPoints[1] = {27, 106};
@@ -84,10 +180,7 @@ WatchFaceInfineat::WatchFaceInfineat(Controllers::DateTime& dateTimeController,
   lv_obj_move_foreground(lineBattery);
 
   notificationIcon = lv_obj_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_bg_color(notificationIcon,
-                                  LV_BTN_PART_MAIN,
-                                  LV_STATE_DEFAULT,
-                                  lv_color_hex(infineatColors.orange[settingsController.GetInfineatColorIndex() * nLines + 7]));
+  lv_obj_set_style_local_bg_color(notificationIcon, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, (*colors)[7]);
   lv_obj_set_style_local_radius(notificationIcon, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_RADIUS_CIRCLE);
   lv_obj_set_size(notificationIcon, 13, 13);
   lv_obj_set_hidden(notificationIcon, true);
@@ -125,25 +218,26 @@ WatchFaceInfineat::WatchFaceInfineat(Controllers::DateTime& dateTimeController,
   lv_obj_set_size(dateContainer, 60, 30);
   lv_obj_align(dateContainer, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, 0, 5);
 
+  static constexpr lv_color_t grayColor = LV_COLOR_MAKE(0x99, 0x99, 0x99);
   labelDate = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(labelDate, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x999999));
+  lv_obj_set_style_local_text_color(labelDate, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, grayColor);
   lv_obj_set_style_local_text_font(labelDate, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, font_teko);
   lv_obj_align(labelDate, dateContainer, LV_ALIGN_IN_TOP_MID, 0, 0);
   lv_label_set_text_static(labelDate, "Mon 01");
 
   bleIcon = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(bleIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x999999));
+  lv_obj_set_style_local_text_color(bleIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, grayColor);
   lv_label_set_text_static(bleIcon, Symbols::bluetooth);
   lv_obj_align(bleIcon, dateContainer, LV_ALIGN_OUT_BOTTOM_MID, 0, 0);
 
   stepValue = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(stepValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x999999));
+  lv_obj_set_style_local_text_color(stepValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, grayColor);
   lv_obj_set_style_local_text_font(stepValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, font_teko);
   lv_obj_align(stepValue, lv_scr_act(), LV_ALIGN_IN_BOTTOM_RIGHT, 10, 0);
   lv_label_set_text_static(stepValue, "0");
 
   stepIcon = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_set_style_local_text_color(stepIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0x999999));
+  lv_obj_set_style_local_text_color(stepIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, grayColor);
   lv_label_set_text_static(stepIcon, Symbols::shoe);
   lv_obj_align(stepIcon, stepValue, LV_ALIGN_OUT_LEFT_MID, -5, 0);
 
@@ -285,20 +379,13 @@ void WatchFaceInfineat::UpdateSelected(lv_obj_t* object, lv_event_t event) {
       settingsController.SetInfineatColorIndex(colorIndex);
     }
     if (object == btnNextColor || object == btnPrevColor) {
+      const std::array<lv_color_t, nLines>* colors = returnColor(static_cast<enum colors>(settingsController.GetInfineatColorIndex()));
       for (int i = 0; i < nLines; i++) {
-        lv_obj_set_style_local_line_color(lines[i],
-                                          LV_LINE_PART_MAIN,
-                                          LV_STATE_DEFAULT,
-                                          lv_color_hex(infineatColors.orange[colorIndex * nLines + i]));
+        lv_color_t color = (*colors)[i];
+        lv_obj_set_style_local_line_color(lines[i], LV_LINE_PART_MAIN, LV_STATE_DEFAULT, color);
       }
-      lv_obj_set_style_local_line_color(lineBattery,
-                                        LV_LINE_PART_MAIN,
-                                        LV_STATE_DEFAULT,
-                                        lv_color_hex(infineatColors.orange[colorIndex * nLines + 4]));
-      lv_obj_set_style_local_bg_color(notificationIcon,
-                                      LV_BTN_PART_MAIN,
-                                      LV_STATE_DEFAULT,
-                                      lv_color_hex(infineatColors.orange[colorIndex * nLines + 7]));
+      lv_obj_set_style_local_line_color(lineBattery, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, (*colors)[4]);
+      lv_obj_set_style_local_bg_color(notificationIcon, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, (*colors)[7]);
     }
   }
 }
@@ -420,14 +507,9 @@ void WatchFaceInfineat::ToggleBatteryIndicatorColor(bool showSideCover) {
     lv_obj_set_style_local_bg_color(notificationIcon, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_WHITE);
   } else {
     lv_obj_set_style_local_image_recolor_opa(logoPine, LV_IMG_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_0);
-    lv_obj_set_style_local_line_color(lineBattery,
-                                      LV_LINE_PART_MAIN,
-                                      LV_STATE_DEFAULT,
-                                      lv_color_hex(infineatColors.orange[settingsController.GetInfineatColorIndex() * nLines + 4]));
-    lv_obj_set_style_local_bg_color(notificationIcon,
-                                    LV_BTN_PART_MAIN,
-                                    LV_STATE_DEFAULT,
-                                    lv_color_hex(infineatColors.orange[settingsController.GetInfineatColorIndex() * nLines + 7]));
+    const std::array<lv_color_t, nLines>* colors = returnColor(static_cast<enum colors>(settingsController.GetInfineatColorIndex()));
+    lv_obj_set_style_local_line_color(lineBattery, LV_LINE_PART_MAIN, LV_STATE_DEFAULT, (*colors)[4]);
+    lv_obj_set_style_local_bg_color(notificationIcon, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, (*colors)[7]);
   }
 }
 

--- a/src/displayapp/screens/WatchFaceInfineat.h
+++ b/src/displayapp/screens/WatchFaceInfineat.h
@@ -21,6 +21,7 @@ namespace Pinetime {
 
       class WatchFaceInfineat : public Screen {
       public:
+        static constexpr int nLines = 9;
         WatchFaceInfineat(Controllers::DateTime& dateTimeController,
                           const Controllers::Battery& batteryController,
                           const Controllers::Ble& bleController,
@@ -84,20 +85,7 @@ namespace Pinetime {
         lv_obj_t* labelBtnSettings;
         lv_obj_t* lblToggle;
 
-        static constexpr int nLines = 9;
-        static constexpr int nColors = 7; // must match number of colors in InfineatColors
-
         lv_obj_t* lines[nLines];
-
-        struct InfineatColors {
-          int orange[nLines] = {0xfd872b, 0xdb3316, 0x6f1000, 0xfd7a0a, 0xffffff, 0xffffff, 0xffffff, 0xe85102, 0xea1c00};
-          int blue[nLines] = {0xe7f8ff, 0x2232d0, 0x182a8b, 0xe7f8ff, 0xffffff, 0xffffff, 0xffffff, 0x5991ff, 0x1636ff};
-          int green[nLines] = {0xb8ff9b, 0x088608, 0x004a00, 0xb8ff9b, 0xffffff, 0xffffff, 0xffffff, 0x62d515, 0x007400};
-          int rainbow[nLines] = {0x2da400, 0xac09c4, 0xfe0303, 0x0d57ff, 0xffffff, 0xffffff, 0xffffff, 0xe0b900, 0xe85102};
-          int gray[nLines] = {0xeeeeee, 0x98959b, 0x191919, 0xeeeeee, 0xffffff, 0xffffff, 0xffffff, 0x919191, 0x3a3a3a};
-          int nordBlue[nLines] = {0xc3daf2, 0x4d78ce, 0x153451, 0xc3daf2, 0xffffff, 0xffffff, 0xffffff, 0x5d8ad2, 0x21518a};
-          int nordGreen[nLines] = {0xd5f0e9, 0x238373, 0x1d413f, 0xd5f0e9, 0xffffff, 0xffffff, 0xffffff, 0x2fb8a2, 0x11705a};
-        } infineatColors;
 
         Controllers::DateTime& dateTimeController;
         const Controllers::Battery& batteryController;


### PR DESCRIPTION
lv_color_hex can't be evaluated at compile time, but LV_COLOR_MAKE can.

I feel like there must be a better approach that I'm missing. Let me know if you have ideas.