### PR TITLE
stopwatch: Add hours tracking

### DIFF
--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -110,7 +110,7 @@ void StopWatch::SetInterfaceStopped() {
 
   lv_label_set_text_static(time, "00:00");
   lv_label_set_text_static(msecTime, "00");
-  
+
   if (isHoursLabelUpdated) {
     lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
     lv_obj_realign(time);

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -152,7 +152,7 @@ void StopWatch::Refresh() {
     } else {
       lv_label_set_text_fmt(time, "%02d:%02d:%02d", currentTimeSeparated.hours, currentTimeSeparated.mins, currentTimeSeparated.secs);
       lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
-      lv_obj_realign(time, msecTime, LV_ALIGN_OUT_TOP_MID, 0, 0);
+      lv_obj_align(time, msecTime, LV_ALIGN_OUT_TOP_MID, 0, 0);
     }
     lv_label_set_text_fmt(msecTime, "%02d", currentTimeSeparated.hundredths);
   } else if (currentState == States::Halted) {

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -152,7 +152,7 @@ void StopWatch::Refresh() {
     } else {
       lv_label_set_text_fmt(time, "%02d:%02d:%02d", currentTimeSeparated.hours, currentTimeSeparated.mins, currentTimeSeparated.secs);
       lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
-      lv_obj_align(time, msecTime, LV_ALIGN_OUT_TOP_MID, 0, 0);
+      lv_obj_realign(time, msecTime, LV_ALIGN_OUT_TOP_MID, 0, 0);
     }
     lv_label_set_text_fmt(msecTime, "%02d", currentTimeSeparated.hundredths);
   } else if (currentState == States::Halted) {

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -152,7 +152,7 @@ void StopWatch::Refresh() {
     } else {
       lv_label_set_text_fmt(time, "%02d:%02d:%02d", currentTimeSeparated.hours, currentTimeSeparated.mins, currentTimeSeparated.secs);
       lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
-      lv_obj_align(time, msecTime, LV_ALIGN_OUT_TOP_MID, 0, 0);
+      lv_obj_realign(time);
     }
     lv_label_set_text_fmt(msecTime, "%02d", currentTimeSeparated.hundredths);
   } else if (currentState == States::Halted) {

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -107,7 +107,11 @@ void StopWatch::SetInterfaceStopped() {
   lv_obj_set_state(time, LV_STATE_DISABLED);
   lv_obj_set_state(msecTime, LV_STATE_DISABLED);
   lv_obj_set_style_local_bg_color(btnPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Colors::blue);
-  lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
+  if (isHoursLabelUpdated) {
+    lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
+    lv_obj_realign(time);
+    isHoursLabelUpdated = false;
+  }
 
   lv_label_set_text_static(time, "00:00");
   lv_label_set_text_static(msecTime, "00");
@@ -152,8 +156,11 @@ void StopWatch::Refresh() {
       lv_label_set_text_fmt(time, "%02d:%02d", currentTimeSeparated.mins, currentTimeSeparated.secs);
     } else {
       lv_label_set_text_fmt(time, "%02d:%02d:%02d", currentTimeSeparated.hours, currentTimeSeparated.mins, currentTimeSeparated.secs);
-      lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
-      lv_obj_realign(time);
+      if (!isHoursLabelUpdated) {
+        lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+        lv_obj_realign(time);
+        isHoursLabelUpdated = true;
+      }
     }
     lv_label_set_text_fmt(msecTime, "%02d", currentTimeSeparated.hundredths);
   } else if (currentState == States::Halted) {

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -12,7 +12,7 @@ namespace {
 
     const int hundredths = (timeElapsedCentis % 100);
     const int secs = (timeElapsedCentis / 100) % 60;
-    const int mins = (((timeElapsedCentis / 100)) / 60) % 60;
+    const int mins = ((timeElapsedCentis / 100) / 60) % 60;
     const int hours = ((timeElapsedCentis / 100) / 60) / 60;
     return TimeSeparated_t {hours, mins, secs, hundredths};
   }

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -12,7 +12,7 @@ namespace {
 
     const int hundredths = (timeElapsedCentis % 100);
     const int secs = (timeElapsedCentis / 100) % 60;
-    const int mins = ((timeElapsedCentis / 100) / 60) % 60;
+    const int mins = (((timeElapsedCentis / 100)) / 60) % 60;
     const int hours = ((timeElapsedCentis / 100) / 60) / 60;
     return TimeSeparated_t {hours, mins, secs, hundredths};
   }
@@ -149,12 +149,12 @@ void StopWatch::Refresh() {
     TimeSeparated_t currentTimeSeparated = convertTicksToTimeSegments(laps[lapsDone]);
     if (currentTimeSeparated.hours == 0) {
       lv_label_set_text_fmt(time, "%02d:%02d", currentTimeSeparated.mins, currentTimeSeparated.secs);
-      lv_label_set_text_fmt(msecTime, "%02d", currentTimeSeparated.hundredths);
     } else {
-      lv_label_set_text_fmt(time, "%02d:%02d", currentTimeSeparated.hours, currentTimeSeparated.mins);
-      lv_label_set_text_fmt(msecTime, "%02d:%02d", currentTimeSeparated.secs, currentTimeSeparated.hundredths);
-      lv_obj_align(msecTime, lapText, LV_ALIGN_OUT_TOP_MID, 0, 0);
+      lv_label_set_text_fmt(time, "%02d:%02d:%02d", currentTimeSeparated.hours, currentTimeSeparated.mins, currentTimeSeparated.secs);
+      lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
+      lv_obj_align(time, msecTime, LV_ALIGN_OUT_TOP_MID, 0, 0);
     }
+    lv_label_set_text_fmt(msecTime, "%02d", currentTimeSeparated.hundredths);
   } else if (currentState == States::Halted) {
     const TickType_t currentTime = xTaskGetTickCount();
     if (currentTime > blinkTime) {

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -107,6 +107,7 @@ void StopWatch::SetInterfaceStopped() {
   lv_obj_set_state(time, LV_STATE_DISABLED);
   lv_obj_set_state(msecTime, LV_STATE_DISABLED);
   lv_obj_set_style_local_bg_color(btnPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Colors::blue);
+  lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
 
   lv_label_set_text_static(time, "00:00");
   lv_label_set_text_static(msecTime, "00");

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -12,7 +12,7 @@ namespace {
 
     const int hundredths = (timeElapsedCentis % 100);
     const int secs = (timeElapsedCentis / 100) % 60;
-    const int mins = (timeElapsedCentis / 100) / 60;
+    const int mins = ((timeElapsedCentis / 100) / 60) % 60;
     const int hours = ((timeElapsedCentis / 100) / 60) / 60;
     return TimeSeparated_t {hours, mins, secs, hundredths};
   }

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -107,14 +107,15 @@ void StopWatch::SetInterfaceStopped() {
   lv_obj_set_state(time, LV_STATE_DISABLED);
   lv_obj_set_state(msecTime, LV_STATE_DISABLED);
   lv_obj_set_style_local_bg_color(btnPlayPause, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, Colors::blue);
+
+  lv_label_set_text_static(time, "00:00");
+  lv_label_set_text_static(msecTime, "00");
+  
   if (isHoursLabelUpdated) {
     lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
     lv_obj_realign(time);
     isHoursLabelUpdated = false;
   }
-
-  lv_label_set_text_static(time, "00:00");
-  lv_label_set_text_static(msecTime, "00");
 
   lv_label_set_text_static(lapText, "");
   lv_label_set_text_static(txtPlayPause, Symbols::play);

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -49,6 +49,7 @@ namespace Pinetime::Applications::Screens {
     int lapsDone = 0;
     lv_obj_t *time, *msecTime, *btnPlayPause, *btnStopLap, *txtPlayPause, *txtStopLap;
     lv_obj_t* lapText;
+    bool isHoursLabelUpdated = false;
 
     lv_task_t* taskRefresh;
   };

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -13,6 +13,7 @@ namespace Pinetime::Applications::Screens {
   enum class States { Init, Running, Halted };
 
   struct TimeSeparated_t {
+    int hours;
     int mins;
     int secs;
     int hundredths;


### PR DESCRIPTION
Addresses https://github.com/InfiniTimeOrg/InfiniTime/issues/394

![Screenshot of changes](https://user-images.githubusercontent.com/100048769/225496444-0648b4e1-ce23-4067-8791-2b64461f54e2.png)

It adds hours without changing any of the existing formatting, but by re-using it as needed.

Once the timer is > 1 hour, the main display becomes Hours:Minutes, and the part beneath becomes Seconds:Milliseconds. Lap timer will display "Hours:Minutes:Seconds.Milliseconds" when a lengthy timer is recorded.