### PR TITLE
notification: Initialise message

### DIFF
--- a/src/components/ble/NotificationManager.h
+++ b/src/components/ble/NotificationManager.h
@@ -30,7 +30,7 @@ namespace Pinetime {
         Id id = 0;
         bool valid = false;
         uint8_t size;
-        std::array<char, MessageSize + 1> message;
+        std::array<char, MessageSize + 1> message {};
         Categories category = Categories::Unknown;
 
         const char* Message() const;


### PR DESCRIPTION
Prevents reading uninitialised memory if notification gets cut off due to being more than 100 chars. The last character is assumed to be `\0`, but it is actually uninitialised.