### PR TITLE
LVGL / FS : Initialize the LVGL FS driver in LittleVgl (instead of FS).

### DIFF
--- a/src/components/fs/FS.h
+++ b/src/components/fs/FS.h
@@ -11,7 +11,6 @@ namespace Pinetime {
       FS(Pinetime::Drivers::SpiNorFlash&);
 
       void Init();
-      void LVGLFileSystemInit();
 
       int FileOpen(lfs_file_t* file_p, const char* fileName, const int flags);
       int FileClose(lfs_file_t* file_p);

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -91,7 +91,7 @@ DisplayApp::DisplayApp(Drivers::St7789& lcd,
     brightnessController {brightnessController},
     touchHandler {touchHandler},
     filesystem {filesystem},
-    lvgl {lcd} {
+    lvgl {lcd, filesystem} {
 }
 
 void DisplayApp::Start(System::BootErrors error) {

--- a/src/displayapp/LittleVgl.h
+++ b/src/displayapp/LittleVgl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <lvgl/lvgl.h>
+#include <components/fs/FS.h>
 
 namespace Pinetime {
   namespace Drivers {
@@ -11,7 +12,7 @@ namespace Pinetime {
     class LittleVgl {
     public:
       enum class FullRefreshDirections { None, Up, Down, Left, Right, LeftAnim, RightAnim };
-      LittleVgl(Pinetime::Drivers::St7789& lcd);
+      LittleVgl(Pinetime::Drivers::St7789& lcd, Pinetime::Controllers::FS& filesystem);
 
       LittleVgl(const LittleVgl&) = delete;
       LittleVgl& operator=(const LittleVgl&) = delete;
@@ -37,8 +38,10 @@ namespace Pinetime {
     private:
       void InitDisplay();
       void InitTouchpad();
+      void InitFileSystem();
 
       Pinetime::Drivers::St7789& lcd;
+      Pinetime::Controllers::FS& filesystem;
 
       lv_disp_buf_t disp_buf_2;
       lv_color_t buf2_1[LV_HOR_RES_MAX * 4];


### PR DESCRIPTION
Previously, the LVGL driver for the filesystem was initialized in the class FS. However, since 6f942e2, the order of the initializations was incorrect  : the driver was initialized (FS::LVGLFileSystemInit()) before LVGL (LittleVgl.Init()), which means that the driver registration was probably dropped when LVGL was initialized.

The LVGL driver is now initialized in LittleVgl.Init(), which seems to make much more sense, since all LVGL drivers are initialized there. This way, we ensure that the initialization of the drivers is consistent.