### PR TITLE
Allow mcuboot tool to use cbor2 additional to cbor

### DIFF
--- a/tools/mcuboot/imgtool/boot_record.py
+++ b/tools/mcuboot/imgtool/boot_record.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 from enum import Enum
-import cbor
+try:
+    import cbor2 as cbor
+except:
+    import cbor
 
 
 class SwComponent(int, Enum):


### PR DESCRIPTION
The mcuboot imgtool uses the python module `cbor`.

An equivalent and updated package `cbor2` requires Python 3.7 or newer.

The arch packages provide a package `python-cbor2`, but no package for `cbor`.

This patch makes it possible to use the system package by adding support for the `cbor2` package additionally to the `cbor` package.