### PR TITLE
Added weather, current track info, ability to select temperature units, settings menu, and better notification indicator to WatchFaceCasioStyleG7710

### DIFF
--- a/src/components/ble/MusicService.h
+++ b/src/components/ble/MusicService.h
@@ -70,9 +70,9 @@ namespace Pinetime {
 
       uint16_t eventHandle {};
 
-      std::string artistName {"Waiting for"};
-      std::string albumName {};
-      std::string trackName {"track information.."};
+      std::string artistName {"No Artist"};
+      std::string albumName {"No Album"};
+      std::string trackName {"No Track"};
 
       bool playing {false};
 

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -41,6 +41,14 @@ namespace Pinetime {
       enum class PTSGaugeStyle : uint8_t { Full, Half, Numeric };
       enum class PTSWeather : uint8_t { On, Off };
 
+      enum class CSGWeatherStyle : uint8_t { Off, On };
+      enum class CSGMediaStyle : uint8_t { Off, Artist, Track, Album };
+
+      struct CasioStyleG7710 {
+        CSGWeatherStyle weatherStyle = CSGWeatherStyle::Off;
+        CSGMediaStyle mediaStyle = CSGMediaStyle::Off;
+      };
+
       struct PineTimeStyle {
         Colors ColorTime = Colors::Teal;
         Colors ColorBar = Colors::Teal;
@@ -156,6 +164,26 @@ namespace Pinetime {
 
       PTSWeather GetPTSWeather() const {
         return settings.PTS.weatherEnable;
+      };
+
+      void SetCSGWeatherStyle(CSGWeatherStyle weatherStyle) {
+        if (weatherStyle != settings.CSG.weatherStyle)
+          settingsChanged = true;
+        settings.CSG.weatherStyle = weatherStyle;
+      };
+
+      CSGWeatherStyle GetCSGWeatherStyle() const {
+        return settings.CSG.weatherStyle;
+      };
+
+      void SetCSGMediaStyle(CSGMediaStyle mediaStyle) {
+        if (mediaStyle != settings.CSG.mediaStyle)
+          settingsChanged = true;
+        settings.CSG.mediaStyle = mediaStyle;
+      };
+
+      CSGMediaStyle GetCSGMediaStyle() const {
+        return settings.CSG.mediaStyle;
       };
 
       void SetAppMenu(uint8_t menu) {
@@ -293,6 +321,8 @@ namespace Pinetime {
         ChimesOption chimesOption = ChimesOption::None;
 
         PineTimeStyle PTS;
+
+        CasioStyleG7710 CSG;
 
         WatchFaceInfineat watchFaceInfineat;
 

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -203,7 +203,7 @@ namespace Pinetime {
         return settingsMenu;
       };
 
-      void SetTempUnits(TempUnits tempunits){
+      void SetTempUnits(TempUnits tempunits) {
         if (tempunits != settings.tempUnits) {
           settingsChanged = true;
         }

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -10,6 +10,7 @@ namespace Pinetime {
     class Settings {
     public:
       enum class ClockType : uint8_t { H24, H12 };
+      enum class TempUnits : uint8_t { Celcius, Fahrenheit };
       enum class Notification : uint8_t { On, Off, Sleep };
       enum class ChimesOption : uint8_t { None, Hours, HalfHours };
       enum class WakeUpMode : uint8_t {
@@ -202,6 +203,17 @@ namespace Pinetime {
         return settingsMenu;
       };
 
+      void SetTempUnits(TempUnits tempunits){
+        if (tempunits != settings.tempUnits) {
+          settingsChanged = true;
+        }
+        settings.tempUnits = tempunits;
+      };
+
+      TempUnits GetTempUnits() const {
+        return settings.tempUnits;
+      };
+
       void SetClockType(ClockType clocktype) {
         if (clocktype != settings.clockType) {
           settingsChanged = true;
@@ -316,6 +328,8 @@ namespace Pinetime {
 
         ClockType clockType = ClockType::H24;
         Notification notificationStatus = Notification::On;
+
+        TempUnits tempUnits = TempUnits::Celcius;
 
         Pinetime::Applications::WatchFace watchFace = Pinetime::Applications::WatchFace::Digital;
         ChimesOption chimesOption = ChimesOption::None;

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -419,6 +419,7 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
                                                        heartRateController,
                                                        motionController,
                                                        systemTask->nimble().weather(),
+                                                       systemTask->nimble().music(),
                                                        filesystem);
       break;
 

--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -25,6 +25,7 @@ Clock::Clock(Controllers::DateTime& dateTimeController,
              Controllers::HeartRateController& heartRateController,
              Controllers::MotionController& motionController,
              Controllers::WeatherService& weatherService,
+             Controllers::MusicService& musicService,
              Controllers::FS& filesystem)
   : dateTimeController {dateTimeController},
     batteryController {batteryController},
@@ -34,6 +35,7 @@ Clock::Clock(Controllers::DateTime& dateTimeController,
     heartRateController {heartRateController},
     motionController {motionController},
     weatherService {weatherService},
+    musicService {musicService},
     filesystem {filesystem},
     screen {[this, &settingsController]() {
       switch (settingsController.GetWatchFace()) {
@@ -129,5 +131,7 @@ std::unique_ptr<Screen> Clock::WatchFaceCasioStyleG7710() {
                                                              settingsController,
                                                              heartRateController,
                                                              motionController,
+                                                             weatherService,
+                                                             musicService,
                                                              filesystem);
 }

--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -8,6 +8,7 @@
 #include "displayapp/screens/Screen.h"
 #include "components/datetime/DateTimeController.h"
 #include "components/ble/weather/WeatherService.h"
+#include "components/ble/MusicService.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -30,6 +31,7 @@ namespace Pinetime {
               Controllers::HeartRateController& heartRateController,
               Controllers::MotionController& motionController,
               Controllers::WeatherService& weatherService,
+              Controllers::MusicService& musicService,
               Controllers::FS& filesystem);
         ~Clock() override;
 
@@ -45,6 +47,7 @@ namespace Pinetime {
         Controllers::HeartRateController& heartRateController;
         Controllers::MotionController& motionController;
         Controllers::WeatherService& weatherService;
+        Controllers::MusicService& musicService;
         Controllers::FS& filesystem;
 
         std::unique_ptr<Screen> screen;

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -225,7 +225,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_obj_set_style_local_text_color(txtMedia, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_obj_set_width(txtMedia, 80);
   lv_label_set_text_static(txtMedia, "No media playing");
-  lv_obj_set_hidden(txtMedia, true);
+  lv_obj_set_hidden(txtMedia, false);
   track = "";
 
   btnMedia = lv_btn_create(lv_scr_act(), nullptr);
@@ -239,6 +239,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   switch (settingsController.GetCSGMediaStyle()) {
     case Pinetime::Controllers::Settings::CSGMediaStyle::Off:
       lv_label_set_text_static(lblMedia, "Media: Off");
+      lv_obj_set_hidden(txtMedia, true);
       break;
     case Pinetime::Controllers::Settings::CSGMediaStyle::Artist:
       lv_label_set_text_static(lblMedia, "Media: Artist");
@@ -533,24 +534,24 @@ void WatchFaceCasioStyleG7710::UpdateSelected(lv_obj_t* object, lv_event_t event
     if (object == btnMedia) {
       switch (settingsController.GetCSGMediaStyle()) {
         case Pinetime::Controllers::Settings::CSGMediaStyle::Off:
-          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Artist);
           lv_label_set_text_static(lblMedia, "Media: Artist");
           lv_obj_set_hidden(txtMedia, false);
+          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Artist);
           break;
         case Pinetime::Controllers::Settings::CSGMediaStyle::Artist:
-          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Track);
           lv_label_set_text_static(lblMedia, "Media: Track");
           lv_obj_set_hidden(txtMedia, false);
+          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Track);
           break;
         case Pinetime::Controllers::Settings::CSGMediaStyle::Track:
-          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Album);
           lv_label_set_text_static(lblMedia, "Media: Album");
           lv_obj_set_hidden(txtMedia, false);
+          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Album);
           break;
         case Pinetime::Controllers::Settings::CSGMediaStyle::Album:
-          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Off);
           lv_label_set_text_static(lblMedia, "Media: Off");
           lv_obj_set_hidden(txtMedia, true);
+          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Off);
           break;
       }
       track = "";

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -231,7 +231,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_obj_set_size(btnMedia, 160, 60);
   lv_obj_align(btnMedia, lv_scr_act(), LV_ALIGN_CENTER, 0, -80);
   lv_obj_set_style_local_bg_opa(btnMedia, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_80);
-  lv_obj_t* lblMedia= lv_label_create(btnMedia, nullptr);
+  lblMedia = lv_label_create(btnMedia, nullptr);
   lv_label_set_text_static(lblMedia, "Media");
   lv_obj_set_event_cb(btnMedia, event_handler);
   lv_obj_set_hidden(btnMedia, true);
@@ -241,7 +241,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_obj_set_size(btnWeather, 160, 60);
   lv_obj_align(btnWeather, lv_scr_act(), LV_ALIGN_CENTER, 0, -10);
   lv_obj_set_style_local_bg_opa(btnWeather, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_80);
-  lv_obj_t* lblWeather = lv_label_create(btnWeather, nullptr);
+  lblWeather = lv_label_create(btnWeather, nullptr);
   lv_label_set_text_static(lblWeather, "Weather");
   lv_obj_set_event_cb(btnWeather, event_handler);
   lv_obj_set_hidden(btnWeather, true);
@@ -251,10 +251,14 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_obj_set_size(btnTempUnits, 160, 60);
   lv_obj_align(btnTempUnits, lv_scr_act(), LV_ALIGN_CENTER, 0, 60);
   lv_obj_set_style_local_bg_opa(btnTempUnits, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_80);
-  lv_obj_t* lblTempUnits = lv_label_create(btnTempUnits, nullptr);
-  lv_label_set_text_static(lblTempUnits, "Units");
+  lblTempUnits = lv_label_create(btnTempUnits, nullptr);
   lv_obj_set_event_cb(btnTempUnits, event_handler);
   lv_obj_set_hidden(btnTempUnits, true);
+  if (settingsController.GetTempUnits() == Controllers::Settings::TempUnits::Celcius) {
+    lv_label_set_text_static(lblTempUnits, "Units: °C");
+  } else {
+    lv_label_set_text_static(lblTempUnits, "Units: °F");
+  }
 
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
   Refresh();
@@ -491,8 +495,10 @@ void WatchFaceCasioStyleG7710::UpdateSelected(lv_obj_t* object, lv_event_t event
     } else if (object == btnTempUnits) {  //if units button, switch units
       if (settingsController.GetTempUnits() == Controllers::Settings::TempUnits::Celcius) {
         settingsController.SetTempUnits(Controllers::Settings::TempUnits::Fahrenheit);
+        lv_label_set_text_static(lblTempUnits, "Units: °F");
       } else {
         settingsController.SetTempUnits(Controllers::Settings::TempUnits::Celcius);
+        lv_label_set_text_static(lblTempUnits, "Units: °C");
       }
     } else if (object == btnWeather) {  //if weather button pressed
       if (lv_obj_get_hidden(weatherIcon)) { //if weather hidden

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -242,9 +242,13 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_obj_align(btnWeather, lv_scr_act(), LV_ALIGN_CENTER, 0, -10);
   lv_obj_set_style_local_bg_opa(btnWeather, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_80);
   lblWeather = lv_label_create(btnWeather, nullptr);
-  lv_label_set_text_static(lblWeather, "Weather");
   lv_obj_set_event_cb(btnWeather, event_handler);
   lv_obj_set_hidden(btnWeather, true);
+  if (settingsController.GetCSGWeatherStyle() == Pinetime::Controllers::Settings::CSGWeatherStyle::Off) {
+    lv_label_set_text_static(lblWeather, "Weather: Off");
+  } else {
+    lv_label_set_text_static(lblWeather, "Weather: On");
+  }
 
   btnTempUnits = lv_btn_create(lv_scr_act(), nullptr);
   btnTempUnits->user_data = this;
@@ -509,16 +513,18 @@ void WatchFaceCasioStyleG7710::UpdateSelected(lv_obj_t* object, lv_event_t event
         if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24){
           lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 118, 70);  //nudge date
         }
+        lv_label_set_text_static(lblWeather, "Weather: On");   //update button text
         //save to settings
         settingsController.SetCSGWeatherStyle(Controllers::Settings::CSGWeatherStyle::On);
       } else {
         // hide weather icon and temperature
         lv_obj_set_hidden(weatherIcon, true);
         lv_obj_set_hidden(temperature, true);
-        //if 24HR, un-nudge date
         if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24){
+        //if 24HR, un-nudge date
           lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 100, 70);  //un-nudge date
         }
+        lv_label_set_text_static(lblWeather, "Weather: Off");   //update button text
         //save to settings
         settingsController.SetCSGWeatherStyle(Controllers::Settings::CSGWeatherStyle::Off);
       }

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -32,7 +32,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
     dateTimeController {dateTimeController},
     batteryController {batteryController},
     bleController {bleController},
-    notificationManager {notificatioManager},
+    notificationManager {notificationManager},
     settingsController {settingsController},
     heartRateController {heartRateController},
     motionController {motionController},
@@ -90,7 +90,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   notificationIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(false));
-  lv_obj_align(notificationIcon, bleIcon, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+  lv_obj_align(notificationIcon, bleIcon, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
   label_day_of_week = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_align(label_day_of_week, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 10, 64);
@@ -276,7 +276,7 @@ void WatchFaceCasioStyleG7710::Refresh() {
   lv_obj_realign(notificationIcon);
 
   //old notification icon, simply shows if there are unread notifications
-/*  notificationState = notificatioManager.AreNewNotificationsAvailable();
+/*  notificationState = notificationManager.AreNewNotificationsAvailable();
   if (notificationState.IsUpdated()) {
     lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
   }*/

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -72,7 +72,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   bleIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(bleIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_label_set_text_static(bleIcon, Symbols::bluetooth);
-  lv_obj_align(bleIcon, batteryPlug, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+  lv_obj_align(bleIcon, batteryPlug, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
    weatherIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(weatherIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
@@ -90,7 +90,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   notificationIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(false));
-  lv_obj_align(notificationIcon, bleIcon, LV_ALIGN_OUT_LEFT_MID, -10, 0);
+  lv_obj_align(notificationIcon, bleIcon, LV_ALIGN_OUT_LEFT_MID, -14, 0);
 
   label_day_of_week = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_align(label_day_of_week, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 10, 64);

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -87,7 +87,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_label_set_text(weatherIcon, Symbols::cloudSunRain);
   //Change weather location based on time format, as there is only room to put it on the side in 12HR
   if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
-    lv_obj_align(weatherIcon, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 107, 72); //upper
+    lv_obj_align(weatherIcon, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 112, 72); //upper
   } else {
     lv_obj_align(weatherIcon, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 25); //lower
   }
@@ -102,11 +102,11 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_obj_set_style_local_text_color(temperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   //Change temperature location based on time format, as there is only room to put it on the side in 12HR
   if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
-    lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_CENTER, 5, -2);   //above colon
+    lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_CENTER, 10, -2);   //above colon
+    //lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 20);   //tucked into the 2
   } else {
     lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 50); //lower
   }
-  //lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 20);   //tucked in the 2
   if (settingsController.GetCSGWeatherStyle() == Pinetime::Controllers::Settings::CSGWeatherStyle::Off) {
     lv_obj_set_hidden(temperature, true);
   } else {
@@ -165,9 +165,8 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_obj_set_style_local_text_color(label_date, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_obj_set_style_local_text_font(label_date, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, font_segment40);
   lv_label_set_text_static(label_date, "6-30");
-  //nudge date over to make room for weather in 24HR mode
-  //TODO move this to Refresh() and only nudge if weather is enabled
-  if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
+  //nudge date over to make room for weather when in 24HR mode with weather enabled
+  if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24 && settingsController.GetCSGWeatherStyle() == Pinetime::Controllers::Settings::CSGWeatherStyle::On) {
     lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 118, 70);  //nudge
   } else {
     lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 100, 70);  //un-nudge
@@ -181,12 +180,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   label_time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(label_time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_obj_set_style_local_text_font(label_time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, font_segment115);
-  //nudge time over a bit to align temperature in 24HR mode
-  if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
-    lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_CENTER, -4, 40);  //nudge
-  } else {
-    lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_CENTER, 0, 40);  //un-nudge
-  }
+  lv_obj_align(label_time, lv_scr_act(), LV_ALIGN_CENTER, 0, 40);
 
   line_time = lv_line_create(lv_scr_act(), nullptr);
   lv_line_set_points(line_time, line_time_points, 3);
@@ -337,8 +331,8 @@ void WatchFaceCasioStyleG7710::Refresh() {
       lv_obj_realign(weatherIcon);
     }
   } else {
-    lv_label_set_text_static(temperature, "76°");
-    lv_label_set_text(weatherIcon, Symbols::sun);
+    lv_label_set_text_static(temperature, "--°");
+    lv_label_set_text(weatherIcon, Symbols::ban);
     lv_obj_realign(temperature);
     lv_obj_realign(weatherIcon);
   }
@@ -482,12 +476,20 @@ void WatchFaceCasioStyleG7710::UpdateSelected(lv_obj_t* object, lv_event_t event
         // show weather icon and temperature
         lv_obj_set_hidden(weatherIcon, false);
         lv_obj_set_hidden(temperature, false);
+        //if 24HR, nudge date over to make room
+        if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24){
+          lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 118, 70);  //nudge date
+        }
         //save to settings
         settingsController.SetCSGWeatherStyle(Controllers::Settings::CSGWeatherStyle::On);
       } else {
         // hide weather icon and temperature
         lv_obj_set_hidden(weatherIcon, true);
         lv_obj_set_hidden(temperature, true);
+        //if 24HR, un-nudge date
+        if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24){
+          lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 100, 70);  //un-nudge date
+        }
         //save to settings
         settingsController.SetCSGWeatherStyle(Controllers::Settings::CSGWeatherStyle::Off);
       }

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -12,25 +12,34 @@
 #include "components/heartrate/HeartRateController.h"
 #include "components/motion/MotionController.h"
 #include "components/settings/Settings.h"
+#include "components/ble/weather/WeatherService.h"
+#include "components/ble/MusicService.h"
+
 using namespace Pinetime::Applications::Screens;
 
 WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTimeController,
                                                    const Controllers::Battery& batteryController,
                                                    const Controllers::Ble& bleController,
-                                                   Controllers::NotificationManager& notificatioManager,
+                                                   Controllers::NotificationManager& notificationManager,
                                                    Controllers::Settings& settingsController,
                                                    Controllers::HeartRateController& heartRateController,
                                                    Controllers::MotionController& motionController,
-                                                   Controllers::FS& filesystem)
+                                                   Controllers::FS& filesystem,
+                                                   Controllers::WeatherService& weatherService,
+                                                   Controllers::TouchHandler& touchHandler,
+                                                   Pinetime::Controllers::MusicService& musicService)
   : currentDateTime {{}},
     batteryIcon(false),
     dateTimeController {dateTimeController},
     batteryController {batteryController},
     bleController {bleController},
-    notificatioManager {notificatioManager},
+    notificationManager {notificationManager},
     settingsController {settingsController},
     heartRateController {heartRateController},
-    motionController {motionController} {
+    motionController {motionController},
+    weatherService {weatherService},
+    touchHandler {touchHandler},
+    musicService {musicService}{
 
   lfs_file f = {};
   if (filesystem.FileOpen(&f, "/fonts/lv_font_dots_40.bin", LFS_O_RDONLY) >= 0) {
@@ -55,22 +64,46 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
 
   batteryIcon.Create(lv_scr_act());
   batteryIcon.SetColor(color_text);
-  lv_obj_align(batteryIcon.GetObject(), label_battery_value, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+  lv_obj_align(batteryIcon.GetObject(), lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, -40, 0);
 
   batteryPlug = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(batteryPlug, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_label_set_text_static(batteryPlug, Symbols::plug);
-  lv_obj_align(batteryPlug, batteryIcon.GetObject(), LV_ALIGN_OUT_LEFT_MID, -5, 0);
+  lv_obj_align(batteryPlug, lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, -38, 0);
 
   bleIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(bleIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_label_set_text_static(bleIcon, Symbols::bluetooth);
-  lv_obj_align(bleIcon, batteryPlug, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+  lv_obj_align(bleIcon, lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, -67, 0);
+
+  touchLockFinger = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(touchLockFinger, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
+  lv_label_set_text_static(touchLockFinger, "t");
+  lv_obj_align(touchLockFinger, lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, -120, 0);
+
+  touchLockCross = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(touchLockCross, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
+  lv_obj_set_style_local_text_font(touchLockCross, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &fontawesome_weathericons);
+  lv_label_set_text_static(touchLockCross, Symbols::ban);
+  lv_obj_align(touchLockCross, lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, -112, -1); //+1,-1 relative to finger
+
+  weatherIcon = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(weatherIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
+  lv_obj_set_style_local_text_font(weatherIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &fontawesome_weathericons);
+  lv_label_set_text(weatherIcon, Symbols::cloudSunRain);
+  lv_obj_align(weatherIcon, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 25);
+  lv_obj_set_auto_realign(weatherIcon, true);
+  lv_obj_set_hidden(weatherIcon, false);
+
+  temperature = lv_label_create(lv_scr_act(), nullptr);
+  lv_obj_set_style_local_text_color(temperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
+  lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 50);
+  lv_obj_set_hidden(temperature, false);
 
   notificationIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(false));
-  lv_obj_align(notificationIcon, bleIcon, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+  lv_obj_align(notificationIcon, lv_scr_act(), LV_ALIGN_IN_TOP_RIGHT, -95, 0);
 
   label_day_of_week = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_align(label_day_of_week, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 10, 64);
@@ -155,6 +188,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
 
   heartbeatValue = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(heartbeatValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
+
   lv_label_set_text_static(heartbeatValue, "");
   lv_obj_align(heartbeatValue, heartbeatIcon, LV_ALIGN_OUT_RIGHT_MID, 5, 0);
 
@@ -167,6 +201,14 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_obj_set_style_local_text_color(stepIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_label_set_text_static(stepIcon, Symbols::shoe);
   lv_obj_align(stepIcon, stepValue, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+
+  txtArtist = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_long_mode(txtArtist, LV_LABEL_LONG_SROLL_CIRC);
+  //lv_obj_align(txtArtist, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, -25,0);
+  lv_obj_align(txtArtist, heartbeatValue, LV_ALIGN_OUT_RIGHT_MID, 10,0);
+  lv_obj_set_style_local_text_color(txtArtist, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
+  lv_obj_set_width(txtArtist, 80);
+  lv_label_set_text_static(txtArtist, "No media playing");
 
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
   Refresh();
@@ -196,6 +238,7 @@ WatchFaceCasioStyleG7710::~WatchFaceCasioStyleG7710() {
 void WatchFaceCasioStyleG7710::Refresh() {
   powerPresent = batteryController.IsPowerPresent();
   if (powerPresent.IsUpdated()) {
+    lv_obj_set_hidden(batteryIcon.GetObject(), powerPresent.Get());
     lv_label_set_text_static(batteryPlug, BatteryIcon::GetPlugIcon(powerPresent.Get()));
   }
 
@@ -205,6 +248,40 @@ void WatchFaceCasioStyleG7710::Refresh() {
     batteryIcon.SetBatteryPercentage(batteryPercent);
     lv_label_set_text_fmt(label_battery_value, "%d%%", batteryPercent);
   }
+
+  if (weatherService.GetCurrentTemperature()->timestamp != 0 && weatherService.GetCurrentClouds()->timestamp != 0 &&
+      weatherService.GetCurrentPrecipitation()->timestamp != 0) {
+    nowTemp = ((weatherService.GetCurrentTemperature()->temperature / 100) * 1.8 + 32);
+    clouds = (weatherService.GetCurrentClouds()->amount);
+    precip = (weatherService.GetCurrentPrecipitation()->amount);
+    if (nowTemp.IsUpdated()) {
+      lv_label_set_text_fmt(temperature, "%d°", nowTemp.Get());
+      if ((clouds <= 30) && (precip == 0)) {
+        lv_label_set_text(weatherIcon, Symbols::sun);
+      } else if ((clouds >= 70) && (clouds <= 90) && (precip == 1)) {
+        lv_label_set_text(weatherIcon, Symbols::cloudSunRain);
+      } else if ((clouds > 90) && (precip == 0)) {
+        lv_label_set_text(weatherIcon, Symbols::cloud);
+      } else if ((clouds > 70) && (precip >= 2)) {
+        lv_label_set_text(weatherIcon, Symbols::cloudShowersHeavy);
+      } else {
+        lv_label_set_text(weatherIcon, Symbols::cloudSun);
+      };
+      lv_obj_realign(temperature);
+      lv_obj_realign(weatherIcon);
+    }
+  } else {
+    lv_label_set_text_static(temperature, "--");
+    lv_label_set_text(weatherIcon, Symbols::ban);
+    lv_obj_realign(temperature);
+    lv_obj_realign(weatherIcon);
+  }
+
+  //placeholder for adding track data someday
+/*  if (track != musicService.getTrack()) {
+    track = musicService.getTrack();
+    lv_label_set_text(txtArtist, track.data());
+  }*/
 
   bleState = bleController.IsConnected();
   bleRadioEnabled = bleController.IsRadioEnabled();
@@ -217,10 +294,11 @@ void WatchFaceCasioStyleG7710::Refresh() {
   lv_obj_realign(bleIcon);
   lv_obj_realign(notificationIcon);
 
-  notificationState = notificatioManager.AreNewNotificationsAvailable();
-  if (notificationState.IsUpdated()) {
-    lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
-  }
+  lv_obj_set_hidden(touchLockCross, touchHandler.touchEnabled);
+
+  uint8_t notifNb = notificationManager.NbNotifications();
+  lv_label_set_text_fmt(notificationIcon, "%i", notifNb);
+
 
   currentDateTime = std::chrono::time_point_cast<std::chrono::minutes>(dateTimeController.CurrentDateTime());
   if (currentDateTime.IsUpdated()) {
@@ -302,6 +380,13 @@ void WatchFaceCasioStyleG7710::Refresh() {
 
     lv_obj_realign(heartbeatIcon);
     lv_obj_realign(heartbeatValue);
+    lv_obj_realign(txtArtist);
+    lv_obj_set_width(txtArtist, 150 - (lv_obj_get_width(stepValue)) - lv_obj_get_width(heartbeatValue));
+  }
+
+  if (artist != musicService.getArtist()) {
+    artist = musicService.getArtist();
+    lv_label_set_text(txtArtist, artist.data());
   }
 
   stepCount = motionController.NbSteps();
@@ -309,6 +394,7 @@ void WatchFaceCasioStyleG7710::Refresh() {
     lv_label_set_text_fmt(stepValue, "%lu", stepCount.Get());
     lv_obj_realign(stepValue);
     lv_obj_realign(stepIcon);
+    lv_obj_set_width(txtArtist, 150 - (lv_obj_get_width(stepValue)) - lv_obj_get_width(heartbeatValue));
   }
 }
 

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -85,11 +85,11 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_obj_set_style_local_text_color(weatherIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_obj_set_style_local_text_font(weatherIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &fontawesome_weathericons);
   lv_label_set_text(weatherIcon, Symbols::cloudSunRain);
-  //Change weather location based on time format, as there is only room to put it on the side in 12HR
+  // Change weather location based on time format, as there is only room to put it on the side in 12HR
   if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
-    lv_obj_align(weatherIcon, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 112, 72); //upper
+    lv_obj_align(weatherIcon, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 112, 72); // upper
   } else {
-    lv_obj_align(weatherIcon, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 25); //lower
+    lv_obj_align(weatherIcon, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 25); // lower
   }
   lv_obj_set_auto_realign(weatherIcon, true);
   if (settingsController.GetCSGWeatherStyle() == Pinetime::Controllers::Settings::CSGWeatherStyle::Off) {
@@ -100,12 +100,12 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
 
   temperature = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(temperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
-  //Change temperature location based on time format, as there is only room to put it on the side in 12HR
+  // Change temperature location based on time format, as there is only room to put it on the side in 12HR
   if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
-    lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_CENTER, 10, -2);   //above colon
-    //lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 20);   //tucked into the 2
+    lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_CENTER, 10, -2); // above colon
+    // lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 20);   //tucked into the 2
   } else {
-    lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 50); //lower
+    lv_obj_align(temperature, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 4, 50); // lower
   }
   if (settingsController.GetCSGWeatherStyle() == Pinetime::Controllers::Settings::CSGWeatherStyle::Off) {
     lv_obj_set_hidden(temperature, true);
@@ -165,11 +165,12 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_obj_set_style_local_text_color(label_date, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_obj_set_style_local_text_font(label_date, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, font_segment40);
   lv_label_set_text_static(label_date, "6-30");
-  //nudge date over to make room for weather when in 24HR mode with weather enabled
-  if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24 && settingsController.GetCSGWeatherStyle() == Pinetime::Controllers::Settings::CSGWeatherStyle::On) {
-    lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 118, 70);  //nudge
+  // nudge date over to make room for weather when in 24HR mode with weather enabled
+  if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24 &&
+      settingsController.GetCSGWeatherStyle() == Pinetime::Controllers::Settings::CSGWeatherStyle::On) {
+    lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 118, 70); // nudge
   } else {
-    lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 100, 70);  //un-nudge
+    lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 100, 70); // un-nudge
   }
 
   line_date = lv_line_create(lv_scr_act(), nullptr);
@@ -221,7 +222,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
 
   txtMedia = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtMedia, LV_LABEL_LONG_SROLL_CIRC);
-  lv_obj_align(txtMedia, heartbeatValue, LV_ALIGN_OUT_RIGHT_MID, 10,0);
+  lv_obj_align(txtMedia, heartbeatValue, LV_ALIGN_OUT_RIGHT_MID, 10, 0);
   lv_obj_set_style_local_text_color(txtMedia, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_obj_set_width(txtMedia, 80);
   lv_label_set_text_static(txtMedia, "No media playing");
@@ -344,13 +345,12 @@ void WatchFaceCasioStyleG7710::Refresh() {
     lv_label_set_text_fmt(label_battery_value, "%d%%", batteryPercent);
   }
 
-
   if (weatherService.GetCurrentTemperature()->timestamp != 0 && weatherService.GetCurrentClouds()->timestamp != 0 &&
       weatherService.GetCurrentPrecipitation()->timestamp != 0) {
     if (settingsController.GetTempUnits() == Controllers::Settings::TempUnits::Celcius) {
-      nowTemp = (weatherService.GetCurrentTemperature()->temperature / 100);  //just use temp as is
+      nowTemp = (weatherService.GetCurrentTemperature()->temperature / 100); // just use temp as is
     } else {
-      nowTemp = ((weatherService.GetCurrentTemperature()->temperature / 100) * 1.8 + 32); //convert to F first
+      nowTemp = ((weatherService.GetCurrentTemperature()->temperature / 100) * 1.8 + 32); // convert to F first
     }
     clouds = (weatherService.GetCurrentClouds()->amount);
     precip = (weatherService.GetCurrentPrecipitation()->amount);
@@ -377,7 +377,6 @@ void WatchFaceCasioStyleG7710::Refresh() {
     lv_obj_realign(weatherIcon);
   }
 
-
   bleState = bleController.IsConnected();
   bleRadioEnabled = bleController.IsRadioEnabled();
   if (bleState.IsUpdated() || bleRadioEnabled.IsUpdated()) {
@@ -389,11 +388,11 @@ void WatchFaceCasioStyleG7710::Refresh() {
   lv_obj_realign(bleIcon);
   lv_obj_realign(notificationIcon);
 
-  //old notification icon, simply shows if there are unread notifications
-/*  notificationState = notificationManager.AreNewNotificationsAvailable();
-  if (notificationState.IsUpdated()) {
-    lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
-  }*/
+  // old notification icon, simply shows if there are unread notifications
+  /*  notificationState = notificationManager.AreNewNotificationsAvailable();
+    if (notificationState.IsUpdated()) {
+      lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
+    }*/
 
   uint8_t notifNb = notificationManager.NbNotifications();
   lv_label_set_text_fmt(notificationIcon, "%i", notifNb);
@@ -482,7 +481,7 @@ void WatchFaceCasioStyleG7710::Refresh() {
     lv_obj_set_width(txtMedia, 150 - (lv_obj_get_width(stepValue)) - lv_obj_get_width(heartbeatValue));
   }
 
-  if(!lv_obj_get_hidden(txtMedia)) {
+  if (!lv_obj_get_hidden(txtMedia)) {
     if (track != musicService.getTrack()) {
       track = musicService.getTrack();
       artist = musicService.getArtist();
@@ -503,10 +502,10 @@ void WatchFaceCasioStyleG7710::Refresh() {
     }
   }
 
-/*  if (artist != musicService.getArtist()) {
-    artist = musicService.getArtist();
-    lv_label_set_text(txtMedia, artist.data());
-  }*/
+  /*  if (artist != musicService.getArtist()) {
+      artist = musicService.getArtist();
+      lv_label_set_text(txtMedia, artist.data());
+    }*/
 
   stepCount = motionController.NbSteps();
   if (stepCount.IsUpdated()) {
@@ -516,7 +515,7 @@ void WatchFaceCasioStyleG7710::Refresh() {
     lv_obj_set_width(txtMedia, 150 - (lv_obj_get_width(stepValue)) - lv_obj_get_width(heartbeatValue));
   }
 
-  //dismiss settings menu after 3 seconds
+  // dismiss settings menu after 3 seconds
   if (!lv_obj_get_hidden(btnWeather)) {
     if ((savedTick > 0) && (lv_tick_get() - savedTick > 3000)) {
       lv_obj_set_hidden(btnMedia, true);
@@ -527,10 +526,10 @@ void WatchFaceCasioStyleG7710::Refresh() {
   }
 }
 
-//handle settings buttons and update settings accordingly
+// handle settings buttons and update settings accordingly
 void WatchFaceCasioStyleG7710::UpdateSelected(lv_obj_t* object, lv_event_t event) {
   if (event == LV_EVENT_CLICKED) {
-    savedTick = lv_tick_get();  //reset 3 second timer to dismiss
+    savedTick = lv_tick_get(); // reset 3 second timer to dismiss
     if (object == btnMedia) {
       switch (settingsController.GetCSGMediaStyle()) {
         case Pinetime::Controllers::Settings::CSGMediaStyle::Off:
@@ -555,7 +554,7 @@ void WatchFaceCasioStyleG7710::UpdateSelected(lv_obj_t* object, lv_event_t event
           break;
       }
       track = "";
-    } else if (object == btnTempUnits) {  //if units button, switch units
+    } else if (object == btnTempUnits) { // if units button, switch units
       if (settingsController.GetTempUnits() == Controllers::Settings::TempUnits::Celcius) {
         settingsController.SetTempUnits(Controllers::Settings::TempUnits::Fahrenheit);
         lv_label_set_text_static(lblTempUnits, "Units: °F");
@@ -563,28 +562,28 @@ void WatchFaceCasioStyleG7710::UpdateSelected(lv_obj_t* object, lv_event_t event
         settingsController.SetTempUnits(Controllers::Settings::TempUnits::Celcius);
         lv_label_set_text_static(lblTempUnits, "Units: °C");
       }
-    } else if (object == btnWeather) {  //if weather button pressed
-      if (lv_obj_get_hidden(weatherIcon)) { //if weather hidden
+    } else if (object == btnWeather) {      // if weather button pressed
+      if (lv_obj_get_hidden(weatherIcon)) { // if weather hidden
         // show weather icon and temperature
         lv_obj_set_hidden(weatherIcon, false);
         lv_obj_set_hidden(temperature, false);
-        //if 24HR, nudge date over to make room
-        if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24){
-          lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 118, 70);  //nudge date
+        // if 24HR, nudge date over to make room
+        if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
+          lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 118, 70); // nudge date
         }
-        lv_label_set_text_static(lblWeather, "Weather: On");   //update button text
-        //save to settings
+        lv_label_set_text_static(lblWeather, "Weather: On"); // update button text
+        // save to settings
         settingsController.SetCSGWeatherStyle(Controllers::Settings::CSGWeatherStyle::On);
       } else {
         // hide weather icon and temperature
         lv_obj_set_hidden(weatherIcon, true);
         lv_obj_set_hidden(temperature, true);
-        if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24){
-        //if 24HR, un-nudge date
-          lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 100, 70);  //un-nudge date
+        if (settingsController.GetClockType() == Controllers::Settings::ClockType::H24) {
+          // if 24HR, un-nudge date
+          lv_obj_align(label_date, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 100, 70); // un-nudge date
         }
-        lv_label_set_text_static(lblWeather, "Weather: Off");   //update button text
-        //save to settings
+        lv_label_set_text_static(lblWeather, "Weather: Off"); // update button text
+        // save to settings
         settingsController.SetCSGWeatherStyle(Controllers::Settings::CSGWeatherStyle::Off);
       }
     }

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.h
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.h
@@ -123,9 +123,9 @@ namespace Pinetime {
         Controllers::WeatherService& weatherService;
         Controllers::MusicService& musicService;
 
-        std::string artist;
-        std::string album;
-        std::string track;
+        std::string artist = "no artist";
+        std::string album = "no album";
+        std::string track = "no track";
 
         void CloseMenu();
 

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.h
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.h
@@ -82,6 +82,9 @@ namespace Pinetime {
         lv_obj_t* btnWeather;
         lv_obj_t* btnMedia;
         lv_obj_t* btnTempUnits;
+        lv_obj_t* lblTempUnits;
+        lv_obj_t* lblMedia;
+        lv_obj_t* lblWeather;
         lv_obj_t* label_time;
         lv_obj_t* line_time;
         lv_obj_t* label_time_ampm;
@@ -107,7 +110,6 @@ namespace Pinetime {
         lv_obj_t* notificationIcon;
         lv_obj_t* line_icons;
         lv_obj_t* txtMedia;
-        lv_obj_t* txtTrack;
 
         BatteryIcon batteryIcon;
 

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.h
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.h
@@ -40,7 +40,12 @@ namespace Pinetime {
                                  Controllers::FS& filesystem);
         ~WatchFaceCasioStyleG7710() override;
 
+        bool OnTouchEvent(TouchEvents event) override;
+        bool OnButtonPushed() override;
+
         void Refresh() override;
+
+        void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
         static bool IsAvailable(Pinetime::Controllers::FS& filesystem);
 
@@ -58,6 +63,7 @@ namespace Pinetime {
         using days = std::chrono::duration<int32_t, std::ratio<86400>>; // TODO: days is standard in c++20
         Utility::DirtyValue<std::chrono::time_point<std::chrono::system_clock, days>> currentDate;
 
+        uint32_t savedTick = 0;
 
         int16_t clouds = 0;
         int16_t precip = 0;
@@ -73,6 +79,8 @@ namespace Pinetime {
         lv_style_t style_line;
         lv_style_t style_border;
 
+        lv_obj_t* btnWeather;
+        lv_obj_t* btnMedia;
         lv_obj_t* label_time;
         lv_obj_t* line_time;
         lv_obj_t* label_time_ampm;
@@ -97,7 +105,7 @@ namespace Pinetime {
         lv_obj_t* stepValue;
         lv_obj_t* notificationIcon;
         lv_obj_t* line_icons;
-        lv_obj_t* txtArtist;
+        lv_obj_t* txtMedia;
         lv_obj_t* txtTrack;
 
         BatteryIcon batteryIcon;
@@ -115,6 +123,8 @@ namespace Pinetime {
         std::string artist;
         std::string album;
         std::string track;
+
+        void CloseMenu();
 
         lv_task_t* taskRefresh;
         lv_font_t* font_dot40 = nullptr;

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.h
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.h
@@ -8,7 +8,9 @@
 #include "displayapp/screens/Screen.h"
 #include "components/datetime/DateTimeController.h"
 #include "components/ble/BleController.h"
+#include "components/ble/weather/WeatherService.h"
 #include "utility/DirtyValue.h"
+#include "touchhandler/TouchHandler.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -18,6 +20,7 @@ namespace Pinetime {
     class NotificationManager;
     class HeartRateController;
     class MotionController;
+    class MusicService;
   }
 
   namespace Applications {
@@ -28,11 +31,14 @@ namespace Pinetime {
         WatchFaceCasioStyleG7710(Controllers::DateTime& dateTimeController,
                                  const Controllers::Battery& batteryController,
                                  const Controllers::Ble& bleController,
-                                 Controllers::NotificationManager& notificatioManager,
+                                 Controllers::NotificationManager& notificationManager,
                                  Controllers::Settings& settingsController,
                                  Controllers::HeartRateController& heartRateController,
                                  Controllers::MotionController& motionController,
-                                 Controllers::FS& filesystem);
+                                 Controllers::FS& filesystem,
+                                 Controllers::WeatherService& weather,
+                                 Controllers::TouchHandler& touchHandler,
+                                 Controllers::MusicService& musicService);
         ~WatchFaceCasioStyleG7710() override;
 
         void Refresh() override;
@@ -49,8 +55,13 @@ namespace Pinetime {
         Utility::DirtyValue<uint8_t> heartbeat {};
         Utility::DirtyValue<bool> heartbeatRunning {};
         Utility::DirtyValue<bool> notificationState {};
+        Utility::DirtyValue<int16_t> nowTemp {};
         using days = std::chrono::duration<int32_t, std::ratio<86400>>; // TODO: days is standard in c++20
         Utility::DirtyValue<std::chrono::time_point<std::chrono::system_clock, days>> currentDate;
+
+
+        int16_t clouds = 0;
+        int16_t precip = 0;
 
         lv_point_t line_icons_points[3] {{0, 5}, {117, 5}, {122, 0}};
         lv_point_t line_day_of_week_number_points[4] {{0, 0}, {100, 0}, {95, 95}, {0, 95}};
@@ -70,11 +81,15 @@ namespace Pinetime {
         lv_obj_t* line_date;
         lv_obj_t* label_day_of_week;
         lv_obj_t* label_week_number;
+        lv_obj_t* weatherIcon;
+        lv_obj_t* temperature;
         lv_obj_t* line_day_of_week_number;
         lv_obj_t* label_day_of_year;
         lv_obj_t* line_day_of_year;
         lv_obj_t* backgroundLabel;
         lv_obj_t* bleIcon;
+        lv_obj_t* touchLockFinger;
+        lv_obj_t* touchLockCross;
         lv_obj_t* batteryPlug;
         lv_obj_t* label_battery_value;
         lv_obj_t* heartbeatIcon;
@@ -83,16 +98,25 @@ namespace Pinetime {
         lv_obj_t* stepValue;
         lv_obj_t* notificationIcon;
         lv_obj_t* line_icons;
+        lv_obj_t* txtArtist;
+        lv_obj_t* txtTrack;
 
         BatteryIcon batteryIcon;
 
         Controllers::DateTime& dateTimeController;
         const Controllers::Battery& batteryController;
         const Controllers::Ble& bleController;
-        Controllers::NotificationManager& notificatioManager;
+        Controllers::NotificationManager& notificationManager;
         Controllers::Settings& settingsController;
         Controllers::HeartRateController& heartRateController;
         Controllers::MotionController& motionController;
+        Controllers::WeatherService& weatherService;
+        Controllers::TouchHandler& touchHandler;
+        Controllers::MusicService& musicService;
+
+        std::string artist;
+        std::string album;
+        std::string track;
 
         lv_task_t* taskRefresh;
         lv_font_t* font_dot40 = nullptr;

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.h
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.h
@@ -81,6 +81,7 @@ namespace Pinetime {
 
         lv_obj_t* btnWeather;
         lv_obj_t* btnMedia;
+        lv_obj_t* btnTempUnits;
         lv_obj_t* label_time;
         lv_obj_t* line_time;
         lv_obj_t* label_time_ampm;

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.h
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.h
@@ -35,10 +35,9 @@ namespace Pinetime {
                                  Controllers::Settings& settingsController,
                                  Controllers::HeartRateController& heartRateController,
                                  Controllers::MotionController& motionController,
-                                 Controllers::FS& filesystem,
                                  Controllers::WeatherService& weather,
-                                 Controllers::TouchHandler& touchHandler,
-                                 Controllers::MusicService& musicService);
+                                 Controllers::MusicService& musicService,
+                                 Controllers::FS& filesystem);
         ~WatchFaceCasioStyleG7710() override;
 
         void Refresh() override;
@@ -111,7 +110,6 @@ namespace Pinetime {
         Controllers::HeartRateController& heartRateController;
         Controllers::MotionController& motionController;
         Controllers::WeatherService& weatherService;
-        Controllers::TouchHandler& touchHandler;
         Controllers::MusicService& musicService;
 
         std::string artist;

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -555,9 +555,9 @@ void WatchFacePineTimeStyle::Refresh() {
   if (weatherService.GetCurrentTemperature()->timestamp != 0 && weatherService.GetCurrentClouds()->timestamp != 0 &&
       weatherService.GetCurrentPrecipitation()->timestamp != 0) {
     if (settingsController.GetTempUnits() == Controllers::Settings::TempUnits::Celcius) {
-      nowTemp = (weatherService.GetCurrentTemperature()->temperature / 100);  //just use temp as is
+      nowTemp = (weatherService.GetCurrentTemperature()->temperature / 100); // just use temp as is
     } else {
-      nowTemp = ((weatherService.GetCurrentTemperature()->temperature / 100) * 1.8 + 32); //convert to F first
+      nowTemp = ((weatherService.GetCurrentTemperature()->temperature / 100) * 1.8 + 32); // convert to F first
     }
     clouds = (weatherService.GetCurrentClouds()->amount);
     precip = (weatherService.GetCurrentPrecipitation()->amount);
@@ -729,7 +729,7 @@ void WatchFacePineTimeStyle::UpdateSelected(lv_obj_t* object, lv_event_t event) 
         settingsController.SetPTSGaugeStyle(Controllers::Settings::PTSGaugeStyle::Full);
       }
     }
-    if (object == btnTempUnits) {  //if units button, switch units
+    if (object == btnTempUnits) { // if units button, switch units
       if (settingsController.GetTempUnits() == Controllers::Settings::TempUnits::Celcius) {
         settingsController.SetTempUnits(Controllers::Settings::TempUnits::Fahrenheit);
         lv_label_set_text_static(lblTempUnits, "°F");

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -397,10 +397,14 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(Controllers::DateTime& dateTimeCo
   lv_obj_set_size(btnTempUnits, 60, 60);
   lv_obj_align(btnTempUnits, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -15, -80);
   lv_obj_set_style_local_bg_opa(btnTempUnits, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
-  lv_obj_t* lblTempUnits = lv_label_create(btnTempUnits, nullptr);
-  lv_label_set_text_static(lblTempUnits, "°C/F");
+  lblTempUnits = lv_label_create(btnTempUnits, nullptr);
   lv_obj_set_event_cb(btnTempUnits, event_handler);
   lv_obj_set_hidden(btnTempUnits, true);
+  if (settingsController.GetTempUnits() == Controllers::Settings::TempUnits::Celcius) {
+    lv_label_set_text_static(lblTempUnits, "°C");
+  } else {
+    lv_label_set_text_static(lblTempUnits, "°F");
+  }
 
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
   Refresh();
@@ -728,8 +732,10 @@ void WatchFacePineTimeStyle::UpdateSelected(lv_obj_t* object, lv_event_t event) 
     if (object == btnTempUnits) {  //if units button, switch units
       if (settingsController.GetTempUnits() == Controllers::Settings::TempUnits::Celcius) {
         settingsController.SetTempUnits(Controllers::Settings::TempUnits::Fahrenheit);
+        lv_label_set_text_static(lblTempUnits, "°F");
       } else {
         settingsController.SetTempUnits(Controllers::Settings::TempUnits::Celcius);
+        lv_label_set_text_static(lblTempUnits, "°C");
       }
     }
     if (object == btnWeather) {

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -392,6 +392,16 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(Controllers::DateTime& dateTimeCo
   lv_label_set_text_static(lblSetOpts, Symbols::settings);
   lv_obj_set_hidden(btnSetOpts, true);
 
+  btnTempUnits = lv_btn_create(lv_scr_act(), nullptr);
+  btnTempUnits->user_data = this;
+  lv_obj_set_size(btnTempUnits, 60, 60);
+  lv_obj_align(btnTempUnits, lv_scr_act(), LV_ALIGN_IN_RIGHT_MID, -15, -80);
+  lv_obj_set_style_local_bg_opa(btnTempUnits, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_50);
+  lv_obj_t* lblTempUnits = lv_label_create(btnTempUnits, nullptr);
+  lv_label_set_text_static(lblTempUnits, "°C/F");
+  lv_obj_set_event_cb(btnTempUnits, event_handler);
+  lv_obj_set_hidden(btnTempUnits, true);
+
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
   Refresh();
 }
@@ -427,6 +437,7 @@ void WatchFacePineTimeStyle::CloseMenu() {
   lv_obj_set_hidden(btnClose, true);
   lv_obj_set_hidden(btnSteps, true);
   lv_obj_set_hidden(btnWeather, true);
+  lv_obj_set_hidden(btnTempUnits, true);
 }
 
 bool WatchFacePineTimeStyle::OnButtonPushed() {
@@ -539,7 +550,11 @@ void WatchFacePineTimeStyle::Refresh() {
 
   if (weatherService.GetCurrentTemperature()->timestamp != 0 && weatherService.GetCurrentClouds()->timestamp != 0 &&
       weatherService.GetCurrentPrecipitation()->timestamp != 0) {
-    nowTemp = (weatherService.GetCurrentTemperature()->temperature / 100);
+    if (settingsController.GetTempUnits() == Controllers::Settings::TempUnits::Celcius) {
+      nowTemp = (weatherService.GetCurrentTemperature()->temperature / 100);  //just use temp as is
+    } else {
+      nowTemp = ((weatherService.GetCurrentTemperature()->temperature / 100) * 1.8 + 32); //convert to F first
+    }
     clouds = (weatherService.GetCurrentClouds()->amount);
     precip = (weatherService.GetCurrentPrecipitation()->amount);
     if (nowTemp.IsUpdated()) {
@@ -710,6 +725,13 @@ void WatchFacePineTimeStyle::UpdateSelected(lv_obj_t* object, lv_event_t event) 
         settingsController.SetPTSGaugeStyle(Controllers::Settings::PTSGaugeStyle::Full);
       }
     }
+    if (object == btnTempUnits) {  //if units button, switch units
+      if (settingsController.GetTempUnits() == Controllers::Settings::TempUnits::Celcius) {
+        settingsController.SetTempUnits(Controllers::Settings::TempUnits::Fahrenheit);
+      } else {
+        settingsController.SetTempUnits(Controllers::Settings::TempUnits::Celcius);
+      }
+    }
     if (object == btnWeather) {
       if (lv_obj_get_hidden(weatherIcon)) {
         // show weather icon and temperature
@@ -759,6 +781,7 @@ void WatchFacePineTimeStyle::UpdateSelected(lv_obj_t* object, lv_event_t event) 
       lv_obj_set_hidden(btnSetOpts, true);
       lv_obj_set_hidden(btnSteps, false);
       lv_obj_set_hidden(btnWeather, false);
+      lv_obj_set_hidden(btnTempUnits, false);
       lv_obj_set_hidden(btnClose, false);
     }
   }

--- a/src/displayapp/screens/WatchFacePineTimeStyle.h
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.h
@@ -78,6 +78,7 @@ namespace Pinetime {
         lv_obj_t* btnClose;
         lv_obj_t* btnSteps;
         lv_obj_t* btnWeather;
+        lv_obj_t* btnTempUnits;
         lv_obj_t* timebar;
         lv_obj_t* sidebar;
         lv_obj_t* timeDD1;

--- a/src/displayapp/screens/WatchFacePineTimeStyle.h
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.h
@@ -79,6 +79,7 @@ namespace Pinetime {
         lv_obj_t* btnSteps;
         lv_obj_t* btnWeather;
         lv_obj_t* btnTempUnits;
+        lv_obj_t* lblTempUnits;
         lv_obj_t* timebar;
         lv_obj_t* sidebar;
         lv_obj_t* timeDD1;


### PR DESCRIPTION
Added to WatchFaceCasioStyleG7710:
- weather and temperature
- ability to display track/artist/album
- ability to set preferred units for temperature
- PineTimeStyle-type settings menu for toggling these features
- notification indicator displaying the number of notifications, not just weather any unread notifications are available

Additionally added support for setting and using the temperature units within WatchFacePineTimeStyle