### PR TITLE
WatchFacePineTimeStyle: Simplify time update check

### DIFF
--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -446,16 +446,13 @@ void WatchFacePineTimeStyle::Refresh() {
     AlignIcons();
   }
 
-  currentDateTime = dateTimeController.CurrentDateTime();
+  currentDateTime = std::chrono::time_point_cast<std::chrono::seconds>(dateTimeController.CurrentDateTime());
   if (currentDateTime.IsUpdated()) {
-    auto hour = dateTimeController.Hours();
-    auto minute = dateTimeController.Minutes();
-    auto second = dateTimeController.Seconds();
-    auto year = dateTimeController.Year();
-    auto month = dateTimeController.Month();
-    auto dayOfWeek = dateTimeController.DayOfWeek();
-    auto day = dateTimeController.Day();
+    uint8_t second = dateTimeController.Seconds();
+    lv_label_set_text_fmt(timeDD3, ":%02d", second);
 
+    uint8_t hour = dateTimeController.Hours();
+    uint8_t minute = dateTimeController.Minutes();
     if (displayedHour != hour || displayedMinute != minute) {
       displayedHour = hour;
       displayedMinute = minute;
@@ -480,21 +477,13 @@ void WatchFacePineTimeStyle::Refresh() {
       }
     }
 
-    if (displayedSecond != second) {
-      displayedSecond = second;
-      lv_label_set_text_fmt(timeDD3, ":%02d", second);
-    }
-
-    if ((year != currentYear) || (month != currentMonth) || (dayOfWeek != currentDayOfWeek) || (day != currentDay)) {
+    currentDate = std::chrono::time_point_cast<days>(currentDateTime.Get());
+    if (currentDate.IsUpdated()) {
       lv_label_set_text_static(dateDayOfWeek, dateTimeController.DayOfWeekShortToString());
+      uint8_t day = dateTimeController.Day();
       lv_label_set_text_fmt(dateDay, "%d", day);
       lv_obj_realign(dateDay);
       lv_label_set_text_static(dateMonth, dateTimeController.MonthShortToString());
-
-      currentYear = year;
-      currentMonth = month;
-      currentDayOfWeek = dayOfWeek;
-      currentDay = day;
     }
   }
 

--- a/src/displayapp/screens/WatchFacePineTimeStyle.h
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.h
@@ -42,22 +42,19 @@ namespace Pinetime {
       private:
         uint8_t displayedHour = -1;
         uint8_t displayedMinute = -1;
-        uint8_t displayedSecond = -1;
 
-        uint16_t currentYear = 1970;
-        Controllers::DateTime::Months currentMonth = Pinetime::Controllers::DateTime::Months::Unknown;
-        Controllers::DateTime::Days currentDayOfWeek = Pinetime::Controllers::DateTime::Days::Unknown;
-        uint8_t currentDay = 0;
         uint32_t savedTick = 0;
 
         DirtyValue<uint8_t> batteryPercentRemaining {};
         DirtyValue<bool> isCharging {};
         DirtyValue<bool> bleState {};
         DirtyValue<bool> bleRadioEnabled {};
-        DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime {};
+        DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>> currentDateTime {};
         DirtyValue<bool> motionSensorOk {};
         DirtyValue<uint32_t> stepCount {};
         DirtyValue<bool> notificationState {};
+        using days = std::chrono::duration<int32_t, std::ratio<86400>>; // TODO: days is standard in c++20
+        DirtyValue<std::chrono::time_point<std::chrono::system_clock, days>> currentDate;
 
         static Pinetime::Controllers::Settings::Colors GetNext(Controllers::Settings::Colors color);
         static Pinetime::Controllers::Settings::Colors GetPrevious(Controllers::Settings::Colors color);


### PR DESCRIPTION
This isn't as thorough as the other PRs, because simply using another time point to check if a minute has passed would've used more memory.