### PR TITLE
README: Remove status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # [InfiniTime](https://github.com/InfiniTimeOrg/InfiniTime)
 
-[![Build PineTime Firmware](https://github.com/InfiniTimeOrg/InfiniTime/workflows/Build%20PineTime%20Firmware/badge.svg?branch=master)](https://github.com/InfiniTimeOrg/InfiniTime/actions)
-
 ![InfiniTime logo](doc/logo/infinitime-logo-small.jpg "InfiniTime Logo")
 
 Fast open-source firmware for the [PineTime smartwatch](https://www.pine64.org/pinetime/) with many features, written in modern C++.


### PR DESCRIPTION
I don't think this badge has shown the actual status of the current workflows for a long time. The real status can easily be seen by clicking on the checkmark or cross icon on the front page. It's also supposed to show the status of the master branch, not develop (default).