### PR TITLE
workflow: Updated workflow comment for all

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build-firmware:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: infinitime/infinitime-build
     outputs:
@@ -147,6 +147,7 @@ jobs:
 
   compare-build-size:
     if: github.event_name == 'pull_request'
+    name: 'Compare build size'
     needs: [build-firmware, get-base-ref-size]
     runs-on: ubuntu-latest
     steps:
@@ -181,28 +182,19 @@ jobs:
         echo "data_diff=$DATA_SIZE_DIFF" >> $GITHUB_OUTPUT
         echo "bss_diff=$BSS_SIZE_DIFF" >> $GITHUB_OUTPUT
 
-    - name: Find Comment
-      # Due to a security concern, comments can only be created in the context of branches in the repo.
-      # PRs from forks can't get the comment.
-      if: github.event.pull_request.head.repo.full_name == github.repository
-      uses: peter-evans/find-comment@v2
-      id: build-size-comment
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        comment-author: 'github-actions[bot]'
-        body-includes: Build size and comparison to
+    - name: Write comment information to files
+      run: |
+        tee comment << EOF
+        Build size and comparison to ${{ github.base_ref }}:
+        | Section | Size | Difference |
+        | ------- | ---- | ---------- |
+        | text    | ${{ needs.build-firmware.outputs.text_size }}B | ${{ steps.output-sizes-diff.outputs.text_diff }}B |
+        | data    | ${{ needs.build-firmware.outputs.data_size }}B | ${{ steps.output-sizes-diff.outputs.data_diff }}B |
+        | bss     | ${{ needs.build-firmware.outputs.bss_size }}B  | ${{ steps.output-sizes-diff.outputs.bss_diff }}B  |
+        EOF
 
-    - name: Create or update comment
-      if: github.event.pull_request.head.repo.full_name == github.repository
-      uses: peter-evans/create-or-update-comment@v2
+    - name: Upload comment
+      uses: actions/upload-artifact@v3
       with:
-        comment-id: ${{ steps.build-size-comment.outputs.comment-id }}
-        issue-number: ${{ github.event.pull_request.number }}
-        body: |
-          Build size and comparison to ${{ github.base_ref }}:
-          | Section | Size | Difference |
-          | ------- | ---- | ---------- |
-          | text    | ${{ needs.build-firmware.outputs.text_size }}B | ${{ steps.output-sizes-diff.outputs.text_diff }}B |
-          | data    | ${{ needs.build-firmware.outputs.data_size }}B | ${{ steps.output-sizes-diff.outputs.data_diff }}B |
-          | bss     | ${{ needs.build-firmware.outputs.bss_size }}B  | ${{ steps.output-sizes-diff.outputs.bss_diff }}B  |
-        edit-mode: replace
+        name: comment
+        path: comment

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,49 @@
+# THIS WORKFLOW HAS WRITE PERMISSIONS TO THE REPO.
+# MAKE SURE IT NEVER RUNS ANY CODE FROM THE FORK
+
+name: PR comment
+
+on:
+  pull_request_target:
+    branches: [ develop ]
+    paths-ignore:
+      - 'doc/**'
+      - '**.md'
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Wait for builds to finish
+      id: wait-for-build
+      uses: fountainhead/action-wait-for-check@297be350cf8393728ea4d4b39435c7d7ae167c93
+      with:
+        checkName: 'Compare build size'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - if: steps.wait-for-build.outputs.conclusion != 'success'
+      run: exit 1
+
+    - name: Download artifact
+      uses: dawidd6/action-download-artifact@bd10f381a96414ce2b13a11bfa89902ba7cea07f
+      with:
+        workflow: main.yml
+        pr: ${{ github.event.pull_request.number }}
+        name: comment
+
+    - name: Find Comment
+      id: find-comment
+      uses: peter-evans/find-comment@81e2da3af01c92f83cb927cf3ace0e085617c556
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        comment-author: 'github-actions[bot]'
+        body-includes: Build size and comparison to
+
+    - name: Create or update comment
+      uses: peter-evans/create-or-update-comment@5adcb0bb0f9fb3f95ef05400558bdb3f329ee808
+      with:
+        comment-id: ${{ steps.find-comment.outputs.comment-id }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body-file: comment
+        edit-mode: replace


### PR DESCRIPTION
The previous version failed, because it looked for the check from the branch in the fork, but looked for it in the main repo. Now uses the sha to get the commit on which checks were run.

Previous description

This works by uploading the data from the main workflow with low permissions as an artifact, then downloading the data in a workflow with higher permissions to post the comment.

Third party actions are fixed at a commit, in case they get compromised.

Also set the build-firmware VM to ubuntu-22.04, which was missed when updating workflow deps earlier.