### PR TITLE
Touchhandler rework

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -222,6 +222,7 @@ void DisplayApp::Refresh() {
         if (state != States::Running) {
           break;
         }
+        lvgl.SetNewTouchPoint(touchHandler.GetX(), touchHandler.GetY(), touchHandler.IsTouching());
         auto gesture = touchHandler.GestureGet();
         if (gesture == TouchEvents::None) {
           break;
@@ -261,7 +262,7 @@ void DisplayApp::Refresh() {
             LoadPreviousScreen();
           }
         } else {
-          touchHandler.CancelTap();
+          lvgl.CancelTap();
         }
       } break;
       case Messages::ButtonPushed:
@@ -339,7 +340,7 @@ void DisplayApp::LoadNewScreen(Apps app, DisplayApp::FullRefreshDirections direc
 }
 
 void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections direction) {
-  touchHandler.CancelTap();
+  lvgl.CancelTap();
   ApplyBrightness();
 
   currentScreen.reset(nullptr);

--- a/src/displayapp/LittleVgl.cpp
+++ b/src/displayapp/LittleVgl.cpp
@@ -180,15 +180,34 @@ void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
   lv_disp_flush_ready(&disp_drv);
 }
 
-void LittleVgl::SetNewTouchPoint(uint16_t x, uint16_t y, bool contact) {
-  tap_x = x;
-  tap_y = y;
-  tapped = contact;
+void LittleVgl::SetNewTouchPoint(int16_t x, int16_t y, bool contact) {
+  if (contact) {
+    if (!isCancelled) {
+      touchPoint = {x, y};
+      tapped = true;
+    }
+  } else {
+    if (isCancelled) {
+      touchPoint = {-1, -1};
+      tapped = false;
+      isCancelled = false;
+    } else {
+      touchPoint = {x, y};
+      tapped = false;
+    }
+  }
+}
+
+void LittleVgl::CancelTap() {
+  if (tapped) {
+    isCancelled = true;
+    touchPoint = {-1, -1};
+  }
 }
 
 bool LittleVgl::GetTouchPadInfo(lv_indev_data_t* ptr) {
-  ptr->point.x = tap_x;
-  ptr->point.y = tap_y;
+  ptr->point.x = touchPoint.x;
+  ptr->point.y = touchPoint.y;
   if (tapped) {
     ptr->state = LV_INDEV_STATE_PR;
   } else {

--- a/src/displayapp/LittleVgl.h
+++ b/src/displayapp/LittleVgl.h
@@ -24,7 +24,8 @@ namespace Pinetime {
       void FlushDisplay(const lv_area_t* area, lv_color_t* color_p);
       bool GetTouchPadInfo(lv_indev_data_t* ptr);
       void SetFullRefresh(FullRefreshDirections direction);
-      void SetNewTouchPoint(uint16_t x, uint16_t y, bool contact);
+      void SetNewTouchPoint(int16_t x, int16_t y, bool contact);
+      void CancelTap();
 
       bool GetFullRefresh() {
         bool returnValue = fullRefresh;
@@ -60,9 +61,9 @@ namespace Pinetime {
       uint16_t writeOffset = 0;
       uint16_t scrollOffset = 0;
 
-      uint16_t tap_x = 0;
-      uint16_t tap_y = 0;
+      lv_point_t touchPoint = {0};
       bool tapped = false;
+      bool isCancelled = false;
     };
   }
 }

--- a/src/displayapp/LittleVgl.h
+++ b/src/displayapp/LittleVgl.h
@@ -61,7 +61,7 @@ namespace Pinetime {
       uint16_t writeOffset = 0;
       uint16_t scrollOffset = 0;
 
-      lv_point_t touchPoint = {0};
+      lv_point_t touchPoint = {};
       bool tapped = false;
       bool isCancelled = false;
     };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,7 +111,7 @@ Pinetime::Controllers::NotificationManager notificationManager;
 Pinetime::Controllers::MotionController motionController;
 Pinetime::Controllers::TimerController timerController;
 Pinetime::Controllers::AlarmController alarmController {dateTimeController};
-Pinetime::Controllers::TouchHandler touchHandler(touchPanel);
+Pinetime::Controllers::TouchHandler touchHandler;
 Pinetime::Controllers::ButtonHandler buttonHandler;
 Pinetime::Controllers::BrightnessController brightnessController {};
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,7 +111,7 @@ Pinetime::Controllers::NotificationManager notificationManager;
 Pinetime::Controllers::MotionController motionController;
 Pinetime::Controllers::TimerController timerController;
 Pinetime::Controllers::AlarmController alarmController {dateTimeController};
-Pinetime::Controllers::TouchHandler touchHandler(touchPanel, lvgl);
+Pinetime::Controllers::TouchHandler touchHandler(touchPanel);
 Pinetime::Controllers::ButtonHandler buttonHandler;
 Pinetime::Controllers::BrightnessController brightnessController {};
 

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -250,7 +250,7 @@ void SystemTask::Work() {
           isDimmed = false;
           break;
         case Messages::TouchWakeUp: {
-          if (touchHandler.GetNewTouchInfo()) {
+          if (touchHandler.ProcessTouchInfo(touchPanel.GetTouchInfo())) {
             auto gesture = touchHandler.GestureGet();
             if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep &&
                 gesture != Pinetime::Applications::TouchEvents::None &&
@@ -342,7 +342,7 @@ void SystemTask::Work() {
           // TODO add intent of fs access icon or something
           break;
         case Messages::OnTouchEvent:
-          if (touchHandler.GetNewTouchInfo()) {
+          if (touchHandler.ProcessTouchInfo(touchPanel.GetTouchInfo())) {
             ReloadIdleTimer();
             displayApp.PushMessage(Pinetime::Applications::Display::Messages::TouchEvent);
           }

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -343,10 +343,9 @@ void SystemTask::Work() {
           break;
         case Messages::OnTouchEvent:
           if (touchHandler.GetNewTouchInfo()) {
-            touchHandler.UpdateLvglTouchPoint();
+            ReloadIdleTimer();
+            displayApp.PushMessage(Pinetime::Applications::Display::Messages::TouchEvent);
           }
-          ReloadIdleTimer();
-          displayApp.PushMessage(Pinetime::Applications::Display::Messages::TouchEvent);
           break;
         case Messages::HandleButtonEvent: {
           Controllers::ButtonActions action = Controllers::ButtonActions::None;

--- a/src/touchhandler/TouchHandler.cpp
+++ b/src/touchhandler/TouchHandler.cpp
@@ -1,9 +1,4 @@
 #include "touchhandler/TouchHandler.h"
-#ifdef PINETIME_IS_RECOVERY
-  #include "displayapp/DummyLittleVgl.h"
-#else
-  #include "displayapp/LittleVgl.h"
-#endif
 
 using namespace Pinetime::Controllers;
 using namespace Pinetime::Applications;
@@ -32,14 +27,7 @@ namespace {
   }
 }
 
-TouchHandler::TouchHandler(Drivers::Cst816S& touchPanel, Components::LittleVgl& lvgl) : touchPanel {touchPanel}, lvgl {lvgl} {
-}
-
-void TouchHandler::CancelTap() {
-  if (info.touching) {
-    isCancelled = true;
-    lvgl.SetNewTouchPoint(-1, -1, true);
-  }
+TouchHandler::TouchHandler(Drivers::Cst816S& touchPanel) : touchPanel {touchPanel} {
 }
 
 Pinetime::Applications::TouchEvents TouchHandler::GestureGet() {
@@ -55,6 +43,7 @@ bool TouchHandler::GetNewTouchInfo() {
     return false;
   }
 
+  // Only a single gesture per touch
   if (info.gesture != Pinetime::Drivers::Cst816S::Gestures::None) {
     if (gestureReleased) {
       if (info.gesture == Pinetime::Drivers::Cst816S::Gestures::SlideDown ||
@@ -77,19 +66,4 @@ bool TouchHandler::GetNewTouchInfo() {
   }
 
   return true;
-}
-
-void TouchHandler::UpdateLvglTouchPoint() {
-  if (info.touching) {
-    if (!isCancelled) {
-      lvgl.SetNewTouchPoint(info.x, info.y, true);
-    }
-  } else {
-    if (isCancelled) {
-      lvgl.SetNewTouchPoint(-1, -1, false);
-      isCancelled = false;
-    } else {
-      lvgl.SetNewTouchPoint(info.x, info.y, false);
-    }
-  }
 }

--- a/src/touchhandler/TouchHandler.cpp
+++ b/src/touchhandler/TouchHandler.cpp
@@ -27,18 +27,13 @@ namespace {
   }
 }
 
-TouchHandler::TouchHandler(Drivers::Cst816S& touchPanel) : touchPanel {touchPanel} {
-}
-
 Pinetime::Applications::TouchEvents TouchHandler::GestureGet() {
   auto returnGesture = gesture;
   gesture = Pinetime::Applications::TouchEvents::None;
   return returnGesture;
 }
 
-bool TouchHandler::GetNewTouchInfo() {
-  info = touchPanel.GetTouchInfo();
-
+bool TouchHandler::ProcessTouchInfo(Drivers::Cst816S::TouchInfos info) {
   if (!info.isValid) {
     return false;
   }
@@ -64,6 +59,8 @@ bool TouchHandler::GetNewTouchInfo() {
   if (!info.touching) {
     gestureReleased = true;
   }
+
+  currentTouchPoint = {info.x, info.y, info.touching};
 
   return true;
 }

--- a/src/touchhandler/TouchHandler.h
+++ b/src/touchhandler/TouchHandler.h
@@ -3,36 +3,34 @@
 #include "displayapp/TouchEvents.h"
 
 namespace Pinetime {
-  namespace Drivers {
-    class Cst816S;
-  }
-
   namespace Controllers {
     class TouchHandler {
     public:
-      explicit TouchHandler(Drivers::Cst816S&);
+      struct TouchPoint {
+        int x;
+        int y;
+        bool touching;
+      };
 
-      bool GetNewTouchInfo();
+      bool ProcessTouchInfo(Drivers::Cst816S::TouchInfos info);
 
       bool IsTouching() const {
-        return info.touching;
+        return currentTouchPoint.touching;
       }
 
       uint8_t GetX() const {
-        return info.x;
+        return currentTouchPoint.x;
       }
 
       uint8_t GetY() const {
-        return info.y;
+        return currentTouchPoint.y;
       }
 
       Pinetime::Applications::TouchEvents GestureGet();
 
     private:
-      Pinetime::Drivers::Cst816S::TouchInfos info;
-      Pinetime::Drivers::Cst816S& touchPanel;
       Pinetime::Applications::TouchEvents gesture;
-      bool isCancelled = false;
+      TouchPoint currentTouchPoint = {};
       bool gestureReleased = true;
     };
   }

--- a/src/touchhandler/TouchHandler.h
+++ b/src/touchhandler/TouchHandler.h
@@ -3,10 +3,6 @@
 #include "displayapp/TouchEvents.h"
 
 namespace Pinetime {
-  namespace Components {
-    class LittleVgl;
-  }
-
   namespace Drivers {
     class Cst816S;
   }
@@ -14,10 +10,9 @@ namespace Pinetime {
   namespace Controllers {
     class TouchHandler {
     public:
-      explicit TouchHandler(Drivers::Cst816S&, Components::LittleVgl&);
-      void CancelTap();
+      explicit TouchHandler(Drivers::Cst816S&);
+
       bool GetNewTouchInfo();
-      void UpdateLvglTouchPoint();
 
       bool IsTouching() const {
         return info.touching;
@@ -36,7 +31,6 @@ namespace Pinetime {
     private:
       Pinetime::Drivers::Cst816S::TouchInfos info;
       Pinetime::Drivers::Cst816S& touchPanel;
-      Pinetime::Components::LittleVgl& lvgl;
       Pinetime::Applications::TouchEvents gesture;
       bool isCancelled = false;
       bool gestureReleased = true;


### PR DESCRIPTION
Moved LVGL handling out of TouchHandler, so it just processes Cst816S data.
Removed Cst816S dependency from TouchHandler. Cst816S::TouchInfo is simply passed to the processing function.

Outside the scope of this PR, but since TouchHandler is just processing Cst816S data to an InfiniTime friendly format, this code could in the future be moved inside the driver itself, so different touch drivers would have their own processing functions.