### PR TITLE
MotorController: Vibration pattern support

### DIFF
--- a/src/components/motor/MotorController.cpp
+++ b/src/components/motor/MotorController.cpp
@@ -5,12 +5,56 @@
 
 using namespace Pinetime::Controllers;
 
+namespace {
+  TimerHandle_t vibTimer;
+
+  void PatternStep(TimerHandle_t xTimer) {
+    /* Vibration pattern format:
+     * {
+     *   durationOfVibration,
+     *   durationOfPause,
+     *   durationOfVibration,
+     *   durationOfPause,
+     *   ...,
+     *   durationOfVibration,
+     *   zeroTerminator
+     * }
+     *
+     * Patterns can be any length
+     * The pattern must end with a duration of vibration and a terminator.
+     */
+
+    static constexpr uint8_t vibrationPattern[] = {30, 150, 30, 150, 30, 0};
+
+    static size_t patternPosition = 0;
+    if (vibrationPattern[patternPosition] != 0 && xTimerChangePeriod(vibTimer, vibrationPattern[patternPosition] << 1, 0) == pdPASS &&
+        xTimerStart(vibTimer, 0) == pdPASS) {
+      if (patternPosition % 2 == 0) {
+        nrf_gpio_pin_clear(Pinetime::PinMap::Motor);
+      } else {
+        nrf_gpio_pin_set(Pinetime::PinMap::Motor);
+      }
+      patternPosition++;
+    } else {
+      patternPosition = 0;
+      nrf_gpio_pin_set(Pinetime::PinMap::Motor);
+      auto* motorController = static_cast<MotorController*>(pvTimerGetTimerID(xTimer));
+      motorController->PatternFinished();
+    }
+  }
+}
+
 void MotorController::Init() {
   nrf_gpio_cfg_output(PinMap::Motor);
   nrf_gpio_pin_set(PinMap::Motor);
 
+  vibTimer = xTimerCreate("vibration", 1, pdFALSE, this, PatternStep);
   shortVib = xTimerCreate("shortVib", 1, pdFALSE, nullptr, StopMotor);
   longVib = xTimerCreate("longVib", pdMS_TO_TICKS(1000), pdTRUE, this, Ring);
+}
+
+void MotorController::PatternFinished() {
+  patternPlaying = false;
 }
 
 void MotorController::Ring(TimerHandle_t xTimer) {
@@ -22,6 +66,15 @@ void MotorController::RunForDuration(uint8_t motorDuration) {
   if (motorDuration > 0 && xTimerChangePeriod(shortVib, pdMS_TO_TICKS(motorDuration), 0) == pdPASS && xTimerStart(shortVib, 0) == pdPASS) {
     nrf_gpio_pin_clear(PinMap::Motor);
   }
+}
+
+bool MotorController::StartPattern() {
+  if (!patternPlaying) {
+    patternPlaying = true;
+    PatternStep(vibTimer);
+    return true;
+  }
+  return false;
 }
 
 void MotorController::StartRinging() {

--- a/src/components/motor/MotorController.h
+++ b/src/components/motor/MotorController.h
@@ -15,10 +15,13 @@ namespace Pinetime {
       void RunForDuration(uint8_t motorDuration);
       void StartRinging();
       void StopRinging();
+      void PatternFinished();
+      bool StartPattern();
 
     private:
       static void Ring(TimerHandle_t xTimer);
       static void StopMotor(TimerHandle_t xTimer);
+      bool patternPlaying;
       TimerHandle_t shortVib;
       TimerHandle_t longVib;
     };

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -295,7 +295,7 @@ void SystemTask::Work() {
           if (state == SystemTaskState::Sleeping) {
             GoToRunning();
           }
-          motorController.RunForDuration(35);
+          motorController.StartPattern();
           displayApp.PushMessage(Pinetime::Applications::Display::Messages::TimerDone);
           break;
         case Messages::SetOffAlarm:


### PR DESCRIPTION
This needs some more testing.

On the PineTime, running the motor too long will cause the battery voltage to drop, which runs the motor slower. This is something that can be heard and should be avoided if possible. The pattern should also be strong, so that it will be most noticable. This is a difficult balancing act. The duration of the vibration and the pause both matter. The current pattern is about as strong as the vibration can be without the speed dropping.

Currently InfiniSim doesn't simulate this correctly. Fix: https://github.com/InfiniTimeOrg/InfiniSim/pull/85

Timer now plays a vibration pattern.