### PR TITLE
Power optimization - enable the DC/DC regulator.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -293,7 +293,12 @@ void calibrate_lf_clock_rc(nrf_drv_clock_evt_type_t /*event*/) {
   nrf_drv_clock_calibration_start(16, calibrate_lf_clock_rc);
 }
 
+void enable_dcdc_regulator() {
+  NRF_POWER->DCDCEN = 1;
+}
+
 int main() {
+  enable_dcdc_regulator();
   logger.Init();
 
   nrf_drv_clock_init();


### PR DESCRIPTION
The DC/DC regulator reduce the power consumption of the MCU compared to the default LDO regulator. The DC/DC regulator needs additional HW that is mounted on the PineTime.

This change reduces the power usage by 380µA during fast advertising, by 200µA during slow advertising and by 186µA when BLE is disabled.