### PR TITLE
Option to display current artist/track/album on CasioStyleG7710

### DIFF
--- a/src/components/ble/MusicService.h
+++ b/src/components/ble/MusicService.h
@@ -70,9 +70,9 @@ namespace Pinetime {
 
       uint16_t eventHandle {};
 
-      std::string artistName {"Waiting for"};
-      std::string albumName {};
-      std::string trackName {"track information.."};
+      std::string artistName {"No Artist"};
+      std::string albumName {"No Album"};
+      std::string trackName {"No Track"};
 
       bool playing {false};
 

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -41,6 +41,12 @@ namespace Pinetime {
       enum class PTSGaugeStyle : uint8_t { Full, Half, Numeric };
       enum class PTSWeather : uint8_t { On, Off };
 
+      enum class CSGMediaStyle : uint8_t { Off, Artist, Track, Album };
+
+      struct CasioStyleG7710 {
+        CSGMediaStyle mediaStyle = CSGMediaStyle::Off;
+      };
+
       struct PineTimeStyle {
         Colors ColorTime = Colors::Teal;
         Colors ColorBar = Colors::Teal;
@@ -156,6 +162,16 @@ namespace Pinetime {
 
       PTSWeather GetPTSWeather() const {
         return settings.PTS.weatherEnable;
+      };
+
+      void SetCSGMediaStyle(CSGMediaStyle mediaStyle) {
+        if (mediaStyle != settings.CSG.mediaStyle)
+          settingsChanged = true;
+        settings.CSG.mediaStyle = mediaStyle;
+      };
+
+      CSGMediaStyle GetCSGMediaStyle() const {
+        return settings.CSG.mediaStyle;
       };
 
       void SetAppMenu(uint8_t menu) {
@@ -293,6 +309,8 @@ namespace Pinetime {
         ChimesOption chimesOption = ChimesOption::None;
 
         PineTimeStyle PTS;
+
+        CasioStyleG7710 CSG;
 
         WatchFaceInfineat watchFaceInfineat;
 

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -419,7 +419,8 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
                                                        heartRateController,
                                                        motionController,
                                                        systemTask->nimble().weather(),
-                                                       filesystem);
+                                                       filesystem,
+                                                       systemTask->nimble().music());
       break;
 
     case Apps::Error:

--- a/src/displayapp/screens/Clock.cpp
+++ b/src/displayapp/screens/Clock.cpp
@@ -25,7 +25,8 @@ Clock::Clock(Controllers::DateTime& dateTimeController,
              Controllers::HeartRateController& heartRateController,
              Controllers::MotionController& motionController,
              Controllers::WeatherService& weatherService,
-             Controllers::FS& filesystem)
+             Controllers::FS& filesystem,
+             Controllers::MusicService& musicService)
   : dateTimeController {dateTimeController},
     batteryController {batteryController},
     bleController {bleController},
@@ -35,6 +36,7 @@ Clock::Clock(Controllers::DateTime& dateTimeController,
     motionController {motionController},
     weatherService {weatherService},
     filesystem {filesystem},
+    musicService {musicService},
     screen {[this, &settingsController]() {
       switch (settingsController.GetWatchFace()) {
         case WatchFace::Digital:
@@ -129,5 +131,6 @@ std::unique_ptr<Screen> Clock::WatchFaceCasioStyleG7710() {
                                                              settingsController,
                                                              heartRateController,
                                                              motionController,
-                                                             filesystem);
+                                                             filesystem,
+                                                             musicService);
 }

--- a/src/displayapp/screens/Clock.h
+++ b/src/displayapp/screens/Clock.h
@@ -8,6 +8,7 @@
 #include "displayapp/screens/Screen.h"
 #include "components/datetime/DateTimeController.h"
 #include "components/ble/weather/WeatherService.h"
+#include "components/ble/MusicService.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -30,7 +31,8 @@ namespace Pinetime {
               Controllers::HeartRateController& heartRateController,
               Controllers::MotionController& motionController,
               Controllers::WeatherService& weatherService,
-              Controllers::FS& filesystem);
+              Controllers::FS& filesystem,
+              Controllers::MusicService& musicService);
         ~Clock() override;
 
         bool OnTouchEvent(TouchEvents event) override;
@@ -46,6 +48,7 @@ namespace Pinetime {
         Controllers::MotionController& motionController;
         Controllers::WeatherService& weatherService;
         Controllers::FS& filesystem;
+        Controllers::MusicService& musicService;
 
         std::unique_ptr<Screen> screen;
         std::unique_ptr<Screen> WatchFaceDigitalScreen();

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -12,7 +12,16 @@
 #include "components/heartrate/HeartRateController.h"
 #include "components/motion/MotionController.h"
 #include "components/settings/Settings.h"
+#include "components/ble/MusicService.h"
+
 using namespace Pinetime::Applications::Screens;
+
+namespace {
+  void event_handler(lv_obj_t* obj, lv_event_t event) {
+    auto* screen = static_cast<WatchFaceCasioStyleG7710*>(obj->user_data);
+    screen->UpdateSelected(obj, event);
+  }
+}
 
 WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTimeController,
                                                    const Controllers::Battery& batteryController,
@@ -21,7 +30,8 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
                                                    Controllers::Settings& settingsController,
                                                    Controllers::HeartRateController& heartRateController,
                                                    Controllers::MotionController& motionController,
-                                                   Controllers::FS& filesystem)
+                                                   Controllers::FS& filesystem,
+                                                   Controllers::MusicService& musicService)
   : currentDateTime {{}},
     batteryIcon(false),
     dateTimeController {dateTimeController},
@@ -30,7 +40,8 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
     notificatioManager {notificatioManager},
     settingsController {settingsController},
     heartRateController {heartRateController},
-    motionController {motionController} {
+    motionController {motionController},
+    musicService {musicService} {
 
   lfs_file f = {};
   if (filesystem.FileOpen(&f, "/fonts/lv_font_dots_40.bin", LFS_O_RDONLY) >= 0) {
@@ -168,6 +179,39 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_label_set_text_static(stepIcon, Symbols::shoe);
   lv_obj_align(stepIcon, stepValue, LV_ALIGN_OUT_LEFT_MID, -5, 0);
 
+  txtMedia = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_long_mode(txtMedia, LV_LABEL_LONG_SROLL_CIRC);
+  lv_obj_align(txtMedia, heartbeatValue, LV_ALIGN_OUT_RIGHT_MID, 10, 0);
+  lv_obj_set_style_local_text_color(txtMedia, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
+  lv_obj_set_width(txtMedia, 80);
+  lv_label_set_text_static(txtMedia, "No media playing");
+  lv_obj_set_hidden(txtMedia, false);
+  track = "";
+
+  btnMedia = lv_btn_create(lv_scr_act(), nullptr);
+  btnMedia->user_data = this;
+  lv_obj_set_size(btnMedia, 160, 60);
+  lv_obj_align(btnMedia, lv_scr_act(), LV_ALIGN_CENTER, 0, -80);
+  lv_obj_set_style_local_bg_opa(btnMedia, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_80);
+  lblMedia = lv_label_create(btnMedia, nullptr);
+  lv_obj_set_event_cb(btnMedia, event_handler);
+  lv_obj_set_hidden(btnMedia, true);
+  switch (settingsController.GetCSGMediaStyle()) {
+    case Pinetime::Controllers::Settings::CSGMediaStyle::Off:
+      lv_label_set_text_static(lblMedia, "Media: Off");
+      lv_obj_set_hidden(txtMedia, true);
+      break;
+    case Pinetime::Controllers::Settings::CSGMediaStyle::Artist:
+      lv_label_set_text_static(lblMedia, "Media: Artist");
+      break;
+    case Pinetime::Controllers::Settings::CSGMediaStyle::Track:
+      lv_label_set_text_static(lblMedia, "Media: Track");
+      break;
+    case Pinetime::Controllers::Settings::CSGMediaStyle::Album:
+      lv_label_set_text_static(lblMedia, "Media: Album");
+      break;
+  }
+
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
   Refresh();
 }
@@ -191,6 +235,28 @@ WatchFaceCasioStyleG7710::~WatchFaceCasioStyleG7710() {
   }
 
   lv_obj_clean(lv_scr_act());
+}
+
+bool WatchFaceCasioStyleG7710::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
+  if (event == Pinetime::Applications::TouchEvents::LongTap && lv_obj_get_hidden(btnMedia)) {
+    lv_obj_set_hidden(btnMedia, false);
+    savedTick = lv_tick_get();
+    return true;
+  }
+  return false;
+}
+
+void WatchFaceCasioStyleG7710::CloseMenu() {
+  settingsController.SaveSettings();
+  lv_obj_set_hidden(btnMedia, true);
+}
+
+bool WatchFaceCasioStyleG7710::OnButtonPushed() {
+  if (!lv_obj_get_hidden(btnMedia)) {
+    CloseMenu();
+    return true;
+  }
+  return false;
 }
 
 void WatchFaceCasioStyleG7710::Refresh() {
@@ -302,6 +368,29 @@ void WatchFaceCasioStyleG7710::Refresh() {
 
     lv_obj_realign(heartbeatIcon);
     lv_obj_realign(heartbeatValue);
+    lv_obj_realign(txtMedia);
+    lv_obj_set_width(txtMedia, 150 - (lv_obj_get_width(stepValue)) - lv_obj_get_width(heartbeatValue));
+  }
+
+  if (!lv_obj_get_hidden(txtMedia)) {
+    if (track != musicService.getTrack()) {
+      track = musicService.getTrack();
+      artist = musicService.getArtist();
+      album = musicService.getAlbum();
+      switch (settingsController.GetCSGMediaStyle()) {
+        case Pinetime::Controllers::Settings::CSGMediaStyle::Artist:
+          lv_label_set_text(txtMedia, artist.data());
+          break;
+        case Pinetime::Controllers::Settings::CSGMediaStyle::Track:
+          lv_label_set_text(txtMedia, track.data());
+          break;
+        case Pinetime::Controllers::Settings::CSGMediaStyle::Album:
+          lv_label_set_text(txtMedia, album.data());
+          break;
+        default:
+          break;
+      }
+    }
   }
 
   stepCount = motionController.NbSteps();
@@ -309,6 +398,47 @@ void WatchFaceCasioStyleG7710::Refresh() {
     lv_label_set_text_fmt(stepValue, "%lu", stepCount.Get());
     lv_obj_realign(stepValue);
     lv_obj_realign(stepIcon);
+    lv_obj_set_width(txtMedia, 150 - (lv_obj_get_width(stepValue)) - lv_obj_get_width(heartbeatValue));
+  }
+
+  // dismiss settings menu after 3 seconds
+  if (!lv_obj_get_hidden(btnMedia)) {
+    if ((savedTick > 0) && (lv_tick_get() - savedTick > 3000)) {
+      lv_obj_set_hidden(btnMedia, true);
+      savedTick = 0;
+    }
+  }
+}
+
+// handle settings buttons and update settings accordingly
+void WatchFaceCasioStyleG7710::UpdateSelected(lv_obj_t* object, lv_event_t event) {
+  if (event == LV_EVENT_CLICKED) {
+    savedTick = lv_tick_get(); // reset 3 second timer to dismiss
+    if (object == btnMedia) {
+      switch (settingsController.GetCSGMediaStyle()) {
+        case Pinetime::Controllers::Settings::CSGMediaStyle::Off:
+          lv_label_set_text_static(lblMedia, "Media: Artist");
+          lv_obj_set_hidden(txtMedia, false);
+          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Artist);
+          break;
+        case Pinetime::Controllers::Settings::CSGMediaStyle::Artist:
+          lv_label_set_text_static(lblMedia, "Media: Track");
+          lv_obj_set_hidden(txtMedia, false);
+          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Track);
+          break;
+        case Pinetime::Controllers::Settings::CSGMediaStyle::Track:
+          lv_label_set_text_static(lblMedia, "Media: Album");
+          lv_obj_set_hidden(txtMedia, false);
+          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Album);
+          break;
+        case Pinetime::Controllers::Settings::CSGMediaStyle::Album:
+          lv_label_set_text_static(lblMedia, "Media: Off");
+          lv_obj_set_hidden(txtMedia, true);
+          settingsController.SetCSGMediaStyle(Pinetime::Controllers::Settings::CSGMediaStyle::Off);
+          break;
+      }
+      track = "";
+    }
   }
 }
 

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.h
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.h
@@ -18,6 +18,7 @@ namespace Pinetime {
     class NotificationManager;
     class HeartRateController;
     class MotionController;
+    class MusicService;
   }
 
   namespace Applications {
@@ -32,10 +33,16 @@ namespace Pinetime {
                                  Controllers::Settings& settingsController,
                                  Controllers::HeartRateController& heartRateController,
                                  Controllers::MotionController& motionController,
-                                 Controllers::FS& filesystem);
+                                 Controllers::FS& filesystem,
+                                 Controllers::MusicService& musicService);
         ~WatchFaceCasioStyleG7710() override;
 
+        bool OnTouchEvent(TouchEvents event) override;
+        bool OnButtonPushed() override;
+
         void Refresh() override;
+
+        void UpdateSelected(lv_obj_t* object, lv_event_t event);
 
         static bool IsAvailable(Pinetime::Controllers::FS& filesystem);
 
@@ -52,6 +59,8 @@ namespace Pinetime {
         using days = std::chrono::duration<int32_t, std::ratio<86400>>; // TODO: days is standard in c++20
         Utility::DirtyValue<std::chrono::time_point<std::chrono::system_clock, days>> currentDate;
 
+        uint32_t savedTick = 0;
+
         lv_point_t line_icons_points[3] {{0, 5}, {117, 5}, {122, 0}};
         lv_point_t line_day_of_week_number_points[4] {{0, 0}, {100, 0}, {95, 95}, {0, 95}};
         lv_point_t line_day_of_year_points[3] {{0, 5}, {130, 5}, {135, 0}};
@@ -63,6 +72,8 @@ namespace Pinetime {
         lv_style_t style_line;
         lv_style_t style_border;
 
+        lv_obj_t* btnMedia;
+        lv_obj_t* lblMedia;
         lv_obj_t* label_time;
         lv_obj_t* line_time;
         lv_obj_t* label_time_ampm;
@@ -83,6 +94,7 @@ namespace Pinetime {
         lv_obj_t* stepValue;
         lv_obj_t* notificationIcon;
         lv_obj_t* line_icons;
+        lv_obj_t* txtMedia;
 
         BatteryIcon batteryIcon;
 
@@ -93,6 +105,13 @@ namespace Pinetime {
         Controllers::Settings& settingsController;
         Controllers::HeartRateController& heartRateController;
         Controllers::MotionController& motionController;
+        Controllers::MusicService& musicService;
+
+        std::string artist = "no artist";
+        std::string album = "no album";
+        std::string track = "no track";
+
+        void CloseMenu();
 
         lv_task_t* taskRefresh;
         lv_font_t* font_dot40 = nullptr;


### PR DESCRIPTION
- adds PTS-style settings menu to pick what info is displayed
- options are Off, Artist, Track, or Album
- info is displayed along the bottom of the face, between heart rate and step count, scrolls if it is too long to fit

- additionally changes the placeholder text in MusicService.h to be more informative

![image](https://github.com/InfiniTimeOrg/InfiniTime/assets/78439591/28d1e4d0-78fc-48e7-bdbd-519e31e7fc9f) ![image](https://github.com/InfiniTimeOrg/InfiniTime/assets/78439591/16aa54a1-3a01-4ab3-9337-d7641cc203e6)
