### PR TITLE
Heartrate measurements in background

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose Debug or Release")
 
-project(pinetime VERSION 1.11.0 LANGUAGES C CXX ASM)
+project(pinetime VERSION 1.11.1 LANGUAGES C CXX ASM)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 14)

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -135,7 +135,7 @@ int HeartRateTask::CurrentTaskDelay() {
       case States::Running:
         return 100;
       case States::BackgroundWaiting:
-        return 500;
+        return 10000;
       default:
         return portMAX_DELAY;
     }

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -24,62 +24,59 @@ void HeartRateTask::Process(void* instance) {
 }
 
 void HeartRateTask::Work() {
-  int lastBpm = 0;
-  while (true) {
-    auto delay = portMAX_DELAY;
-    if (state == States::Running) {
-      if (measurementStarted) {
-        delay = 40;
-      } else {
-        delay = 100;
-      }
-    } else {
-      delay = portMAX_DELAY;
-    }
+  lastBpm = 0;
 
+  while (true) {
+    auto delay = CurrentTaskDelay();
     Messages msg;
+
     if (xQueueReceive(messageQueue, &msg, delay) == pdTRUE) {
       switch (msg) {
         case Messages::GoToSleep:
-          StopMeasurement();
-          state = States::Idle;
+          if (state == States::Running) {
+            state = States::Idle;
+          } else if (state == States::Measuring) {
+            state = States::BackgroundWaiting;
+            backgroundMeasurementWaitingStart = xTaskGetTickCount();
+            StopMeasurement();
+          }
           break;
         case Messages::WakeUp:
-          state = States::Running;
-          if (measurementStarted) {
-            lastBpm = 0;
+          if (state == States::Idle) {
+            state = States::Running;
+          } else if (state == States::BackgroundMeasuring) {
+            state = States::Measuring;
+          } else if (state == States::BackgroundWaiting) {
+            state = States::Measuring;
             StartMeasurement();
           }
           break;
         case Messages::StartMeasurement:
-          if (measurementStarted) {
+          if (state == States::Measuring || state == States::BackgroundMeasuring) {
             break;
           }
+          state = States::Measuring;
           lastBpm = 0;
           StartMeasurement();
-          measurementStarted = true;
           break;
         case Messages::StopMeasurement:
-          if (!measurementStarted) {
+          if (state == States::Running || state == States::Idle) {
             break;
           }
+          if (state == States::Measuring) {
+            state = States::Running;
+          } else if (state == States::BackgroundMeasuring) {
+            state = States::Idle;
+          }
           StopMeasurement();
-          measurementStarted = false;
           break;
       }
     }
 
-    if (measurementStarted) {
-      ppg.Preprocess(static_cast<float>(heartRateSensor.ReadHrs()));
-      auto bpm = ppg.HeartRate();
-
-      if (lastBpm == 0 && bpm == 0) {
-        controller.Update(Controllers::HeartRateController::States::NotEnoughData, 0);
-      }
-      if (bpm != 0) {
-        lastBpm = bpm;
-        controller.Update(Controllers::HeartRateController::States::Running, lastBpm);
-      }
+    if (state == States::BackgroundWaiting) {
+      HandleBackgroundWaiting();
+    } else if (state == States::BackgroundMeasuring || state == States::Measuring) {
+      HandleSensorData();
     }
   }
 }
@@ -102,4 +99,44 @@ void HeartRateTask::StartMeasurement() {
 void HeartRateTask::StopMeasurement() {
   heartRateSensor.Disable();
   vTaskDelay(100);
+}
+
+void HeartRateTask::HandleBackgroundWaiting() {
+  if (xTaskGetTickCount() - backgroundMeasurementWaitingStart >= DURATION_BETWEEN_BACKGROUND_MEASUREMENTS) {
+    state = States::BackgroundMeasuring;
+    StartMeasurement();
+  }
+}
+
+void HeartRateTask::HandleSensorData() {
+  ppg.Preprocess(static_cast<float>(heartRateSensor.ReadHrs()));
+  auto bpm = ppg.HeartRate();
+
+  if (lastBpm == 0 && bpm == 0) {
+    controller.Update(Controllers::HeartRateController::States::NotEnoughData, 0);
+  }
+
+  if (bpm != 0) {
+    lastBpm = bpm;
+    controller.Update(Controllers::HeartRateController::States::Running, lastBpm);
+    if (state == States::BackgroundMeasuring) {
+      StopMeasurement();
+      state = States::BackgroundWaiting;
+      backgroundMeasurementWaitingStart = xTaskGetTickCount();
+    }
+  }
+}
+
+int HeartRateTask::CurrentTaskDelay() {
+    switch (state) {
+      case States::Measuring:
+      case States::BackgroundMeasuring:
+        return 50;
+      case States::Running:
+        return 100;
+      case States::BackgroundWaiting:
+        return 500;
+      default:
+        return portMAX_DELAY;
+    }
 }

--- a/src/heartratetask/HeartRateTask.h
+++ b/src/heartratetask/HeartRateTask.h
@@ -4,6 +4,8 @@
 #include <queue.h>
 #include <components/heartrate/Ppg.h>
 
+#define DURATION_BETWEEN_BACKGROUND_MEASUREMENTS 5 * 60 * 1000 // 5 Minutes assuming 1 Hz
+
 namespace Pinetime {
   namespace Drivers {
     class Hrs3300;
@@ -17,7 +19,7 @@ namespace Pinetime {
     class HeartRateTask {
     public:
       enum class Messages : uint8_t { GoToSleep, WakeUp, StartMeasurement, StopMeasurement };
-      enum class States { Idle, Running };
+      enum class States { Idle, Running, Measuring, BackgroundWaiting, BackgroundMeasuring };
 
       explicit HeartRateTask(Drivers::Hrs3300& heartRateSensor, Controllers::HeartRateController& controller);
       void Start();
@@ -29,13 +31,18 @@ namespace Pinetime {
       void StartMeasurement();
       void StopMeasurement();
 
+      void HandleBackgroundWaiting();
+      void HandleSensorData();
+      int CurrentTaskDelay();
+
       TaskHandle_t taskHandle;
       QueueHandle_t messageQueue;
       States state = States::Running;
       Drivers::Hrs3300& heartRateSensor;
       Controllers::HeartRateController& controller;
       Controllers::Ppg ppg;
-      bool measurementStarted = false;
+      int lastBpm = 0;
+      TickType_t backgroundMeasurementWaitingStart;
     };
 
   }


### PR DESCRIPTION
This implements heart rate measurements when the screen is turned off.
The ticket I found for this is: https://github.com/InfiniTimeOrg/InfiniTime/issues/183

When starting the heart rate measurements through the HeartRate screen and turning off the screen, the heart rate task doesn't stop but keeps running in the background until the heart rate measurement is stopped through the screen again.
The task wait delay is set to ~10 seconds (10k ticks) so the task doesn't run all the time and drains the battery too much.

Already tested it on my PineTime and works great.
Right now it was more a proof of concept, therefore the interval between background measurements is hard-coded to ~5 minutes. But I'd be happy to implement a settings screen to configure the interval or other features that are wanted.
