### PR TITLE
Add D/M/Y, M/D/Y format support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -420,6 +420,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/settings/SettingSteps.cpp
         displayapp/screens/settings/SettingSetDateTime.cpp
         displayapp/screens/settings/SettingSetDate.cpp
+        displayapp/screens/settings/SettingSetDateTimeFormat.cpp
         displayapp/screens/settings/SettingSetTime.cpp
         displayapp/screens/settings/SettingChimes.cpp
         displayapp/screens/settings/SettingShakeThreshold.cpp

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -9,6 +9,7 @@ namespace Pinetime {
     class Settings {
     public:
       enum class ClockType : uint8_t { H24, H12 };
+      enum class DateType : uint8_t { DMY, MDY };
       enum class Notification : uint8_t { On, Off, Sleep };
       enum class ChimesOption : uint8_t { None, Hours, HalfHours };
       enum class WakeUpMode : uint8_t {
@@ -172,6 +173,17 @@ namespace Pinetime {
         return settings.clockType;
       };
 
+      void SetDateType(DateType dateType) {
+        if (dateType != settings.dateType) {
+          settingsChanged = true;
+        }
+        settings.dateType = dateType;
+      }
+
+      DateType GetDateType() const {
+        return settings.dateType;
+      }
+
       void SetNotificationStatus(Notification status) {
         if (status != settings.notificationStatus) {
           settingsChanged = true;
@@ -266,7 +278,7 @@ namespace Pinetime {
     private:
       Pinetime::Controllers::FS& fs;
 
-      static constexpr uint32_t settingsVersion = 0x0004;
+      static constexpr uint32_t settingsVersion = 0x0005;
 
       struct SettingsData {
         uint32_t version = settingsVersion;
@@ -274,6 +286,7 @@ namespace Pinetime {
         uint32_t screenTimeOut = 15000;
 
         ClockType clockType = ClockType::H24;
+        DateType dateType = DateType::DMY;
         Notification notificationStatus = Notification::On;
 
         uint8_t clockFace = 0;

--- a/src/displayapp/screens/settings/SettingSetDateTime.cpp
+++ b/src/displayapp/screens/settings/SettingSetDateTime.cpp
@@ -1,6 +1,7 @@
 #include "displayapp/screens/settings/SettingSetDateTime.h"
 #include "displayapp/screens/settings/SettingSetDate.h"
 #include "displayapp/screens/settings/SettingSetTime.h"
+#include "displayapp/screens/settings/SettingSetDateTimeFormat.h"
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/ScreenList.h"
 #include "components/settings/Settings.h"
@@ -25,20 +26,29 @@ SettingSetDateTime::SettingSetDateTime(Pinetime::Applications::DisplayApp* app,
               },
               [this]() -> std::unique_ptr<Screen> {
                 return screenSetTime();
+              },
+              [this]() -> std::unique_ptr<Screen> {
+                return screenSetFormat();
               }},
              Screens::ScreenListModes::UpDown} {
 }
 
 std::unique_ptr<Screen> SettingSetDateTime::screenSetDate() {
-  Widgets::DotIndicator dotIndicator(0, 2);
+  Widgets::DotIndicator dotIndicator(0, 3);
   dotIndicator.Create();
   return std::make_unique<Screens::SettingSetDate>(dateTimeController, *this);
 }
 
 std::unique_ptr<Screen> SettingSetDateTime::screenSetTime() {
-  Widgets::DotIndicator dotIndicator(1, 2);
+  Widgets::DotIndicator dotIndicator(1, 3);
   dotIndicator.Create();
   return std::make_unique<Screens::SettingSetTime>(dateTimeController, settingsController, *this);
+}
+
+std::unique_ptr<Screen> SettingSetDateTime::screenSetFormat() {
+  Widgets::DotIndicator dotIndicator(2, 3);
+  dotIndicator.Create();
+  return std::make_unique<Screens::SettingSetDateTimeFormat>(dateTimeController, settingsController, *this);
 }
 
 SettingSetDateTime::~SettingSetDateTime() {

--- a/src/displayapp/screens/settings/SettingSetDateTime.h
+++ b/src/displayapp/screens/settings/SettingSetDateTime.h
@@ -24,9 +24,10 @@ namespace Pinetime {
         Controllers::DateTime& dateTimeController;
         Controllers::Settings& settingsController;
 
-        ScreenList<2> screens;
+        ScreenList<3> screens;
         std::unique_ptr<Screen> screenSetDate();
         std::unique_ptr<Screen> screenSetTime();
+        std::unique_ptr<Screen> screenSetFormat();
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingSetDateTimeFormat.cpp
+++ b/src/displayapp/screens/settings/SettingSetDateTimeFormat.cpp
@@ -11,7 +11,7 @@ using namespace Pinetime::Applications::Screens;
 namespace {
   constexpr int16_t BUTTON_WIDTH = 100;
   constexpr int16_t BUTTON_HEIGHT = 60;
-  constexpr int16_t BUTTON_SPACING = BUTTON_HEIGHT/2 + 5;
+  constexpr int16_t BUTTON_SPACING = BUTTON_HEIGHT / 2 + 5;
   constexpr int16_t BUTTON_PADDING = 15;
   constexpr lv_color_t ACTIVE_COLOR = Colors::lightGray;
   constexpr lv_color_t INACTIVE_COLOR = Colors::bgAlt;
@@ -19,14 +19,14 @@ namespace {
   void event_handler(lv_obj_t* obj, lv_event_t event) {
     auto* screen = static_cast<SettingSetDateTimeFormat*>(obj->user_data);
     if (event == LV_EVENT_CLICKED) {
-      screen->HandleButtonPress();
+      screen->HandleButtonPress(obj);
     }
   }
 }
 
 SettingSetDateTimeFormat::SettingSetDateTimeFormat(Pinetime::Controllers::DateTime& dateTimeController,
-                              Pinetime::Controllers::Settings& settingsController,
-                              Pinetime::Applications::Screens::SettingSetDateTime& settingSetDateTime)
+                                                   Pinetime::Controllers::Settings& settingsController,
+                                                   Pinetime::Applications::Screens::SettingSetDateTime& settingSetDateTime)
   : dateTimeController {dateTimeController}, settingsController {settingsController}, settingSetDateTime {settingSetDateTime} {
 
   lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
@@ -41,7 +41,7 @@ SettingSetDateTimeFormat::SettingSetDateTimeFormat(Pinetime::Controllers::DateTi
   lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
-  //TODO set color to match the other screens
+  // TODO set color to match the other screens
 
   btnTime12hr = lv_btn_create(lv_scr_act(), nullptr);
   btnTime12hr->user_data = this;
@@ -49,6 +49,7 @@ SettingSetDateTimeFormat::SettingSetDateTimeFormat(Pinetime::Controllers::DateTi
   lv_label_set_text_static(label12hr, "12 hr");
   lv_obj_set_size(btnTime12hr, BUTTON_WIDTH, BUTTON_HEIGHT);
   lv_obj_align(btnTime12hr, nullptr, LV_ALIGN_IN_LEFT_MID, BUTTON_PADDING, BUTTON_SPACING);
+  lv_obj_set_event_cb(btnTime12hr, event_handler);
 
   btnTime24hr = lv_btn_create(lv_scr_act(), nullptr);
   btnTime24hr->user_data = this;
@@ -56,6 +57,7 @@ SettingSetDateTimeFormat::SettingSetDateTimeFormat(Pinetime::Controllers::DateTi
   lv_label_set_text_static(label24hr, "24 hr");
   lv_obj_set_size(btnTime24hr, BUTTON_WIDTH, BUTTON_HEIGHT);
   lv_obj_align(btnTime24hr, nullptr, LV_ALIGN_IN_LEFT_MID, BUTTON_PADDING, -BUTTON_SPACING);
+  lv_obj_set_event_cb(btnTime24hr, event_handler);
 
   btnDateDmy = lv_btn_create(lv_scr_act(), nullptr);
   btnDateDmy->user_data = this;
@@ -63,6 +65,7 @@ SettingSetDateTimeFormat::SettingSetDateTimeFormat(Pinetime::Controllers::DateTi
   lv_label_set_text_static(labelDmy, "D/M/Y");
   lv_obj_set_size(btnDateDmy, BUTTON_WIDTH, BUTTON_HEIGHT);
   lv_obj_align(btnDateDmy, nullptr, LV_ALIGN_IN_RIGHT_MID, -BUTTON_PADDING, BUTTON_SPACING);
+  lv_obj_set_event_cb(btnDateDmy, event_handler);
 
   btnDateMdy = lv_btn_create(lv_scr_act(), nullptr);
   btnDateMdy->user_data = this;
@@ -70,6 +73,7 @@ SettingSetDateTimeFormat::SettingSetDateTimeFormat(Pinetime::Controllers::DateTi
   lv_label_set_text_static(labelMdy, "M/D/Y");
   lv_obj_set_size(btnDateMdy, BUTTON_WIDTH, BUTTON_HEIGHT);
   lv_obj_align(btnDateMdy, nullptr, LV_ALIGN_IN_RIGHT_MID, -BUTTON_PADDING, -BUTTON_SPACING);
+  lv_obj_set_event_cb(btnDateMdy, event_handler);
 
   this->SetSelectedColors();
 }
@@ -109,5 +113,14 @@ void SettingSetDateTimeFormat::SetSelectedColors() {
 }
 
 void SettingSetDateTimeFormat::HandleButtonPress(lv_obj_t* buttonPressed) {
-
+  if (buttonPressed == this->btnTime12hr) {
+    this->settingsController.SetClockType(Pinetime::Controllers::Settings::ClockType::H12);
+  } else if (buttonPressed == this->btnTime24hr) {
+    this->settingsController.SetClockType(Pinetime::Controllers::Settings::ClockType::H24);
+  } else if (buttonPressed == this->btnDateDmy) {
+    this->settingsController.SetDateType(Pinetime::Controllers::Settings::DateType::DMY);
+  } else if (buttonPressed == this->btnDateMdy) {
+    this->settingsController.SetDateType(Pinetime::Controllers::Settings::DateType::MDY);
+  }
+  this->SetSelectedColors();
 }

--- a/src/displayapp/screens/settings/SettingSetDateTimeFormat.cpp
+++ b/src/displayapp/screens/settings/SettingSetDateTimeFormat.cpp
@@ -4,17 +4,20 @@
 #include <nrf_log.h>
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/Symbols.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 using namespace Pinetime::Applications::Screens;
 
 namespace {
-  constexpr int16_t POS_X_DAY = -72;
-  constexpr int16_t POS_X_MONTH = 0;
-  constexpr int16_t POS_X_YEAR = 72;
-  constexpr int16_t POS_Y_TEXT = -6;
+  constexpr int16_t BUTTON_WIDTH = 100;
+  constexpr int16_t BUTTON_HEIGHT = 60;
+  constexpr int16_t BUTTON_SPACING = BUTTON_HEIGHT/2 + 5;
+  constexpr int16_t BUTTON_PADDING = 15;
+  constexpr lv_color_t ACTIVE_COLOR = Colors::lightGray;
+  constexpr lv_color_t INACTIVE_COLOR = Colors::bgAlt;
 
   void event_handler(lv_obj_t* obj, lv_event_t event) {
-    auto* screen = static_cast<SettingSetDate*>(obj->user_data);
+    auto* screen = static_cast<SettingSetDateTimeFormat*>(obj->user_data);
     if (event == LV_EVENT_CLICKED) {
       screen->HandleButtonPress();
     }
@@ -38,16 +41,73 @@ SettingSetDateTimeFormat::SettingSetDateTimeFormat(Pinetime::Controllers::DateTi
   lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
-  btnSetTime = lv_btn_create(lv_scr_act(), nullptr);
-  btnSetTime->user_data = this;
-  lv_obj_set_size(btnSetTime, 120, 48);
-  lv_obj_align(btnSetTime, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
-  lv_obj_set_style_local_bg_color(btnSetTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0x38, 0x38, 0x38));
-  lblSetTime = lv_label_create(btnSetTime, nullptr);
-  lv_label_set_text_static(lblSetTime, "Set");
-  lv_obj_set_event_cb(btnSetTime, event_handler);
+  //TODO set color to match the other screens
+
+  btnTime12hr = lv_btn_create(lv_scr_act(), nullptr);
+  btnTime12hr->user_data = this;
+  lv_obj_t* label12hr = lv_label_create(btnTime12hr, nullptr);
+  lv_label_set_text_static(label12hr, "12 hr");
+  lv_obj_set_size(btnTime12hr, BUTTON_WIDTH, BUTTON_HEIGHT);
+  lv_obj_align(btnTime12hr, nullptr, LV_ALIGN_IN_LEFT_MID, BUTTON_PADDING, BUTTON_SPACING);
+
+  btnTime24hr = lv_btn_create(lv_scr_act(), nullptr);
+  btnTime24hr->user_data = this;
+  lv_obj_t* label24hr = lv_label_create(btnTime24hr, nullptr);
+  lv_label_set_text_static(label24hr, "24 hr");
+  lv_obj_set_size(btnTime24hr, BUTTON_WIDTH, BUTTON_HEIGHT);
+  lv_obj_align(btnTime24hr, nullptr, LV_ALIGN_IN_LEFT_MID, BUTTON_PADDING, -BUTTON_SPACING);
+
+  btnDateDmy = lv_btn_create(lv_scr_act(), nullptr);
+  btnDateDmy->user_data = this;
+  lv_obj_t* labelDmy = lv_label_create(btnDateDmy, nullptr);
+  lv_label_set_text_static(labelDmy, "D/M/Y");
+  lv_obj_set_size(btnDateDmy, BUTTON_WIDTH, BUTTON_HEIGHT);
+  lv_obj_align(btnDateDmy, nullptr, LV_ALIGN_IN_RIGHT_MID, -BUTTON_PADDING, BUTTON_SPACING);
+
+  btnDateMdy = lv_btn_create(lv_scr_act(), nullptr);
+  btnDateMdy->user_data = this;
+  lv_obj_t* labelMdy = lv_label_create(btnDateMdy, nullptr);
+  lv_label_set_text_static(labelMdy, "M/D/Y");
+  lv_obj_set_size(btnDateMdy, BUTTON_WIDTH, BUTTON_HEIGHT);
+  lv_obj_align(btnDateMdy, nullptr, LV_ALIGN_IN_RIGHT_MID, -BUTTON_PADDING, -BUTTON_SPACING);
+
+  this->SetSelectedColors();
 }
 
 SettingSetDateTimeFormat::~SettingSetDateTimeFormat() {
   lv_obj_clean(lv_scr_act());
+}
+
+void SettingSetDateTimeFormat::SetSelectedColors() {
+  switch (settingsController.GetClockType()) {
+    case Pinetime::Controllers::Settings::ClockType::H12:
+      lv_obj_set_style_local_bg_color(this->btnTime12hr, LV_PAGE_PART_BG, LV_STATE_DEFAULT, ACTIVE_COLOR);
+      lv_obj_set_style_local_bg_color(this->btnTime24hr, LV_PAGE_PART_BG, LV_STATE_DEFAULT, INACTIVE_COLOR);
+      break;
+    case Pinetime::Controllers::Settings::ClockType::H24:
+      lv_obj_set_style_local_bg_color(this->btnTime12hr, LV_PAGE_PART_BG, LV_STATE_DEFAULT, INACTIVE_COLOR);
+      lv_obj_set_style_local_bg_color(this->btnTime24hr, LV_PAGE_PART_BG, LV_STATE_DEFAULT, ACTIVE_COLOR);
+      break;
+    default:
+      // this shouldn't happen
+      return;
+  }
+
+  switch (settingsController.GetDateType()) {
+    case Pinetime::Controllers::Settings::DateType::DMY:
+      lv_obj_set_style_local_bg_color(this->btnDateDmy, LV_PAGE_PART_BG, LV_STATE_DEFAULT, ACTIVE_COLOR);
+      lv_obj_set_style_local_bg_color(this->btnDateMdy, LV_PAGE_PART_BG, LV_STATE_DEFAULT, INACTIVE_COLOR);
+      break;
+    case Pinetime::Controllers::Settings::DateType::MDY:
+      lv_obj_set_style_local_bg_color(this->btnDateDmy, LV_PAGE_PART_BG, LV_STATE_DEFAULT, INACTIVE_COLOR);
+      lv_obj_set_style_local_bg_color(this->btnDateMdy, LV_PAGE_PART_BG, LV_STATE_DEFAULT, ACTIVE_COLOR);
+      break;
+    default:
+      // this shoudln't happen
+      return;
+  }
+}
+
+void SettingSetDateTimeFormat::HandleButtonPress(lv_obj_t* buttonPressed) {
+
 }

--- a/src/displayapp/screens/settings/SettingSetDateTimeFormat.cpp
+++ b/src/displayapp/screens/settings/SettingSetDateTimeFormat.cpp
@@ -1,0 +1,53 @@
+#include "displayapp/screens/settings/SettingSetDate.h"
+#include "displayapp/screens/settings/SettingSetDateTimeFormat.h"
+#include <lvgl/lvgl.h>
+#include <nrf_log.h>
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Symbols.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  constexpr int16_t POS_X_DAY = -72;
+  constexpr int16_t POS_X_MONTH = 0;
+  constexpr int16_t POS_X_YEAR = 72;
+  constexpr int16_t POS_Y_TEXT = -6;
+
+  void event_handler(lv_obj_t* obj, lv_event_t event) {
+    auto* screen = static_cast<SettingSetDate*>(obj->user_data);
+    if (event == LV_EVENT_CLICKED) {
+      screen->HandleButtonPress();
+    }
+  }
+}
+
+SettingSetDateTimeFormat::SettingSetDateTimeFormat(Pinetime::Controllers::DateTime& dateTimeController,
+                              Pinetime::Controllers::Settings& settingsController,
+                              Pinetime::Applications::Screens::SettingSetDateTime& settingSetDateTime)
+  : dateTimeController {dateTimeController}, settingsController {settingsController}, settingSetDateTime {settingSetDateTime} {
+
+  lv_obj_t* title = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(title, "Set format");
+  lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 15, 15);
+
+  lv_obj_t* icon = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(icon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
+
+  lv_label_set_text_static(icon, Symbols::clock);
+  lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
+
+  btnSetTime = lv_btn_create(lv_scr_act(), nullptr);
+  btnSetTime->user_data = this;
+  lv_obj_set_size(btnSetTime, 120, 48);
+  lv_obj_align(btnSetTime, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
+  lv_obj_set_style_local_bg_color(btnSetTime, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_MAKE(0x38, 0x38, 0x38));
+  lblSetTime = lv_label_create(btnSetTime, nullptr);
+  lv_label_set_text_static(lblSetTime, "Set");
+  lv_obj_set_event_cb(btnSetTime, event_handler);
+}
+
+SettingSetDateTimeFormat::~SettingSetDateTimeFormat() {
+  lv_obj_clean(lv_scr_act());
+}

--- a/src/displayapp/screens/settings/SettingSetDateTimeFormat.h
+++ b/src/displayapp/screens/settings/SettingSetDateTimeFormat.h
@@ -14,9 +14,12 @@ namespace Pinetime {
       class SettingSetDateTimeFormat : public Screen {
       public:
         SettingSetDateTimeFormat(Pinetime::Controllers::DateTime& dateTimeController,
-                        Pinetime::Controllers::Settings& settingsController,
-                       Pinetime::Applications::Screens::SettingSetDateTime& settingSetDateTime);
+                                 Pinetime::Controllers::Settings& settingsController,
+                                 Pinetime::Applications::Screens::SettingSetDateTime& settingSetDateTime);
         ~SettingSetDateTimeFormat() override;
+
+        void HandleButtonPress(lv_obj_t* buttonPressed);
+        void SetSelectedColors();
 
       private:
         Controllers::DateTime& dateTimeController;
@@ -28,9 +31,6 @@ namespace Pinetime {
 
         lv_obj_t* btnDateDmy;
         lv_obj_t* btnDateMdy;
-
-        void HandleButtonPress(lv_obj_t* buttonPressed);
-        void SetSelectedColors();
       };
     }
   }

--- a/src/displayapp/screens/settings/SettingSetDateTimeFormat.h
+++ b/src/displayapp/screens/settings/SettingSetDateTimeFormat.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstdint>
+#include <lvgl/lvgl.h>
+#include "components/datetime/DateTimeController.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/widgets/Counter.h"
+#include "displayapp/widgets/DotIndicator.h"
+#include "displayapp/screens/settings/SettingSetDateTime.h"
+
+namespace Pinetime {
+  namespace Applications {
+    namespace Screens {
+      class SettingSetDateTimeFormat : public Screen {
+      public:
+        SettingSetDateTimeFormat(Pinetime::Controllers::DateTime& dateTimeController,
+                        Pinetime::Controllers::Settings& settingsController,
+                       Pinetime::Applications::Screens::SettingSetDateTime& settingSetDateTime);
+        ~SettingSetDateTimeFormat() override;
+
+      private:
+        Controllers::DateTime& dateTimeController;
+        Controllers::Settings& settingsController;
+        Pinetime::Applications::Screens::SettingSetDateTime& settingSetDateTime;
+
+        lv_obj_t* btnSetTime;
+        lv_obj_t* lblSetTime;
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingSetDateTimeFormat.h
+++ b/src/displayapp/screens/settings/SettingSetDateTimeFormat.h
@@ -23,8 +23,14 @@ namespace Pinetime {
         Controllers::Settings& settingsController;
         Pinetime::Applications::Screens::SettingSetDateTime& settingSetDateTime;
 
-        lv_obj_t* btnSetTime;
-        lv_obj_t* lblSetTime;
+        lv_obj_t* btnTime12hr;
+        lv_obj_t* btnTime24hr;
+
+        lv_obj_t* btnDateDmy;
+        lv_obj_t* btnDateMdy;
+
+        void HandleButtonPress(lv_obj_t* buttonPressed);
+        void SetSelectedColors();
       };
     }
   }

--- a/src/displayapp/screens/settings/Settings.h
+++ b/src/displayapp/screens/settings/Settings.h
@@ -36,12 +36,12 @@ namespace Pinetime {
           {Symbols::eye, "Wake Up", Apps::SettingWakeUp},
           {Symbols::home, "Watch face", Apps::SettingWatchFace},
           {Symbols::shoe, "Steps", Apps::SettingSteps},
-          
+
           {Symbols::clock, "Date&Time", Apps::SettingSetDateTime},
           {Symbols::batteryHalf, "Battery", Apps::BatteryInfo},
           {Symbols::clock, "Chimes", Apps::SettingChimes},
           {Symbols::tachometer, "Shake Calib.", Apps::SettingShakeThreshold},
-          
+
           {Symbols::check, "Firmware", Apps::FirmwareValidation},
           {Symbols::bluetooth, "Bluetooth", Apps::SettingBluetooth},
           {Symbols::list, "About", Apps::SysInfo},

--- a/src/displayapp/screens/settings/Settings.h
+++ b/src/displayapp/screens/settings/Settings.h
@@ -34,15 +34,14 @@ namespace Pinetime {
         static constexpr std::array<List::Applications, entriesPerScreen * nScreens> entries {{
           {Symbols::sun, "Display", Apps::SettingDisplay},
           {Symbols::eye, "Wake Up", Apps::SettingWakeUp},
-          {Symbols::clock, "Time format", Apps::SettingTimeFormat},
           {Symbols::home, "Watch face", Apps::SettingWatchFace},
-
           {Symbols::shoe, "Steps", Apps::SettingSteps},
+          
           {Symbols::clock, "Date&Time", Apps::SettingSetDateTime},
           {Symbols::batteryHalf, "Battery", Apps::BatteryInfo},
           {Symbols::clock, "Chimes", Apps::SettingChimes},
-
           {Symbols::tachometer, "Shake Calib.", Apps::SettingShakeThreshold},
+          
           {Symbols::check, "Firmware", Apps::FirmwareValidation},
           {Symbols::bluetooth, "Bluetooth", Apps::SettingBluetooth},
           {Symbols::list, "About", Apps::SysInfo},


### PR DESCRIPTION
This PR adds the baseline support for date formats. As part of it, I merged the time format screen into the Date & Time screen (see below).

This addresses #1166, #1590 

![image](https://user-images.githubusercontent.com/38388134/226074271-3a0c4707-ce4a-4360-88fe-a400f6680bfb.png)

This is more of a draft, there will definitely need to be some more changes system wide.

I **did not** implement it across the watchfaces. I'm more than willing to, but I wanted to hold off on that in case it should be a separate PR.

I increased the settings version number (from 4 to 5) as a precaution, since there is now a new setting. I do not know the implications of this, so it should be considered before (if, rather) this gets merged.

I don't feel that it is necessary to add Y/D/M or Y/M/D formats, as not all watchfaces show the year.

**Possible improvements**

- Show a preview of the time/date format in that screen (there's a bit of extra space at the bottom) *OR*
- Increase the size of the buttons to use all of the remaining vertical space

I'm still new to the codebase, so please let me know if I've committed some heinous crime in the commits.