### PR TITLE
Spi instance cleanup

### DIFF
--- a/src/drivers/Spi.cpp
+++ b/src/drivers/Spi.cpp
@@ -17,17 +17,6 @@ bool Spi::Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize) {
   return spiMaster.Read(pinCsn, cmd, cmdSize, data, dataSize);
 }
 
-void Spi::Sleep() {
-  nrf_gpio_cfg_default(pinCsn);
-  NRF_LOG_INFO("[SPI] Sleep")
-}
-
 bool Spi::WriteCmdAndBuffer(const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize) {
   return spiMaster.WriteCmdAndBuffer(pinCsn, cmd, cmdSize, data, dataSize);
-}
-
-void Spi::Wakeup() {
-  nrf_gpio_cfg_output(pinCsn);
-  nrf_gpio_pin_set(pinCsn);
-  NRF_LOG_INFO("[SPI] Wakeup")
 }

--- a/src/drivers/Spi.cpp
+++ b/src/drivers/Spi.cpp
@@ -26,11 +26,6 @@ bool Spi::WriteCmdAndBuffer(const uint8_t* cmd, size_t cmdSize, const uint8_t* d
   return spiMaster.WriteCmdAndBuffer(pinCsn, cmd, cmdSize, data, dataSize);
 }
 
-bool Spi::Init() {
-  nrf_gpio_pin_set(pinCsn); /* disable Set slave select (inactive high) */
-  return true;
-}
-
 void Spi::Wakeup() {
   nrf_gpio_cfg_output(pinCsn);
   nrf_gpio_pin_set(pinCsn);

--- a/src/drivers/Spi.h
+++ b/src/drivers/Spi.h
@@ -13,7 +13,6 @@ namespace Pinetime {
       Spi(Spi&&) = delete;
       Spi& operator=(Spi&&) = delete;
 
-      bool Init();
       bool Write(const uint8_t* data, size_t size);
       bool Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize);
       bool WriteCmdAndBuffer(const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize);

--- a/src/drivers/Spi.h
+++ b/src/drivers/Spi.h
@@ -8,10 +8,6 @@ namespace Pinetime {
     class Spi {
     public:
       Spi(SpiMaster& spiMaster, uint8_t pinCsn);
-      Spi(const Spi&) = delete;
-      Spi& operator=(const Spi&) = delete;
-      Spi(Spi&&) = delete;
-      Spi& operator=(Spi&&) = delete;
 
       bool Write(const uint8_t* data, size_t size);
       bool Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize);

--- a/src/drivers/Spi.h
+++ b/src/drivers/Spi.h
@@ -16,8 +16,6 @@ namespace Pinetime {
       bool Write(const uint8_t* data, size_t size);
       bool Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize);
       bool WriteCmdAndBuffer(const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize);
-      void Sleep();
-      void Wakeup();
 
     private:
       SpiMaster& spiMaster;

--- a/src/drivers/SpiNorFlash.cpp
+++ b/src/drivers/SpiNorFlash.cpp
@@ -6,7 +6,7 @@
 
 using namespace Pinetime::Drivers;
 
-SpiNorFlash::SpiNorFlash(Spi& spi) : spi {spi} {
+SpiNorFlash::SpiNorFlash(Spi&& spi) : spi {spi} {
 }
 
 void SpiNorFlash::Init() {

--- a/src/drivers/SpiNorFlash.h
+++ b/src/drivers/SpiNorFlash.h
@@ -1,14 +1,13 @@
 #pragma once
 #include <cstddef>
 #include <cstdint>
+#include "drivers/Spi.h"
 
 namespace Pinetime {
   namespace Drivers {
-    class Spi;
-
     class SpiNorFlash {
     public:
-      explicit SpiNorFlash(Spi& spi);
+      explicit SpiNorFlash(Spi&& spi);
       SpiNorFlash(const SpiNorFlash&) = delete;
       SpiNorFlash& operator=(const SpiNorFlash&) = delete;
       SpiNorFlash(SpiNorFlash&&) = delete;
@@ -54,7 +53,7 @@ namespace Pinetime {
       };
       static constexpr uint16_t pageSize = 256;
 
-      Spi& spi;
+      Spi spi;
       Identification device_id;
     };
   }

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -6,7 +6,7 @@
 
 using namespace Pinetime::Drivers;
 
-St7789::St7789(Spi& spi, uint8_t pinDataCommand) : spi {spi}, pinDataCommand {pinDataCommand} {
+St7789::St7789(Spi&& spi, uint8_t pinDataCommand) : spi {spi}, pinDataCommand {pinDataCommand} {
 }
 
 void St7789::Init() {

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -10,7 +10,6 @@ St7789::St7789(Spi& spi, uint8_t pinDataCommand) : spi {spi}, pinDataCommand {pi
 }
 
 void St7789::Init() {
-  spi.Init();
   nrf_gpio_cfg_output(pinDataCommand);
   nrf_gpio_cfg_output(26);
   nrf_gpio_pin_set(26);

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -1,14 +1,13 @@
 #pragma once
 #include <cstddef>
 #include <cstdint>
+#include "drivers/Spi.h"
 
 namespace Pinetime {
   namespace Drivers {
-    class Spi;
-
     class St7789 {
     public:
-      explicit St7789(Spi& spi, uint8_t pinDataCommand);
+      explicit St7789(Spi&& spi, uint8_t pinDataCommand);
       St7789(const St7789&) = delete;
       St7789& operator=(const St7789&) = delete;
       St7789(St7789&&) = delete;
@@ -27,7 +26,7 @@ namespace Pinetime {
       void Wakeup();
 
     private:
-      Spi& spi;
+      Spi spi;
       uint8_t pinDataCommand;
       uint8_t verticalScrollingStartAddress = 0;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,11 +67,9 @@ Pinetime::Drivers::SpiMaster spi {Pinetime::Drivers::SpiMaster::SpiModule::SPI0,
                                    Pinetime::PinMap::SpiMosi,
                                    Pinetime::PinMap::SpiMiso}};
 
-Pinetime::Drivers::Spi lcdSpi {spi, Pinetime::PinMap::SpiLcdCsn};
-Pinetime::Drivers::St7789 lcd {lcdSpi, Pinetime::PinMap::LcdDataCommand};
+Pinetime::Drivers::St7789 lcd {Pinetime::Drivers::Spi {spi, Pinetime::PinMap::SpiLcdCsn}, Pinetime::PinMap::LcdDataCommand};
 
-Pinetime::Drivers::Spi flashSpi {spi, Pinetime::PinMap::SpiFlashCsn};
-Pinetime::Drivers::SpiNorFlash spiNorFlash {flashSpi};
+Pinetime::Drivers::SpiNorFlash spiNorFlash {Pinetime::Drivers::Spi {spi, Pinetime::PinMap::SpiFlashCsn}};
 
 // The TWI device should work @ up to 400Khz but there is a HW bug which prevent it from
 // respecting correct timings. According to erratas heet, this magic value makes it run

--- a/src/recoveryLoader.cpp
+++ b/src/recoveryLoader.cpp
@@ -42,11 +42,10 @@ Pinetime::Drivers::SpiMaster spi {Pinetime::Drivers::SpiMaster::SpiModule::SPI0,
                                    Pinetime::PinMap::SpiSck,
                                    Pinetime::PinMap::SpiMosi,
                                    Pinetime::PinMap::SpiMiso}};
-Pinetime::Drivers::Spi flashSpi {spi, Pinetime::PinMap::SpiFlashCsn};
-Pinetime::Drivers::SpiNorFlash spiNorFlash {flashSpi};
 
-Pinetime::Drivers::Spi lcdSpi {spi, Pinetime::PinMap::SpiLcdCsn};
-Pinetime::Drivers::St7789 lcd {lcdSpi, Pinetime::PinMap::LcdDataCommand};
+Pinetime::Drivers::SpiNorFlash spiNorFlash {Pinetime::Drivers::Spi {spi, Pinetime::PinMap::SpiFlashCsn}};
+
+Pinetime::Drivers::St7789 lcd {Pinetime::Drivers::Spi {spi, Pinetime::PinMap::SpiLcdCsn}, Pinetime::PinMap::LcdDataCommand};
 
 Pinetime::Components::Gfx gfx {lcd};
 Pinetime::Controllers::BrightnessController brightnessController;


### PR DESCRIPTION
Spi: Remove Init function
The pin is set on construct, and the function was only used on St7789
driver.

Spi: Remove unused functions
SpiMaster handles the sleep

main: Don't instantiate Spi globally
They're specific to the drivers, so the driver should own them.