### PR TITLE
Swiping up on metronome switches arc input to counter for higher precision

### DIFF
--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -47,8 +47,8 @@ Metronome::Metronome(Controllers::MotorController& motorController, System::Syst
   bpmTap->user_data = this;
   lv_obj_set_event_cb(bpmTap, eventHandler);
   lv_obj_set_style_local_bg_opa(bpmTap, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
-  lv_obj_set_height(bpmTap, 80);
-  lv_obj_align(bpmTap, bpmCounter.GetObject(), LV_ALIGN_CENTER, 0, 0);
+  lv_obj_set_height(bpmTap, 130);
+  lv_obj_align(bpmTap, bpmCounter.GetObject(), LV_ALIGN_CENTER, 0, 30);
 
   bpbDropdown = lv_dropdown_create(lv_scr_act(), nullptr);
   bpbDropdown->user_data = this;

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -39,15 +39,14 @@ Metronome::Metronome(Controllers::MotorController& motorController, System::Syst
   createLabel("bpm", bpmValue, LV_ALIGN_OUT_BOTTOM_MID, &jetbrains_mono_bold_20, 0, 0);
 
   bpmCounter.Create();
-  bpmCounter.SetValue(120);
+  bpmCounter.SetValue(bpm);
   lv_obj_align(bpmCounter.GetObject(), lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 0);
   lv_obj_set_hidden(bpmCounter.GetObject(), true);
-  //bpmCounter.HideControls();
 
   bpmTap = lv_btn_create(lv_scr_act(), nullptr);
   bpmTap->user_data = this;
   lv_obj_set_event_cb(bpmTap, eventHandler);
-  lv_obj_set_style_local_bg_opa(bpmTap, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
+  lv_obj_set_style_local_bg_opa(bpmTap, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_60);
   lv_obj_set_height(bpmTap, 80);
   lv_obj_align(bpmTap, bpmCounter.GetObject(), LV_ALIGN_CENTER, 0, 0);
 
@@ -116,21 +115,27 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
       }
       break;
     }
-    case LV_EVENT_PRESSED: {
+    case LV_EVENT_PRESSED: {  // if bmp is tapped, record the tap...
       if (obj == bpmTap) {
-        TickType_t delta = xTaskGetTickCount() - tappedTime;
+        delta = xTaskGetTickCount() - tappedTime;
+        tappedTime = xTaskGetTickCount();
+        if (lv_obj_get_hidden(bpmCounter.GetObject())) {
+          allowExit = true;
+        }
+      }
+      break;
+    }
+    case LV_EVENT_RELEASED: { // but only commit the change if the tap leaves the button as well, so as not to capture bpm on swipe events
+      if (obj == bpmTap) {
         if (tappedTime != 0 && delta < configTICK_RATE_HZ * 3) {
           bpm = configTICK_RATE_HZ * 60 / delta;
           lv_arc_set_value(bpmArc, bpm);
           lv_label_set_text_fmt(bpmValue, "%03d", bpm);
           bpmCounter.SetValue(bpm);
         }
-        tappedTime = xTaskGetTickCount();
-        allowExit = true;
       }
       break;
     }
-    case LV_EVENT_RELEASED:
     case LV_EVENT_PRESS_LOST:
       if (obj == bpmTap) {
         allowExit = false;
@@ -161,12 +166,10 @@ bool Metronome::OnTouchEvent(TouchEvents event) {
     if (allowExit) {
       return false;
     }
-    lv_obj_set_hidden(bpmTap, false);
     lv_obj_set_hidden(bpmArc, false);
     lv_obj_set_hidden(bpmCounter.GetObject(), true);
   } else if (event == TouchEvents::SwipeUp){
     lv_obj_set_hidden(bpmCounter.GetObject(), false);
-    lv_obj_set_hidden(bpmTap, true);
     lv_obj_set_hidden(bpmArc, true);
     allowExit = false;
   }

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -46,7 +46,7 @@ Metronome::Metronome(Controllers::MotorController& motorController, System::Syst
   bpmTap = lv_btn_create(lv_scr_act(), nullptr);
   bpmTap->user_data = this;
   lv_obj_set_event_cb(bpmTap, eventHandler);
-  lv_obj_set_style_local_bg_opa(bpmTap, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_60);
+  lv_obj_set_style_local_bg_opa(bpmTap, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
   lv_obj_set_height(bpmTap, 80);
   lv_obj_align(bpmTap, bpmCounter.GetObject(), LV_ALIGN_CENTER, 0, 0);
 
@@ -159,19 +159,26 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
     default:
       break;
   }
+  if (obj == bpbDropdown) { // if the user is interacting with the dropdown, take note
+    inDropdown = true;
+  } else {
+    inDropdown = false;
+  }
 }
 
 bool Metronome::OnTouchEvent(TouchEvents event) {
-  if (event == TouchEvents::SwipeDown) {
-    if (allowExit) {
-      return false;
+  if (!inDropdown) {  // only parse swipe events when not in the dropdown menu
+    if (event == TouchEvents::SwipeDown) {
+      if (allowExit) {
+        return false;
+      }
+      lv_obj_set_hidden(bpmArc, false);
+      lv_obj_set_hidden(bpmCounter.GetObject(), true);
+    } else if (event == TouchEvents::SwipeUp){
+      lv_obj_set_hidden(bpmCounter.GetObject(), false);
+      lv_obj_set_hidden(bpmArc, true);
+      allowExit = false;
     }
-    lv_obj_set_hidden(bpmArc, false);
-    lv_obj_set_hidden(bpmCounter.GetObject(), true);
-  } else if (event == TouchEvents::SwipeUp){
-    lv_obj_set_hidden(bpmCounter.GetObject(), false);
-    lv_obj_set_hidden(bpmArc, true);
-    allowExit = false;
   }
   return true;
 }

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -115,7 +115,7 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
       }
       break;
     }
-    case LV_EVENT_PRESSED: {  // if bmp is tapped, record the tap...
+    case LV_EVENT_PRESSED: { // if bmp is tapped, record the tap...
       if (obj == bpmTap) {
         delta = xTaskGetTickCount() - tappedTime;
         tappedTime = xTaskGetTickCount();
@@ -167,14 +167,14 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
 }
 
 bool Metronome::OnTouchEvent(TouchEvents event) {
-  if (!inDropdown) {  // only parse swipe events when not in the dropdown menu
+  if (!inDropdown) { // only parse swipe events when not in the dropdown menu
     if (event == TouchEvents::SwipeDown) {
       if (allowExit) {
         return false;
       }
       lv_obj_set_hidden(bpmArc, false);
       lv_obj_set_hidden(bpmCounter.GetObject(), true);
-    } else if (event == TouchEvents::SwipeUp){
+    } else if (event == TouchEvents::SwipeUp) {
       lv_obj_set_hidden(bpmCounter.GetObject(), false);
       lv_obj_set_hidden(bpmArc, true);
       allowExit = false;

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -47,8 +47,8 @@ Metronome::Metronome(Controllers::MotorController& motorController, System::Syst
   bpmTap->user_data = this;
   lv_obj_set_event_cb(bpmTap, eventHandler);
   lv_obj_set_style_local_bg_opa(bpmTap, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
-  lv_obj_set_height(bpmTap, 130);
-  lv_obj_align(bpmTap, bpmCounter.GetObject(), LV_ALIGN_CENTER, 0, 30);
+  lv_obj_set_height(bpmTap, 80);
+  lv_obj_align(bpmTap, bpmCounter.GetObject(), LV_ALIGN_CENTER, 0, 0);
 
   bpbDropdown = lv_dropdown_create(lv_scr_act(), nullptr);
   bpbDropdown->user_data = this;

--- a/src/displayapp/screens/Metronome.cpp
+++ b/src/displayapp/screens/Metronome.cpp
@@ -38,12 +38,18 @@ Metronome::Metronome(Controllers::MotorController& motorController, System::Syst
   bpmValue = createLabel("120", bpmArc, LV_ALIGN_IN_TOP_MID, &jetbrains_mono_76, 0, 55);
   createLabel("bpm", bpmValue, LV_ALIGN_OUT_BOTTOM_MID, &jetbrains_mono_bold_20, 0, 0);
 
+  bpmCounter.Create();
+  bpmCounter.SetValue(120);
+  lv_obj_align(bpmCounter.GetObject(), lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 0);
+  lv_obj_set_hidden(bpmCounter.GetObject(), true);
+  //bpmCounter.HideControls();
+
   bpmTap = lv_btn_create(lv_scr_act(), nullptr);
   bpmTap->user_data = this;
   lv_obj_set_event_cb(bpmTap, eventHandler);
   lv_obj_set_style_local_bg_opa(bpmTap, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_TRANSP);
   lv_obj_set_height(bpmTap, 80);
-  lv_obj_align(bpmTap, bpmValue, LV_ALIGN_IN_TOP_MID, 0, 0);
+  lv_obj_align(bpmTap, bpmCounter.GetObject(), LV_ALIGN_CENTER, 0, 0);
 
   bpbDropdown = lv_dropdown_create(lv_scr_act(), nullptr);
   bpbDropdown->user_data = this;
@@ -77,6 +83,11 @@ Metronome::~Metronome() {
 }
 
 void Metronome::Refresh() {
+  if (bpm != bpmCounter.GetValue()) {
+    bpm = bpmCounter.GetValue();
+    lv_arc_set_value(bpmArc, bpm);
+    lv_label_set_text_fmt(bpmValue, "%03d", bpm);
+  }
   if (metronomeStarted) {
     if (xTaskGetTickCount() - startTime > 60u * configTICK_RATE_HZ / static_cast<uint16_t>(bpm)) {
       startTime += 60 * configTICK_RATE_HZ / bpm;
@@ -96,6 +107,7 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
     case LV_EVENT_VALUE_CHANGED: {
       if (obj == bpmArc) {
         bpm = lv_arc_get_value(bpmArc);
+        bpmCounter.SetValue(bpm);
         lv_label_set_text_fmt(bpmValue, "%03d", bpm);
       } else if (obj == bpbDropdown) {
         bpb = lv_dropdown_get_selected(obj) + 1;
@@ -111,6 +123,7 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
           bpm = configTICK_RATE_HZ * 60 / delta;
           lv_arc_set_value(bpmArc, bpm);
           lv_label_set_text_fmt(bpmValue, "%03d", bpm);
+          bpmCounter.SetValue(bpm);
         }
         tappedTime = xTaskGetTickCount();
         allowExit = true;
@@ -144,8 +157,18 @@ void Metronome::OnEvent(lv_obj_t* obj, lv_event_t event) {
 }
 
 bool Metronome::OnTouchEvent(TouchEvents event) {
-  if (event == TouchEvents::SwipeDown && allowExit) {
-    running = false;
+  if (event == TouchEvents::SwipeDown) {
+    if (allowExit) {
+      return false;
+    }
+    lv_obj_set_hidden(bpmTap, false);
+    lv_obj_set_hidden(bpmArc, false);
+    lv_obj_set_hidden(bpmCounter.GetObject(), true);
+  } else if (event == TouchEvents::SwipeUp){
+    lv_obj_set_hidden(bpmCounter.GetObject(), false);
+    lv_obj_set_hidden(bpmTap, true);
+    lv_obj_set_hidden(bpmArc, true);
+    allowExit = false;
   }
   return true;
 }

--- a/src/displayapp/screens/Metronome.h
+++ b/src/displayapp/screens/Metronome.h
@@ -20,6 +20,7 @@ namespace Pinetime {
       private:
         TickType_t startTime = 0;
         TickType_t tappedTime = 0;
+        TickType_t delta = 0;
         Controllers::MotorController& motorController;
         System::SystemTask& systemTask;
         int16_t bpm = 120;
@@ -34,7 +35,7 @@ namespace Pinetime {
         lv_obj_t* playPause;
         lv_obj_t* lblPlayPause;
 
-        Widgets::Counter bpmCounter = Widgets::Counter(0, 220, jetbrains_mono_76);
+        Widgets::Counter bpmCounter = Widgets::Counter(40, 220, jetbrains_mono_76);
 
         lv_task_t* taskRefresh;
       };

--- a/src/displayapp/screens/Metronome.h
+++ b/src/displayapp/screens/Metronome.h
@@ -29,7 +29,7 @@ namespace Pinetime {
 
         bool metronomeStarted = false;
         bool allowExit = false;
-        bool inDropdown = false;  // used to block swipes while dropdown is open
+        bool inDropdown = false; // used to block swipes while dropdown is open
 
         lv_obj_t *bpmArc, *bpmTap, *bpmValue;
         lv_obj_t *bpbDropdown, *currentBpbText;

--- a/src/displayapp/screens/Metronome.h
+++ b/src/displayapp/screens/Metronome.h
@@ -29,6 +29,7 @@ namespace Pinetime {
 
         bool metronomeStarted = false;
         bool allowExit = false;
+        bool inDropdown = false;  // used to block swipes while dropdown is open
 
         lv_obj_t *bpmArc, *bpmTap, *bpmValue;
         lv_obj_t *bpbDropdown, *currentBpbText;

--- a/src/displayapp/screens/Metronome.h
+++ b/src/displayapp/screens/Metronome.h
@@ -3,6 +3,7 @@
 #include "systemtask/SystemTask.h"
 #include "components/motor/MotorController.h"
 #include "displayapp/screens/Screen.h"
+#include "displayapp/widgets/Counter.h"
 
 namespace Pinetime {
   namespace Applications {
@@ -32,6 +33,8 @@ namespace Pinetime {
         lv_obj_t *bpbDropdown, *currentBpbText;
         lv_obj_t* playPause;
         lv_obj_t* lblPlayPause;
+
+        Widgets::Counter bpmCounter = Widgets::Counter(0, 220, jetbrains_mono_76);
 
         lv_task_t* taskRefresh;
       };


### PR DESCRIPTION
Swipe up to switch the arc to a counter to make precise BPMs easier to input
Swipe down to switch back to the arc

Implements fix proposed in https://github.com/InfiniTimeOrg/InfiniTime/issues/1191#issuecomment-1408550849
Resolves #1191

![image](https://github.com/InfiniTimeOrg/InfiniTime/assets/78439591/641eb43a-da0c-47f7-86e5-057f729ccfe3) ![image](https://github.com/InfiniTimeOrg/InfiniTime/assets/78439591/4b20bf5f-2842-4247-8bc8-f2086db35064)

