### PR TITLE
Reorder notification struct fields

### DIFF
--- a/src/components/ble/NotificationManager.h
+++ b/src/components/ble/NotificationManager.h
@@ -27,11 +27,12 @@ namespace Pinetime {
       struct Notification {
         using Id = uint8_t;
         using Idx = uint8_t;
+
+        std::array<char, MessageSize + 1> message;
+        uint8_t size;
+        Categories category = Categories::Unknown;
         Id id = 0;
         bool valid = false;
-        uint8_t size;
-        std::array<char, MessageSize + 1> message;
-        Categories category = Categories::Unknown;
 
         const char* Message() const;
         const char* Title() const;


### PR DESCRIPTION
This pull request is extracted from #1482 and changes the order for the notification struct fields to allow the creation of notifications using a string literal like this:
```cpp
NotificationManager::Notifiation notification {
  "String literal with notification text",
  42,
  NotificationManager::Categories::SimpleAlert
};
```