### PR TITLE
apps: POC for bitfield-based compile-time apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose Debug or Release")
 project(pinetime VERSION 1.11.0 LANGUAGES C CXX ASM)
 
 set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 # set(CMAKE_GENERATOR "Unix Makefiles")
 set(CMAKE_C_EXTENSIONS OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -786,6 +786,10 @@ add_definitions(-D__STACK_SIZE=1024)
 add_definitions(-D__HEAP_SIZE=4096)
 add_definitions(-DMYNEWT_VAL_BLE_LL_RFMGMT_ENABLE_TIME=1500)
 
+if(DISABLED_APPS)
+  add_definitions(-DDISABLED_APPS=${DISABLED_APPS})
+endif()
+
 # Note: Only use this for debugging
 # Derive the low frequency clock from the main clock (SYNT)
 # add_definitions(-DCLOCK_CONFIG_LF_SRC=2)

--- a/src/displayapp/Apps.h
+++ b/src/displayapp/Apps.h
@@ -1,43 +1,52 @@
 #pragma once
 
+#include <cstdint>
+
 namespace Pinetime {
   namespace Applications {
-    enum class Apps {
-      None,
-      Launcher,
-      Clock,
-      SysInfo,
-      FirmwareUpdate,
-      FirmwareValidation,
-      NotificationsPreview,
-      Notifications,
-      Timer,
-      Alarm,
-      FlashLight,
-      BatteryInfo,
-      Music,
-      Paint,
-      Paddle,
-      Twos,
-      HeartRate,
-      Navigation,
-      StopWatch,
-      Metronome,
-      Motion,
-      Steps,
-      PassKey,
-      QuickSettings,
-      Settings,
-      SettingWatchFace,
-      SettingTimeFormat,
-      SettingDisplay,
-      SettingWakeUp,
-      SettingSteps,
-      SettingSetDateTime,
-      SettingChimes,
-      SettingShakeThreshold,
-      SettingBluetooth,
-      Error
+    enum class Apps : uint64_t {
+      None = 1ull << 63ull,
+      Launcher = 1ull << 62ull,
+      Clock = 1ull << 61ull,
+      SysInfo = 1ull << 60ull,
+      FirmwareUpdate = 1ull << 59ull,
+      FirmwareValidation = 1ull << 58ull,
+      NotificationsPreview = 1ull << 57ull,
+      Notifications = 1ull << 56ull,
+      Timer = 1ull << 55ull,
+      Alarm = 1ull << 54ull,
+      FlashLight = 1ull << 53ull,
+      BatteryInfo = 1ull << 52ull,
+      HeartRate = 1ull << 51ull,
+      StopWatch = 1ull << 50ull,
+      Steps = 1ull << 49ull,
+      PassKey = 1ull << 48ull,
+      QuickSettings = 1ull << 47ull,
+      Settings = 1ull << 46ull,
+      SettingWatchFace = 1ull << 45ull,
+      SettingTimeFormat = 1ull << 44ull,
+      SettingDisplay = 1ull << 43ull,
+      SettingWakeUp = 1ull << 42ull,
+      SettingSteps = 1ull << 41ull,
+      SettingSetDateTime = 1ull << 40ull,
+      SettingChimes = 1ull << 39ull,
+      SettingShakeThreshold = 1ull << 38ull,
+      SettingBluetooth = 1ull << 37ull,
+      Error = 1ull << 36ull,
+
+      Music = 1ull << 0ull,
+      Paint = 1ull << 1ull,
+      Paddle = 1ull << 2ull,
+      Twos = 1ull << 3ull,
+      Navigation = 1ull << 4ull,
+      Metronome = 1ull << 5ull,
+      Motion = 1ull << 6ull,
     };
+
+#ifndef DISABLED_APPS
+    constexpr uint64_t disabledApps = static_cast<uint64_t>(Apps::Motion);
+#else
+    constexpr uint64_t disabledApps = DISABLED_APPS;
+#endif
   }
 }

--- a/src/displayapp/Apps.h
+++ b/src/displayapp/Apps.h
@@ -4,43 +4,47 @@
 
 namespace Pinetime {
   namespace Applications {
-    enum class Apps : uint64_t {
-      None = 1ull << 63ull,
-      Launcher = 1ull << 62ull,
-      Clock = 1ull << 61ull,
-      SysInfo = 1ull << 60ull,
-      FirmwareUpdate = 1ull << 59ull,
-      FirmwareValidation = 1ull << 58ull,
-      NotificationsPreview = 1ull << 57ull,
-      Notifications = 1ull << 56ull,
-      Timer = 1ull << 55ull,
-      Alarm = 1ull << 54ull,
-      FlashLight = 1ull << 53ull,
-      BatteryInfo = 1ull << 52ull,
-      HeartRate = 1ull << 51ull,
-      StopWatch = 1ull << 50ull,
-      Steps = 1ull << 49ull,
-      PassKey = 1ull << 48ull,
-      QuickSettings = 1ull << 47ull,
-      Settings = 1ull << 46ull,
-      SettingWatchFace = 1ull << 45ull,
-      SettingTimeFormat = 1ull << 44ull,
-      SettingDisplay = 1ull << 43ull,
-      SettingWakeUp = 1ull << 42ull,
-      SettingSteps = 1ull << 41ull,
-      SettingSetDateTime = 1ull << 40ull,
-      SettingChimes = 1ull << 39ull,
-      SettingShakeThreshold = 1ull << 38ull,
-      SettingBluetooth = 1ull << 37ull,
-      Error = 1ull << 36ull,
+    constexpr uint64_t rightShift(uint64_t nb) {
+      return UINT64_C(1) << nb;
+    }
 
-      Music = 1ull << 0ull,
-      Paint = 1ull << 1ull,
-      Paddle = 1ull << 2ull,
-      Twos = 1ull << 3ull,
-      Navigation = 1ull << 4ull,
-      Metronome = 1ull << 5ull,
-      Motion = 1ull << 6ull,
+    enum class Apps : uint64_t {
+      None = rightShift(63),
+      Launcher = rightShift(62),
+      Clock = rightShift(61),
+      SysInfo = rightShift(60),
+      FirmwareUpdate = rightShift(59),
+      FirmwareValidation = rightShift(58),
+      NotificationsPreview = rightShift(57),
+      Notifications = rightShift(56),
+      Timer = rightShift(55),
+      Alarm = rightShift(54),
+      FlashLight = rightShift(53),
+      BatteryInfo = rightShift(52),
+      HeartRate = rightShift(51),
+      StopWatch = rightShift(50),
+      Steps = rightShift(49),
+      PassKey = rightShift(48),
+      QuickSettings = rightShift(47),
+      Settings = rightShift(46),
+      SettingWatchFace = rightShift(45),
+      SettingTimeFormat = rightShift(44),
+      SettingDisplay = rightShift(43),
+      SettingWakeUp = rightShift(42),
+      SettingSteps = rightShift(41),
+      SettingSetDateTime = rightShift(40),
+      SettingChimes = rightShift(39),
+      SettingShakeThreshold = rightShift(38),
+      SettingBluetooth = rightShift(37),
+      Error = rightShift(36),
+
+      Music = rightShift(0),
+      Paint = rightShift(1),
+      Paddle = rightShift(2),
+      Twos = rightShift(3),
+      Navigation = rightShift(4),
+      Metronome = rightShift(5),
+      Motion = rightShift(6),
     };
 
 #ifndef DISABLED_APPS
@@ -48,5 +52,9 @@ namespace Pinetime {
 #else
     constexpr uint64_t disabledApps = DISABLED_APPS;
 #endif
+
+    constexpr bool isDisabled(Apps app) {
+      return disabledApps & static_cast<uint64_t>(app);
+    }
   }
 }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -363,9 +363,6 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
       currentScreen =
         std::make_unique<Screens::ApplicationList>(this, settingsController, batteryController, bleController, dateTimeController);
       break;
-    case Apps::Motion:
-      // currentScreen = std::make_unique<Screens::Motion>(motionController);
-      // break;
     case Apps::None:
     case Apps::Clock:
       currentScreen = std::make_unique<Screens::Clock>(dateTimeController,
@@ -476,25 +473,42 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
       currentScreen = std::make_unique<Screens::StopWatch>(*systemTask);
       break;
     case Apps::Twos:
-      currentScreen = std::make_unique<Screens::Twos>();
+      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Twos))) {
+        currentScreen = std::make_unique<Screens::Twos>();
+      }
       break;
     case Apps::Paint:
-      currentScreen = std::make_unique<Screens::InfiniPaint>(lvgl, motorController);
+      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Paint))) {
+        currentScreen = std::make_unique<Screens::InfiniPaint>(lvgl, motorController);
+      }
       break;
     case Apps::Paddle:
-      currentScreen = std::make_unique<Screens::Paddle>(lvgl);
+      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Paddle))) {
+        currentScreen = std::make_unique<Screens::Paddle>(lvgl);
+      }
       break;
     case Apps::Music:
-      currentScreen = std::make_unique<Screens::Music>(systemTask->nimble().music());
+      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Music))) {
+        currentScreen = std::make_unique<Screens::Music>(systemTask->nimble().music());
+      }
       break;
     case Apps::Navigation:
-      currentScreen = std::make_unique<Screens::Navigation>(systemTask->nimble().navigation());
+      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Navigation))) {
+        currentScreen = std::make_unique<Screens::Navigation>(systemTask->nimble().navigation());
+      }
       break;
     case Apps::HeartRate:
       currentScreen = std::make_unique<Screens::HeartRate>(heartRateController, *systemTask);
       break;
     case Apps::Metronome:
-      currentScreen = std::make_unique<Screens::Metronome>(motorController, *systemTask);
+      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Metronome))) {
+        currentScreen = std::make_unique<Screens::Metronome>(motorController, *systemTask);
+      }
+      break;
+    case Apps::Motion:
+      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Motion))) {
+        currentScreen = std::make_unique<Screens::Motion>(motionController);
+      }
       break;
     case Apps::Steps:
       currentScreen = std::make_unique<Screens::Steps>(motionController, settingsController);

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -1,4 +1,5 @@
 #include "displayapp/DisplayApp.h"
+#include <displayapp/Apps.h>
 #include <libraries/log/nrf_log.h>
 #include "displayapp/screens/HeartRate.h"
 #include "displayapp/screens/Motion.h"
@@ -478,22 +479,22 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
       }
       break;
     case Apps::Paint:
-      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Paint))) {
+      if constexpr (!isDisabled(Apps::Paint)) {
         currentScreen = std::make_unique<Screens::InfiniPaint>(lvgl, motorController);
       }
       break;
     case Apps::Paddle:
-      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Paddle))) {
+      if constexpr (!isDisabled(Apps::Paddle)) {
         currentScreen = std::make_unique<Screens::Paddle>(lvgl);
       }
       break;
     case Apps::Music:
-      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Music))) {
+      if constexpr (!isDisabled(Apps::Music)) {
         currentScreen = std::make_unique<Screens::Music>(systemTask->nimble().music());
       }
       break;
     case Apps::Navigation:
-      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Navigation))) {
+      if constexpr (!isDisabled(Apps::Navigation)) {
         currentScreen = std::make_unique<Screens::Navigation>(systemTask->nimble().navigation());
       }
       break;
@@ -501,12 +502,12 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
       currentScreen = std::make_unique<Screens::HeartRate>(heartRateController, *systemTask);
       break;
     case Apps::Metronome:
-      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Metronome))) {
+      if constexpr (!isDisabled(Apps::Metronome)) {
         currentScreen = std::make_unique<Screens::Metronome>(motorController, *systemTask);
       }
       break;
     case Apps::Motion:
-      if constexpr (!(disabledApps & static_cast<uint64_t>(Apps::Motion))) {
+      if constexpr (!isDisabled(Apps::Motion)) {
         currentScreen = std::make_unique<Screens::Motion>(motionController);
       }
       break;

--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -45,16 +45,21 @@ namespace Pinetime {
           {Symbols::hourGlass, Apps::Timer},
           {Symbols::shoe, Apps::Steps},
           {Symbols::heartBeat, Apps::HeartRate},
-          {Symbols::music, Apps::Music},
+          {disabledApps & static_cast<uint64_t>(Apps::Music) ? Symbols::none : Symbols::music,
+           disabledApps& static_cast<uint64_t>(Apps::Music) ? Apps::None : Apps::Music},
 
-          {Symbols::paintbrush, Apps::Paint},
-          {Symbols::paddle, Apps::Paddle},
-          {"2", Apps::Twos},
-          {Symbols::drum, Apps::Metronome},
-          {Symbols::map, Apps::Navigation},
-          {Symbols::none, Apps::None},
-
-          // {"M", Apps::Motion},
+          {disabledApps & static_cast<uint64_t>(Apps::Paint) ? Symbols::none : Symbols::paintbrush,
+           disabledApps& static_cast<uint64_t>(Apps::Paint) ? Apps::None : Apps::Paint},
+          {disabledApps & static_cast<uint64_t>(Apps::Paddle) ? Symbols::none : Symbols::paddle,
+           disabledApps& static_cast<uint64_t>(Apps::Paddle) ? Apps::None : Apps::Paddle},
+          {disabledApps & static_cast<uint64_t>(Apps::Twos) ? Symbols::none : "2",
+           disabledApps& static_cast<uint64_t>(Apps::Twos) ? Apps::None : Apps::Twos},
+          {disabledApps & static_cast<uint64_t>(Apps::Metronome) ? Symbols::none : Symbols::drum,
+           disabledApps& static_cast<uint64_t>(Apps::Metronome) ? Apps::None : Apps::Metronome},
+          {disabledApps & static_cast<uint64_t>(Apps::Navigation) ? Symbols::none : Symbols::map,
+           disabledApps& static_cast<uint64_t>(Apps::Navigation) ? Apps::None : Apps::Navigation},
+          {disabledApps & static_cast<uint64_t>(Apps::Motion) ? Symbols::none : "M",
+           disabledApps& static_cast<uint64_t>(Apps::Motion) ? Apps::None : Apps::Motion},
         }};
         ScreenList<nScreens> screens;
       };

--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -45,21 +45,14 @@ namespace Pinetime {
           {Symbols::hourGlass, Apps::Timer},
           {Symbols::shoe, Apps::Steps},
           {Symbols::heartBeat, Apps::HeartRate},
-          {disabledApps & static_cast<uint64_t>(Apps::Music) ? Symbols::none : Symbols::music,
-           disabledApps& static_cast<uint64_t>(Apps::Music) ? Apps::None : Apps::Music},
+          {isDisabled(Apps::Music) ? Symbols::none : Symbols::music, isDisabled(Apps::Music) ? Apps::None : Apps::Music},
 
-          {disabledApps & static_cast<uint64_t>(Apps::Paint) ? Symbols::none : Symbols::paintbrush,
-           disabledApps& static_cast<uint64_t>(Apps::Paint) ? Apps::None : Apps::Paint},
-          {disabledApps & static_cast<uint64_t>(Apps::Paddle) ? Symbols::none : Symbols::paddle,
-           disabledApps& static_cast<uint64_t>(Apps::Paddle) ? Apps::None : Apps::Paddle},
-          {disabledApps & static_cast<uint64_t>(Apps::Twos) ? Symbols::none : "2",
-           disabledApps& static_cast<uint64_t>(Apps::Twos) ? Apps::None : Apps::Twos},
-          {disabledApps & static_cast<uint64_t>(Apps::Metronome) ? Symbols::none : Symbols::drum,
-           disabledApps& static_cast<uint64_t>(Apps::Metronome) ? Apps::None : Apps::Metronome},
-          {disabledApps & static_cast<uint64_t>(Apps::Navigation) ? Symbols::none : Symbols::map,
-           disabledApps& static_cast<uint64_t>(Apps::Navigation) ? Apps::None : Apps::Navigation},
-          {disabledApps & static_cast<uint64_t>(Apps::Motion) ? Symbols::none : "M",
-           disabledApps& static_cast<uint64_t>(Apps::Motion) ? Apps::None : Apps::Motion},
+          {isDisabled(Apps::Paint) ? Symbols::none : Symbols::paintbrush, isDisabled(Apps::Paint) ? Apps::None : Apps::Paint},
+          {isDisabled(Apps::Paddle) ? Symbols::none : Symbols::paddle, isDisabled(Apps::Paddle) ? Apps::None : Apps::Paddle},
+          {isDisabled(Apps::Twos) ? Symbols::none : "2", isDisabled(Apps::Twos) ? Apps::None : Apps::Twos},
+          {isDisabled(Apps::Metronome) ? Symbols::none : Symbols::drum, isDisabled(Apps::Metronome) ? Apps::None : Apps::Metronome},
+          {isDisabled(Apps::Navigation) ? Symbols::none : Symbols::map, isDisabled(Apps::Navigation) ? Apps::None : Apps::Navigation},
+          {isDisabled(Apps::Motion) ? Symbols::none : "M", isDisabled(Apps::Motion) ? Apps::None : Apps::Motion},
         }};
         ScreenList<nScreens> screens;
       };


### PR DESCRIPTION
Proof-of-concept for using the value of the Apps enumerations for a 64-bit bitfield for choosing what apps to include at compile-time. The reason for making this is because we want to minimise the number of places people need to add their new app to. By using the values of the Apps enumerations and a bitfield developers don't need to add their app to another place just for it to be togglable at compile-time. (Inspired by https://github.com/InfiniTimeOrg/InfiniTime/pull/1408#issuecomment-1455078843).

This also attempts to use the preprocessor as little as possible, and I've got it down to one ifdef for the declaration of `disabledApps`.

For some reason, this increases flash usage considerably, but it does fluctuate as expected by changing the `disabledApps` variable.

The implementation for the ApplicationList is really ugly (and clang-format can't format it properly), so if anyone has any suggestions on how to make that nicer, it would be much appreciated. It also doesn't move apps in the UI, so there are just gaps wherever apps have been disabled.

Another issue is that, to disable apps via the CMake command-line, users need to calculate bitwise operations for the apps they want to disable. This isn't very friendly, so if someone has any ideas, I'd love to hear them.

Fixes #1114