### PR TITLE
Watchdog: Set wdt behaviour correctly

### DIFF
--- a/src/drivers/Watchdog.cpp
+++ b/src/drivers/Watchdog.cpp
@@ -1,13 +1,11 @@
 #include "drivers/Watchdog.h"
 #include <mdk/nrf.h>
+#include <nrf_wdt.h>
+
 using namespace Pinetime::Drivers;
 
 void Watchdog::Setup(uint8_t timeoutSeconds) {
-  NRF_WDT->CONFIG &= ~(WDT_CONFIG_SLEEP_Msk << WDT_CONFIG_SLEEP_Pos);
-  NRF_WDT->CONFIG |= (WDT_CONFIG_HALT_Run << WDT_CONFIG_SLEEP_Pos);
-
-  NRF_WDT->CONFIG &= ~(WDT_CONFIG_HALT_Msk << WDT_CONFIG_HALT_Pos);
-  NRF_WDT->CONFIG |= (WDT_CONFIG_HALT_Pause << WDT_CONFIG_HALT_Pos);
+  nrf_wdt_behaviour_set(NRF_WDT_BEHAVIOUR_RUN_SLEEP);
 
   /* timeout (s) = (CRV + 1) / 32768 */
   // JF : 7500 = 7.5s


### PR DESCRIPTION
The first removed line shifts a mask, but the mask itself is shifted, so
the shift is applied twice. The shift is zero, so effectively this sets
the first bit to zero.

The second line creates a mask with halt run parameter at sleep
position, which is clearly wrong. It sets the first bit to one, making
the first line redundant.

The third line shifts a mask again, like the first line. This sets the
seventh bit to one, which is undefined and probably (hopefully) does
nothing.

The fourth line does a logical or with HALT_Pause, but HALT_Pause is
zero, so it does nothing.

Effectively none of the lines are correct.

Use NRF hal to explicitly set the behaviour to what it is when the first
bit is set.