### PR TITLE
DateTimeController: Fix integer overflow on day of year

### DIFF
--- a/src/components/datetime/DateTimeController.h
+++ b/src/components/datetime/DateTimeController.h
@@ -67,7 +67,7 @@ namespace Pinetime {
         return static_cast<Days>(daysSinceSunday);
       }
 
-      uint8_t DayOfYear() const {
+      int DayOfYear() const {
         return localTime.tm_yday + 1;
       }
 


### PR DESCRIPTION
`tm_yday` is an int and is a number between 0 and 365.