### PR TITLE
Power optimization - Improve SPI sleep mode

### DIFF
--- a/src/drivers/PinMap.h
+++ b/src/drivers/PinMap.h
@@ -34,6 +34,7 @@ namespace Pinetime {
     static constexpr uint8_t SpiFlashCsn = 5;
     static constexpr uint8_t SpiLcdCsn = 25;
     static constexpr uint8_t LcdDataCommand = 18;
+    static constexpr uint8_t LcdReset = 26;
 
     static constexpr uint8_t TwiScl = 7;
     static constexpr uint8_t TwiSda = 6;

--- a/src/drivers/Spi.cpp
+++ b/src/drivers/Spi.cpp
@@ -27,7 +27,8 @@ bool Spi::WriteCmdAndBuffer(const uint8_t* cmd, size_t cmdSize, const uint8_t* d
 }
 
 bool Spi::Init() {
-  nrf_gpio_pin_set(pinCsn); /* disable Set slave select (inactive high) */
+  nrf_gpio_cfg_output(pinCsn);
+  nrf_gpio_pin_set(pinCsn);
   return true;
 }
 

--- a/src/drivers/SpiMaster.cpp
+++ b/src/drivers/SpiMaster.cpp
@@ -204,6 +204,9 @@ bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size) {
       ;
     nrf_gpio_pin_set(this->pinCsn);
     currentBufferAddr = 0;
+
+    DisableWorkaroundForFtpan58(spiBaseAddress, 0, 0);
+
     xSemaphoreGive(mutex);
   }
 

--- a/src/drivers/SpiNorFlash.cpp
+++ b/src/drivers/SpiNorFlash.cpp
@@ -10,7 +10,6 @@ SpiNorFlash::SpiNorFlash(Spi& spi) : spi {spi} {
 }
 
 void SpiNorFlash::Init() {
-  spi.Init();
   device_id = ReadIdentificaion();
   NRF_LOG_INFO("[SpiNorFlash] Manufacturer : %d, Memory type : %d, memory density : %d",
                device_id.manufacturer,
@@ -24,12 +23,10 @@ void SpiNorFlash::Uninit() {
 void SpiNorFlash::Sleep() {
   auto cmd = static_cast<uint8_t>(Commands::DeepPowerDown);
   spi.Write(&cmd, sizeof(uint8_t));
-  spi.Sleep();
   NRF_LOG_INFO("[SpiNorFlash] Sleep")
 }
 
 void SpiNorFlash::Wakeup() {
-  spi.Wakeup();
   // send Commands::ReleaseFromDeepPowerDown then 3 dummy bytes before reading Device ID
   static constexpr uint8_t cmdSize = 4;
   uint8_t cmd[cmdSize] = {static_cast<uint8_t>(Commands::ReleaseFromDeepPowerDown), 0x01, 0x02, 0x03};

--- a/src/drivers/SpiNorFlash.cpp
+++ b/src/drivers/SpiNorFlash.cpp
@@ -10,6 +10,7 @@ SpiNorFlash::SpiNorFlash(Spi& spi) : spi {spi} {
 }
 
 void SpiNorFlash::Init() {
+  spi.Init();
   device_id = ReadIdentificaion();
   NRF_LOG_INFO("[SpiNorFlash] Manufacturer : %d, Memory type : %d, memory density : %d",
                device_id.manufacturer,
@@ -23,10 +24,12 @@ void SpiNorFlash::Uninit() {
 void SpiNorFlash::Sleep() {
   auto cmd = static_cast<uint8_t>(Commands::DeepPowerDown);
   spi.Write(&cmd, sizeof(uint8_t));
+  spi.Sleep();
   NRF_LOG_INFO("[SpiNorFlash] Sleep")
 }
 
 void SpiNorFlash::Wakeup() {
+  spi.Wakeup();
   // send Commands::ReleaseFromDeepPowerDown then 3 dummy bytes before reading Device ID
   static constexpr uint8_t cmdSize = 4;
   uint8_t cmd[cmdSize] = {static_cast<uint8_t>(Commands::ReleaseFromDeepPowerDown), 0x01, 0x02, 0x03};

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -6,7 +6,7 @@
 
 using namespace Pinetime::Drivers;
 
-St7789::St7789(Spi& spi, uint8_t pinDataCommand, uint8_t pinReset) : spi {spi}, pinDataCommand {pinDataCommand}, pinReset{pinReset} {
+St7789::St7789(Spi& spi, uint8_t pinDataCommand, uint8_t pinReset) : spi {spi}, pinDataCommand {pinDataCommand}, pinReset {pinReset} {
 }
 
 void St7789::Init() {

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -6,13 +6,13 @@
 
 using namespace Pinetime::Drivers;
 
-St7789::St7789(Spi& spi, uint8_t pinDataCommand) : spi {spi}, pinDataCommand {pinDataCommand} {
+St7789::St7789(Spi& spi, uint8_t pinDataCommand, uint8_t pinReset) : spi {spi}, pinDataCommand {pinDataCommand}, pinReset{pinReset} {
 }
 
 void St7789::Init() {
   nrf_gpio_cfg_output(pinDataCommand);
-  nrf_gpio_cfg_output(26);
-  nrf_gpio_pin_set(26);
+  nrf_gpio_cfg_output(pinReset);
+  nrf_gpio_pin_set(pinReset);
   HardwareReset();
   SoftwareReset();
   SleepOut();
@@ -178,15 +178,15 @@ void St7789::DrawBuffer(uint16_t x, uint16_t y, uint16_t width, uint16_t height,
 }
 
 void St7789::HardwareReset() {
-  nrf_gpio_pin_clear(26);
+  nrf_gpio_pin_clear(pinReset);
   nrf_delay_ms(10);
-  nrf_gpio_pin_set(26);
+  nrf_gpio_pin_set(pinReset);
 }
 
 void St7789::Sleep() {
   SleepIn();
   nrf_gpio_cfg_default(pinDataCommand);
-  nrf_gpio_cfg_default(26);
+  nrf_gpio_cfg_default(pinReset);
   NRF_LOG_INFO("[LCD] Sleep");
 }
 

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -187,10 +187,13 @@ void St7789::HardwareReset() {
 void St7789::Sleep() {
   SleepIn();
   nrf_gpio_cfg_default(pinDataCommand);
+  nrf_gpio_cfg_default(26);
+  spi.Sleep();
   NRF_LOG_INFO("[LCD] Sleep");
 }
 
 void St7789::Wakeup() {
+  spi.Wakeup();
   nrf_gpio_cfg_output(pinDataCommand);
   SleepOut();
   VerticalScrollStartAddress(verticalScrollingStartAddress);

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -10,7 +10,6 @@ St7789::St7789(Spi& spi, uint8_t pinDataCommand) : spi {spi}, pinDataCommand {pi
 }
 
 void St7789::Init() {
-  spi.Init();
   nrf_gpio_cfg_output(pinDataCommand);
   nrf_gpio_cfg_output(26);
   nrf_gpio_pin_set(26);
@@ -188,12 +187,10 @@ void St7789::Sleep() {
   SleepIn();
   nrf_gpio_cfg_default(pinDataCommand);
   nrf_gpio_cfg_default(26);
-  spi.Sleep();
   NRF_LOG_INFO("[LCD] Sleep");
 }
 
 void St7789::Wakeup() {
-  spi.Wakeup();
   nrf_gpio_cfg_output(pinDataCommand);
   SleepOut();
   VerticalScrollStartAddress(verticalScrollingStartAddress);

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -186,7 +186,6 @@ void St7789::HardwareReset() {
 void St7789::Sleep() {
   SleepIn();
   nrf_gpio_cfg_default(pinDataCommand);
-  nrf_gpio_cfg_default(pinReset);
   NRF_LOG_INFO("[LCD] Sleep");
 }
 

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -8,7 +8,7 @@ namespace Pinetime {
 
     class St7789 {
     public:
-      explicit St7789(Spi& spi, uint8_t pinDataCommand);
+      explicit St7789(Spi& spi, uint8_t pinDataCommand, uint8_t pinReset);
       St7789(const St7789&) = delete;
       St7789& operator=(const St7789&) = delete;
       St7789(St7789&&) = delete;
@@ -29,6 +29,7 @@ namespace Pinetime {
     private:
       Spi& spi;
       uint8_t pinDataCommand;
+      uint8_t pinReset;
       uint8_t verticalScrollingStartAddress = 0;
 
       void HardwareReset();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,7 @@ Pinetime::Drivers::SpiMaster spi {Pinetime::Drivers::SpiMaster::SpiModule::SPI0,
                                    Pinetime::PinMap::SpiMiso}};
 
 Pinetime::Drivers::Spi lcdSpi {spi, Pinetime::PinMap::SpiLcdCsn};
-Pinetime::Drivers::St7789 lcd {lcdSpi, Pinetime::PinMap::LcdDataCommand};
+Pinetime::Drivers::St7789 lcd {lcdSpi, Pinetime::PinMap::LcdDataCommand, Pinetime::PinMap::LcdReset};
 
 Pinetime::Drivers::Spi flashSpi {spi, Pinetime::PinMap::SpiFlashCsn};
 Pinetime::Drivers::SpiNorFlash spiNorFlash {flashSpi};

--- a/src/recoveryLoader.cpp
+++ b/src/recoveryLoader.cpp
@@ -46,7 +46,7 @@ Pinetime::Drivers::Spi flashSpi {spi, Pinetime::PinMap::SpiFlashCsn};
 Pinetime::Drivers::SpiNorFlash spiNorFlash {flashSpi};
 
 Pinetime::Drivers::Spi lcdSpi {spi, Pinetime::PinMap::SpiLcdCsn};
-Pinetime::Drivers::St7789 lcd {lcdSpi, Pinetime::PinMap::LcdDataCommand};
+Pinetime::Drivers::St7789 lcd {lcdSpi, Pinetime::PinMap::LcdDataCommand, Pinetime::PinMap::LcdReset};
 
 Pinetime::Components::Gfx gfx {lcd};
 Pinetime::Controllers::BrightnessController brightnessController;


### PR DESCRIPTION
Ensure that all pins are set to their default configuration during sleep mode. Disable the workaround for FTPAN58 (SPI freezes when transfering a single byte) at the end of the transfer. This disables the resources needed for the workaround. Those changes reduce the power usage by 430-490µA.