### PR TITLE
Fix double tap behaviour on PineTimeStyle settings screen

### DIFF
--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -364,13 +364,13 @@ WatchFacePineTimeStyle::~WatchFacePineTimeStyle() {
 }
 
 bool WatchFacePineTimeStyle::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
-  if ((event == Pinetime::Applications::TouchEvents::LongTap) && lv_obj_get_hidden(btnRandom)) {
+  if ((event == Pinetime::Applications::TouchEvents::LongTap) && lv_obj_get_hidden(btnClose)) {
     lv_obj_set_hidden(btnSetColor, false);
     lv_obj_set_hidden(btnSetOpts, false);
     savedTick = lv_tick_get();
     return true;
   }
-  if ((event == Pinetime::Applications::TouchEvents::DoubleTap) && (lv_obj_get_hidden(btnRandom) == false)) {
+  if ((event == Pinetime::Applications::TouchEvents::DoubleTap) && (lv_obj_get_hidden(btnClose) == false)) {
     return true;
   }
   return false;


### PR DESCRIPTION
Fixes #1467 "Double tapping PineTimeStyle steps style button sends watch to sleep"
Double tap is disabled on the color settings screen by checking if the Rnd button is visible, but this didn't work for the options screen as the Rnd button isn't visible. I've changed it to check if the Close button is visible instead, which is used on both settings screens, and resolves the bug. I also changed the button used to disable the long press behaviour which was an as-yet-undiscovered bug which would have allowed the long press action to be used when the options screen was visible.