### PR TITLE
weather: Add functions for temperature in Fahrenheit

### DIFF
--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -606,6 +606,13 @@ namespace Pinetime {
       return result;
     }
 
+    int16_t WeatherService::GetTempFahrenheit(int16_t temp) const {
+      if (temp == -32768) {
+        return -32768;
+      }
+      return temp * 9 / 5 + 3200;
+    }
+
     void WeatherService::CleanUpQcbor(QCBORDecodeContext* decodeContext) {
       QCBORDecode_ExitMap(decodeContext);
       QCBORDecode_Finish(decodeContext);

--- a/src/components/ble/weather/WeatherService.h
+++ b/src/components/ble/weather/WeatherService.h
@@ -70,6 +70,12 @@ namespace Pinetime {
        */
       int16_t GetTodayMinTemp() const;
 
+      /**
+       * Converts the temperature in degrees Celsius to degrees Fahrenheit
+       * @return -32768 if there's no data, degrees Fahrenheit times 100 otherwise
+       */
+      int16_t GetTempFahrenheit(int16_t temp) const;
+
       /*
        * Management functions
        */


### PR DESCRIPTION
This adds some functions to the `WeatherService` class for getting the temperature in Fahrenheit. This could theoretically overflow, but only if the temperature is 164.27 °C or higher (or -164.28 °C or lower), which I believe is unlikely enough that we don't need to worry about it. Please tell me if you think that is an issue.

This doesn't add a setting to display the temperature in Fahrenheit in PTS.

Related to #1783.