### PR TITLE
fonts: Make patching silent

### DIFF
--- a/src/displayapp/fonts/generate.py
+++ b/src/displayapp/fonts/generate.py
@@ -67,7 +67,7 @@ def main():
         subprocess.check_call(line)
         if patches:
             for patch in patches:
-                subprocess.check_call(['/usr/bin/env', 'patch', name+'.c', patch])
+                subprocess.check_call(['/usr/bin/env', 'patch', '--silent', name+'.c', patch])
 
 
 


### PR DESCRIPTION
The generate script should only output anything if there are errors.