### PR TITLE
DateTimeController: Remove SetTime tick parameter

### DIFF
--- a/src/components/ble/CurrentTimeClient.cpp
+++ b/src/components/ble/CurrentTimeClient.cpp
@@ -1,5 +1,4 @@
 #include "components/ble/CurrentTimeClient.h"
-#include <hal/nrf_rtc.h>
 #include <nrf_log.h>
 #include "components/datetime/DateTimeController.h"
 
@@ -88,8 +87,7 @@ int CurrentTimeClient::OnCurrentTimeReadResult(uint16_t conn_handle, const ble_g
     uint16_t year = ((uint16_t) result.year_MSO << 8) + result.year_LSO;
 
     NRF_LOG_INFO("Received data: %d-%d-%d %d:%d:%d", year, result.month, result.dayofmonth, result.hour, result.minute, result.second);
-    dateTimeController
-      .SetTime(year, result.month, result.dayofmonth, result.hour, result.minute, result.second, nrf_rtc_counter_get(portNRF_RTC_REG));
+    dateTimeController.SetTime(year, result.month, result.dayofmonth, result.hour, result.minute, result.second);
   } else {
     NRF_LOG_INFO("Error retrieving current time: %d", error->status);
   }

--- a/src/components/ble/CurrentTimeService.cpp
+++ b/src/components/ble/CurrentTimeService.cpp
@@ -1,5 +1,4 @@
 #include "components/ble/CurrentTimeService.h"
-#include <hal/nrf_rtc.h>
 #include <nrf_log.h>
 
 using namespace Pinetime::Controllers;
@@ -50,8 +49,7 @@ int CurrentTimeService::OnCurrentTimeAccessed(struct ble_gatt_access_ctxt* ctxt)
 
     NRF_LOG_INFO("Received data: %d-%d-%d %d:%d:%d", year, result.month, result.dayofmonth, result.hour, result.minute, result.second);
 
-    m_dateTimeController
-      .SetTime(year, result.month, result.dayofmonth, result.hour, result.minute, result.second, nrf_rtc_counter_get(portNRF_RTC_REG));
+    m_dateTimeController.SetTime(year, result.month, result.dayofmonth, result.hour, result.minute, result.second);
 
   } else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
     CtsCurrentTimeData currentDateTime;

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -1,7 +1,6 @@
 #include "components/ble/NimbleController.h"
 #include <cstring>
 
-#include <hal/nrf_rtc.h>
 #include <nrf_log.h>
 #define min // workaround: nimble's min/max macros conflict with libstdc++
 #define max

--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -20,7 +20,7 @@ void DateTime::SetCurrentTime(std::chrono::time_point<std::chrono::system_clock,
   UpdateTime(previousSystickCounter); // Update internal state without updating the time
 }
 
-void DateTime::SetTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint32_t systickCounter) {
+void DateTime::SetTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second) {
   std::tm tm = {
     /* .tm_sec  = */ second,
     /* .tm_min  = */ minute,
@@ -35,9 +35,8 @@ void DateTime::SetTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, 
 
   NRF_LOG_INFO("%d %d %d ", day, month, year);
   NRF_LOG_INFO("%d %d %d ", hour, minute, second);
-  previousSystickCounter = systickCounter;
 
-  UpdateTime(systickCounter);
+  UpdateTime(previousSystickCounter);
   NRF_LOG_INFO("* %d %d %d ", this->hour, this->minute, this->second);
   NRF_LOG_INFO("* %d %d %d ", this->day, this->month, this->year);
 
@@ -63,7 +62,7 @@ void DateTime::UpdateTime(uint32_t systickCounter) {
    * 1000 ms = 1024 ticks
    */
   auto correctedDelta = systickDelta / 1024;
-  auto rest = (systickDelta - (correctedDelta * 1024));
+  auto rest = systickDelta % 1024;
   if (systickCounter >= rest) {
     previousSystickCounter = systickCounter - rest;
   } else {

--- a/src/components/datetime/DateTimeController.h
+++ b/src/components/datetime/DateTimeController.h
@@ -31,7 +31,7 @@ namespace Pinetime {
         December
       };
 
-      void SetTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second, uint32_t systickCounter);
+      void SetTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second);
 
       /*
        * setter corresponding to the BLE Set Local Time characteristic.

--- a/src/displayapp/screens/settings/SettingSetDate.cpp
+++ b/src/displayapp/screens/settings/SettingSetDate.cpp
@@ -1,7 +1,6 @@
 #include "displayapp/screens/settings/SettingSetDate.h"
 #include "displayapp/screens/settings/SettingSetDateTime.h"
 #include <lvgl/lvgl.h>
-#include <hal/nrf_rtc.h>
 #include <nrf_log.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Symbols.h"
@@ -96,13 +95,8 @@ void SettingSetDate::HandleButtonPress() {
   const uint8_t monthValue = monthCounter.GetValue();
   const uint8_t dayValue = dayCounter.GetValue();
   NRF_LOG_INFO("Setting date (manually) to %04d-%02d-%02d", yearValue, monthValue, dayValue);
-  dateTimeController.SetTime(yearValue,
-                             monthValue,
-                             dayValue,
-                             dateTimeController.Hours(),
-                             dateTimeController.Minutes(),
-                             dateTimeController.Seconds(),
-                             nrf_rtc_counter_get(portNRF_RTC_REG));
+  dateTimeController
+    .SetTime(yearValue, monthValue, dayValue, dateTimeController.Hours(), dateTimeController.Minutes(), dateTimeController.Seconds());
   settingSetDateTime.Advance();
 }
 

--- a/src/displayapp/screens/settings/SettingSetTime.cpp
+++ b/src/displayapp/screens/settings/SettingSetTime.cpp
@@ -1,6 +1,5 @@
 #include "displayapp/screens/settings/SettingSetTime.h"
 #include <lvgl/lvgl.h>
-#include <hal/nrf_rtc.h>
 #include <nrf_log.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Symbols.h"
@@ -100,7 +99,6 @@ void SettingSetTime::SetTime() {
                              dateTimeController.Day(),
                              static_cast<uint8_t>(hoursValue),
                              static_cast<uint8_t>(minutesValue),
-                             0,
-                             nrf_rtc_counter_get(portNRF_RTC_REG));
+                             0);
   settingSetDateTime.Quit();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
 // nrf
-#include <hal/nrf_rtc.h>
 #include <hal/nrf_wdt.h>
 #include <legacy/nrf_drv_clock.h>
 #include <libraries/gpiote/app_gpiote.h>


### PR DESCRIPTION
The systick doesn't need to be updated when setting time.

Also removed unused nrf_rtc.h includes.

I guess this change will make it so depending on the previous systick value, the time can shift an amount less than one second. Is this a problem?