### PR TITLE
Added CMake changes to allow for project building and debugging on MacOS ARM processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose Debug or Release")
 
+# Override the default system to cross-compile for ARM processors
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR ARM)
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
 project(pinetime VERSION 1.12.0 LANGUAGES C CXX ASM)
 
 set(CMAKE_C_STANDARD 99)
@@ -13,6 +19,10 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Generate source level debug information
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 
 set(NRF_TARGET "nrf52")
 


### PR DESCRIPTION
I recently bought an ARM-based Mac and wasn't able to build or debug the InfiniTime project.

These changes allow the project to be built and debugged on ARM-based processors. Most of these changes are actually already in the cmake-nRF5x toolchain but aren't set early enough to fix the issues. My guess is most contributors are using Intel-based processors so these issues aren't being caught.

For example, the line:
```
set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
```
is set below 
https://github.com/InfiniTimeOrg/InfiniTime/blob/main/cmake-nRF5x/arm-gcc-toolchain.cmake#L27-L32
but isn't added in the CMakeLists.txt until the end of the build process.
https://github.com/InfiniTimeOrg/InfiniTime/blob/main/CMakeLists.txt#L74

From my research these lines need to be added before the `project()` line:
https://github.com/InfiniTimeOrg/InfiniTime/blob/main/CMakeLists.txt#L5

I'm new to this so if there are any better ways or something I missed please let me know.

Sources:
https://github.com/microsoft/vscode-cmake-tools/issues/662
https://gitlab.kitware.com/cmake/cmake/-/issues/23105
https://stackoverflow.com/a/12794195