### PR TITLE
inactivity: Use LVGL inactivity timers

### DIFF
--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -128,6 +128,8 @@ namespace Pinetime {
       static constexpr size_t returnAppStackSize = 10;
       StaticStack<Apps, returnAppStackSize> returnAppStack;
       StaticStack<FullRefreshDirections, returnAppStackSize> appStackDirections;
+
+      bool isDimmed = false;
     };
   }
 }

--- a/src/displayapp/Messages.h
+++ b/src/displayapp/Messages.h
@@ -17,7 +17,6 @@ namespace Pinetime {
         NewNotification,
         TimerDone,
         BleFirmwareUpdateStarted,
-        UpdateTimeOut,
         DimScreen,
         RestoreBrightness,
         ShowPairingKey,

--- a/src/displayapp/screens/settings/SettingDisplay.cpp
+++ b/src/displayapp/screens/settings/SettingDisplay.cpp
@@ -69,7 +69,6 @@ void SettingDisplay::UpdateSelected(lv_obj_t* object, lv_event_t event) {
       if (object == cbOption[i]) {
         lv_checkbox_set_checked(cbOption[i], true);
         settingsController.SetScreenTimeOut(options[i]);
-        app->PushMessage(Applications::Display::Messages::UpdateTimeOut);
       } else {
         lv_checkbox_set_checked(cbOption[i], false);
       }

--- a/src/systemtask/Messages.h
+++ b/src/systemtask/Messages.h
@@ -12,7 +12,6 @@ namespace Pinetime {
       OnTimerDone,
       OnNewCall,
       BleConnected,
-      UpdateTimeOut,
       BleFirmwareUpdateStarted,
       BleFirmwareUpdateFinished,
       OnTouchEvent,

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -84,6 +84,10 @@ namespace Pinetime {
       void OnIdle();
       void OnDim();
 
+      bool IsSleepDisabled() {
+        return doNotGoToSleep;
+      }
+
       Pinetime::Controllers::NimbleController& nimble() {
         return nimbleController;
       };
@@ -123,14 +127,10 @@ namespace Pinetime {
 
       static void Process(void* instance);
       void Work();
-      void ReloadIdleTimer();
       bool isBleDiscoveryTimerRunning = false;
       uint8_t bleDiscoveryTimer = 0;
-      TimerHandle_t dimTimer;
-      TimerHandle_t idleTimer;
       TimerHandle_t measureBatteryTimer;
       bool doNotGoToSleep = false;
-      bool isDimmed = false;
       SystemTaskState state = SystemTaskState::Running;
 
       void HandleButtonAction(Controllers::ButtonActions action);


### PR DESCRIPTION
Replace custom FreeRTOS inactivity timers with LVGL inactivity timers.

There may be some more optimizations possible, for example the restore brightness message can probably be replaced with `lv_disp_trig_activity(nullptr);`

~~- [ ] Fix an issue where setting the timer to the exact timeout setting causes the watch to go to sleep at the time the timer expires.~~ Looks like this isn't a new issue and shouldn't be blocking.