### PR TITLE
Power optimization - Increase SystemTaskPeriod.

### DIFF
--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -181,7 +181,7 @@ void SystemTask::Work() {
     UpdateMotion();
 
     Messages msg;
-    if (xQueueReceive(systemTasksMsgQueue, &msg, 100) == pdTRUE) {
+    if (xQueueReceive(systemTasksMsgQueue, &msg, 4000) == pdTRUE) {
       switch (msg) {
         case Messages::EnableSleeping:
           // Make sure that exiting an app doesn't enable sleeping,


### PR DESCRIPTION
Increase the timeout on the message queue in SystemTask. This reduces the power consumption by 60-70µs in sleep mode.