### PR TITLE
Notifications: std::optional id

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose Debug or Release")
 project(pinetime VERSION 1.11.0 LANGUAGES C CXX ASM)
 
 set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 # set(CMAKE_GENERATOR "Unix Makefiles")
 set(CMAKE_C_EXTENSIONS OFF)

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -4,6 +4,7 @@
 #include <FreeRTOS.h>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include "displayapp/screens/Screen.h"
 #include "components/ble/NotificationManager.h"
 #include "components/motor/MotorController.h"
@@ -76,8 +77,7 @@ namespace Pinetime {
         System::SystemTask& systemTask;
         Modes mode = Modes::Normal;
         std::unique_ptr<NotificationItem> currentItem;
-        Pinetime::Controllers::NotificationManager::Notification::Id currentId;
-        bool validDisplay = false;
+        std::optional<Pinetime::Controllers::NotificationManager::Notification::Id> currentId;
         bool afterDismissNextMessageFromAbove = false;
 
         lv_point_t timeoutLinePoints[2] {{0, 1}, {239, 1}};


### PR DESCRIPTION
validDisplay is used to express when the screen is displaying a real notification, instead of displaying that there are no notifications. When it is not displaying a notification, the currentId is always invalid. Use std::optional to replace validDisplay and express that currentId may be invalid.

Set CXX standard to 17 to support std::optional.