### PR TITLE
WIP: DisplayApp: Use LVGL gestures

### DIFF
--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -74,6 +74,7 @@ namespace Pinetime {
       void SetFullRefresh(FullRefreshDirections direction);
 
       void Register(Pinetime::System::SystemTask* systemTask);
+      void HandleScreenGesture(lv_gesture_dir_t dir);
 
     private:
       Pinetime::Drivers::St7789& lcd;
@@ -116,6 +117,7 @@ namespace Pinetime {
       static void Process(void* instance);
       void InitHw();
       void Refresh();
+      void LoadPreviousScreen();
       void LoadNewScreen(Apps app, DisplayApp::FullRefreshDirections direction);
       void LoadScreen(Apps app, DisplayApp::FullRefreshDirections direction);
       void PushMessageToSystemTask(Pinetime::System::Messages message);

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -34,6 +34,7 @@ Metronome::Metronome(Controllers::MotorController& motorController, System::Syst
   lv_obj_set_size(bpmArc, 210, 210);
   lv_arc_set_adjustable(bpmArc, true);
   lv_obj_align(bpmArc, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 0);
+  lv_obj_set_gesture_parent(bpmArc, false);
 
   bpmValue = createLabel("120", bpmArc, LV_ALIGN_IN_TOP_MID, &jetbrains_mono_76, 0, 55);
   createLabel("bpm", bpmValue, LV_ALIGN_OUT_BOTTOM_MID, &jetbrains_mono_bold_20, 0, 0);
@@ -113,16 +114,9 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
           lv_label_set_text_fmt(bpmValue, "%03d", bpm);
         }
         tappedTime = xTaskGetTickCount();
-        allowExit = true;
       }
       break;
     }
-    case LV_EVENT_RELEASED:
-    case LV_EVENT_PRESS_LOST:
-      if (obj == bpmTap) {
-        allowExit = false;
-      }
-      break;
     case LV_EVENT_CLICKED: {
       if (obj == playPause) {
         metronomeStarted = !metronomeStarted;
@@ -141,11 +135,4 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
     default:
       break;
   }
-}
-
-bool Metronome::OnTouchEvent(TouchEvents event) {
-  if (event == TouchEvents::SwipeDown && allowExit) {
-    running = false;
-  }
-  return true;
 }

--- a/src/displayapp/screens/Metronome.h
+++ b/src/displayapp/screens/Metronome.h
@@ -14,7 +14,6 @@ namespace Pinetime {
         ~Metronome() override;
         void Refresh() override;
         void OnEvent(lv_obj_t* obj, lv_event_t event);
-        bool OnTouchEvent(TouchEvents event) override;
 
       private:
         TickType_t startTime = 0;
@@ -26,7 +25,6 @@ namespace Pinetime {
         uint8_t counter = 1;
 
         bool metronomeStarted = false;
-        bool allowExit = false;
 
         lv_obj_t *bpmArc, *bpmTap, *bpmValue;
         lv_obj_t *bpbDropdown, *currentBpbText;


### PR DESCRIPTION
I was investigating issue #1685 and found that it can be fixed by using LVGL gestures.

Communicating hardware gestures to LVGL is tricky, because there's no built in support for it. Using LVGL gestures, we only need the touch coordinates from the touch panel. Following up, OnTouchEvent functions can be replaced by LVGL event handlers.

TODO:

- [ ] ~~Fix ScreenList swipe behavior~~ Find a solution to dragging past multiple objects. https://github.com/InfiniTimeOrg/InfiniTime/pull/1686#issuecomment-1465172083
- [ ] Tweak `lv_conf.h`

Relates to #1011
Fixes #1685