### PR TITLE
Changed CasioStyleG7710 notification icon to show number of undismissed notifications

### DIFF
--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -65,12 +65,13 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   bleIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(bleIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_label_set_text_static(bleIcon, Symbols::bluetooth);
-  lv_obj_align(bleIcon, batteryPlug, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+  lv_obj_align(bleIcon, batteryPlug, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
   notificationIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(false));
-  lv_obj_align(notificationIcon, bleIcon, LV_ALIGN_OUT_LEFT_MID, -5, 0);
+  lv_obj_align(notificationIcon, bleIcon, LV_ALIGN_OUT_LEFT_MID, -14, 0);
+    lv_label_set_text_fmt(notificationIcon, "0");
 
   label_day_of_week = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_align(label_day_of_week, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 10, 64);
@@ -218,8 +219,9 @@ void WatchFaceCasioStyleG7710::Refresh() {
   lv_obj_realign(notificationIcon);
 
   notificationState = notificatioManager.AreNewNotificationsAvailable();
-  if (notificationState.IsUpdated()) {
-    lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(notificationState.Get()));
+  if(notificationState.IsUpdated()){
+    uint8_t notifNb = notificatioManager.NbNotifications();
+    lv_label_set_text_fmt(notificationIcon, "%i", notifNb);
   }
 
   currentDateTime = std::chrono::time_point_cast<std::chrono::minutes>(dateTimeController.CurrentDateTime());

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -71,7 +71,7 @@ WatchFaceCasioStyleG7710::WatchFaceCasioStyleG7710(Controllers::DateTime& dateTi
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);
   lv_label_set_text_static(notificationIcon, NotificationIcon::GetIcon(false));
   lv_obj_align(notificationIcon, bleIcon, LV_ALIGN_OUT_LEFT_MID, -14, 0);
-    lv_label_set_text_fmt(notificationIcon, "0");
+  lv_label_set_text_fmt(notificationIcon, "0");
 
   label_day_of_week = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_align(label_day_of_week, lv_scr_act(), LV_ALIGN_IN_TOP_LEFT, 10, 64);
@@ -219,7 +219,7 @@ void WatchFaceCasioStyleG7710::Refresh() {
   lv_obj_realign(notificationIcon);
 
   notificationState = notificatioManager.AreNewNotificationsAvailable();
-  if(notificationState.IsUpdated()){
+  if (notificationState.IsUpdated()) {
     uint8_t notifNb = notificatioManager.NbNotifications();
     lv_label_set_text_fmt(notificationIcon, "%i", notifNb);
   }


### PR DESCRIPTION
Previously, CasioStyleG7710's notification icon only showed an 'i' if there were any unread notifications (i.e. notifications that the watch recieved while notifications were muted)

This change implements the fix i proposed in #1803, displaying the number of undismissed notifications present instead