### PR TITLE
workflow: Buildsize comment when simulator fails

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -29,6 +29,7 @@ jobs:
       uses: dawidd6/action-download-artifact@bd10f381a96414ce2b13a11bfa89902ba7cea07f
       with:
         workflow: main.yml
+        workflow_conclusion:
         pr: ${{ github.event.pull_request.number }}
         name: comment
 


### PR DESCRIPTION
The workflow checks that the buildsize comparison succeeds. The download artifact step also checks that all of the main workflow succeeds. This isn't necessary, and causes the comment not to be created when the simulator build fails. This change disabled the success conclusion requirement.