### PR TITLE
Draft [Help wanted]: Unified app interface

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -595,6 +595,7 @@ set(INCLUDE_FILES
         displayapp/Messages.h
         displayapp/TouchEvents.h
         displayapp/screens/Screen.h
+        displayapp/screens/App.h
         displayapp/screens/Clock.h
         displayapp/screens/Tile.h
         displayapp/screens/InfiniPaint.h

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -30,6 +30,7 @@
 #include "displayapp/screens/PassKey.h"
 #include "displayapp/screens/Error.h"
 #include "displayapp/screens/Weather.h"
+#include "displayapp/screens/App.h"
 
 #include "drivers/Cst816s.h"
 #include "drivers/St7789.h"
@@ -520,7 +521,21 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
       currentScreen = std::make_unique<Screens::StopWatch>(*systemTask);
       break;
     case Apps::Twos:
-      currentScreen = std::make_unique<Screens::Twos>();
+      // currentScreen = std::make_unique<Screens::Twos>();
+      {
+        Pinetime::Applications::AppInterface appInterface = {
+          &lvgl,
+          motorController,
+          settingsController,
+          alarmController,
+          timer,
+          heartRateController,
+          systemTask,
+          systemTask->nimble().music(),
+          systemTask->nimble().navigation()
+        };
+        currentScreen = Screens::Twos::Get(appInterface);
+      }
       break;
     case Apps::Paint:
       currentScreen = std::make_unique<Screens::InfiniPaint>(lvgl, motorController);

--- a/src/displayapp/screens/App.h
+++ b/src/displayapp/screens/App.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <lvgl/lvgl.h>
+#include <memory>
+
+namespace Pinetime {
+  namespace Applications {
+    struct AppInterface {
+      Pinetime::Components::LittleVgl* lvgl;
+      Pinetime::Controllers::MotorController& motorController;
+      Pinetime::Controllers::Settings& settingsController;
+      Pinetime::Controllers::AlarmController& alarmController;
+      Pinetime::Controllers::Timer timer;
+      Pinetime::Controllers::HeartRateController& heartRateController;
+      Pinetime::System::SystemTask* systemTask;
+      Pinetime::Controllers::MusicService& musicService;
+      Pinetime::Controllers::NavigationService& navigationService;
+      // Pinetime::Controllers::WeatherService& weatherService;
+    };
+
+    namespace Screens {
+      class App : Screen {
+        static std::unique_ptr<Screens::Screen> Get(AppInterface appInterface);
+
+        // returns the symbol for the app menu
+        static constexpr char* GetSymbol() {
+          return "?";
+        };
+        
+        // TODO something like
+        // static virtual bool NeedsMotorController() { return true; };
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -10,6 +10,7 @@
 #include "components/battery/BatteryController.h"
 #include "displayapp/screens/Symbols.h"
 #include "displayapp/screens/Tile.h"
+#include "displayapp/screens/Twos.h"
 
 namespace Pinetime {
   namespace Applications {
@@ -49,7 +50,7 @@ namespace Pinetime {
 
           {Symbols::paintbrush, Apps::Paint},
           {Symbols::paddle, Apps::Paddle},
-          {"2", Apps::Twos},
+          {Twos::GetSymbol(), Apps::Twos},
           {Symbols::drum, Apps::Metronome},
           {Symbols::map, Apps::Navigation},
           {Symbols::none, Apps::None},

--- a/src/displayapp/screens/Twos.h
+++ b/src/displayapp/screens/Twos.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <lvgl/src/lv_core/lv_obj.h>
-#include "displayapp/screens/Screen.h"
+#include <memory>
+#include "displayapp/screens/App.h"
 
 namespace Pinetime {
   namespace Applications {
@@ -11,12 +12,20 @@ namespace Pinetime {
     };
 
     namespace Screens {
-      class Twos : public Screen {
+      class Twos : public App {
       public:
         Twos();
         ~Twos() override;
 
         bool OnTouchEvent(TouchEvents event) override;
+
+        static std::unique_ptr<Pinetime::Applications::Screens::Screen> Get(AppInterface appInterface) {
+          return std::make_unique<Twos>();
+        };
+
+        static constexpr char* GetSymbol() {
+          return "2";
+        };
 
       private:
         static constexpr int nColors = 5;


### PR DESCRIPTION
This is an experiment based on #1571. It is about reducing all the different places in the code where apps are declared.

I am not experienced with this, so any input would be really helpful. Maybe we can figure something out together. Take this PR as a basis for discussion. I would like to learn from this. And hopefully we can find a good solution on how to handle apps :relieved:  

The idea is to implement an `App` class that gets inherited by all `Screen`s we consider to be apps. This means all the screens that could one day be loaded dynamically (watch faces maybe their own thing...).
For example `QuickSettings` is not an `App`, but `Twos` is.

There are some issues to be resolved with the current state:
1. The apps are explicitly instanciated in the `DisplayApp.cpp` and with custom arguments. This PR tries to implement an `AppInterface` that provides the same way of creation for all apps. Right now, this is done via a `Get` method that is known to be present with all apps. We can further on reduce the capabilities that we give each app, but I would like to focus on getting this to run the easy way first.
2. The `ApplicationList` explicitly lists all the apps and their symbols. This PR implements a `GetSymbol` method for the `App` class. This moves the declaration of the symbol inside the app.
3. All apps are handled individually. This is not fixed right now, but I would like to have an `AppController` in the later progress that can handle the `App` objects. The interface of the `App` class must be enough to do all the things the controller has to do.

I would really like your ideas and feedback! :)