### PR TITLE
Alarm: enlarge info button

### DIFF
--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -94,7 +94,7 @@ Alarm::Alarm(Controllers::AlarmController& alarmController,
   btnInfo = lv_btn_create(lv_scr_act(), nullptr);
   btnInfo->user_data = this;
   lv_obj_set_event_cb(btnInfo, btnEventHandler);
-  lv_obj_set_size(btnInfo, 50, 50);
+  lv_obj_set_size(btnInfo, 60, 60);
   lv_obj_align(btnInfo, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, -4);
   lv_obj_set_style_local_bg_color(btnInfo, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, bgColor);
   lv_obj_set_style_local_border_width(btnInfo, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, 4);


### PR DESCRIPTION
I have difficulties tapping the info button due to my fat finger.
I always tap the info button right after setting the alarm clock (if in fire once mode) to make sure I have set it right, but often end up touching the area just outside of the button because the button is so small, and result in a change of time which also toggles off the alarm clock.
Then, I have to correct the time again and toggle the alarm on, before I can have another go at the info button.
I believe a slightly larger button is better.

![InfiniSim_2023-06-11_210955](https://github.com/InfiniTimeOrg/InfiniTime/assets/8587031/a053efc8-45ea-4964-9e61-05678cee14b5)
![InfiniSim_2023-06-11_210744](https://github.com/InfiniTimeOrg/InfiniTime/assets/8587031/0bf4c975-d9a6-4155-a282-133474e93c4e)
