### PR TITLE
Settings: Add double click action settings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -417,6 +417,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/settings/SettingChimes.cpp
         displayapp/screens/settings/SettingShakeThreshold.cpp
         displayapp/screens/settings/SettingBluetooth.cpp
+        displayapp/screens/settings/SettingDoubleClick.cpp
 
         ## Watch faces
         displayapp/screens/WatchFaceAnalog.cpp

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -14,6 +14,7 @@ namespace Pinetime {
       enum class Notification : uint8_t { On, Off, Sleep };
       enum class ChimesOption : uint8_t { None, Hours, HalfHours };
       enum class WakeUpMode : uint8_t { SingleTap = 0, DoubleTap = 1, RaiseWrist = 2, Shake = 3, LowerWrist = 4 };
+      enum class DoubleClickAction : uint8_t { GoToNotifications, AudioNext };
       enum class Colors : uint8_t {
         White,
         Silver,
@@ -249,6 +250,16 @@ namespace Pinetime {
         return settings.wakeUpMode;
       }
 
+      void SetDoubleClickAction(DoubleClickAction action) {
+        if (settings.doubleClickAction != action)
+          settingsChanged = true;
+        settings.doubleClickAction = action;
+      }
+
+      DoubleClickAction GetDoubleClickAction() {
+        return settings.doubleClickAction;
+      }
+
       bool isWakeUpModeOn(const WakeUpMode mode) const {
         return getWakeUpModes()[static_cast<size_t>(mode)];
       }
@@ -308,6 +319,7 @@ namespace Pinetime {
         uint16_t shakeWakeThreshold = 150;
 
         Controllers::BrightnessController::Levels brightLevel = Controllers::BrightnessController::Levels::Medium;
+        DoubleClickAction doubleClickAction;
       };
 
       SettingsData settings;

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -8,6 +8,7 @@
 #include "components/ble/BleController.h"
 #include "components/datetime/DateTimeController.h"
 #include "components/ble/NotificationManager.h"
+#include "components/ble/MusicService.h"
 #include "components/motion/MotionController.h"
 #include "components/motor/MotorController.h"
 #include "displayapp/screens/ApplicationList.h"
@@ -48,6 +49,7 @@
 #include "displayapp/screens/settings/SettingChimes.h"
 #include "displayapp/screens/settings/SettingShakeThreshold.h"
 #include "displayapp/screens/settings/SettingBluetooth.h"
+#include "displayapp/screens/settings/SettingDoubleClick.h"
 
 #include "libs/lv_conf.h"
 #include "UserApps.h"
@@ -360,9 +362,7 @@ void DisplayApp::Refresh() {
         LoadNewScreen(Apps::SysInfo, DisplayApp::FullRefreshDirections::Up);
         break;
       case Messages::ButtonDoubleClicked:
-        if (currentApp != Apps::Notifications && currentApp != Apps::NotificationsPreview) {
-          LoadNewScreen(Apps::Notifications, DisplayApp::FullRefreshDirections::Down);
-        }
+        HandleDoubleClick();
         break;
 
       case Messages::BleFirmwareUpdateStarted:
@@ -507,6 +507,9 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
     case Apps::SettingWakeUp:
       currentScreen = std::make_unique<Screens::SettingWakeUp>(settingsController);
       break;
+    case Apps::SettingDoubleClick:
+      currentScreen = std::make_unique<Screens::SettingDoubleClick>(settingsController);
+      break;
     case Apps::SettingDisplay:
       currentScreen = std::make_unique<Screens::SettingDisplay>(this, settingsController);
       break;
@@ -631,4 +634,17 @@ void DisplayApp::ApplyBrightness() {
     brightness = Controllers::BrightnessController::Levels::High;
   }
   brightnessController.Set(brightness);
+}
+
+void DisplayApp::HandleDoubleClick() {
+  switch (settingsController.GetDoubleClickAction()) {
+    case Controllers::Settings::DoubleClickAction::GoToNotifications:
+      if (currentApp != Apps::Notifications && currentApp != Apps::NotificationsPreview) {
+        LoadNewScreen(Apps::Notifications, DisplayApp::FullRefreshDirections::Down);
+      }
+      break;
+    case Controllers::Settings::DoubleClickAction::AudioNext:
+      systemTask->nimble().music().event(Controllers::MusicService::EVENT_MUSIC_NEXT);
+      break;
+  }
 }

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -129,6 +129,7 @@ namespace Pinetime {
       DisplayApp::FullRefreshDirections nextDirection;
       System::BootErrors bootError;
       void ApplyBrightness();
+      void HandleDoubleClick();
 
       static constexpr size_t returnAppStackSize = 10;
       Utility::StaticStack<Apps, returnAppStackSize> returnAppStack;

--- a/src/displayapp/apps/Apps.h.in
+++ b/src/displayapp/apps/Apps.h.in
@@ -41,6 +41,7 @@ namespace Pinetime {
       SettingChimes,
       SettingShakeThreshold,
       SettingBluetooth,
+      SettingDoubleClick,
       Error,
       Weather
     };

--- a/src/displayapp/screens/Symbols.h
+++ b/src/displayapp/screens/Symbols.h
@@ -39,6 +39,7 @@ namespace Pinetime {
         static constexpr const char* eye = "\xEF\x81\xAE";
         static constexpr const char* home = "\xEF\x80\x95";
         static constexpr const char* sleep = "\xEE\xBD\x84";
+        static constexpr const char* angleDoubleRight = "\xEF\x84\x81";
 
         // fontawesome_weathericons.c
         // static constexpr const char* sun = "\xEF\x86\x85";

--- a/src/displayapp/screens/settings/SettingDoubleClick.cpp
+++ b/src/displayapp/screens/settings/SettingDoubleClick.cpp
@@ -1,0 +1,61 @@
+#include "displayapp/screens/settings/SettingDoubleClick.h"
+#include <lvgl/lvgl.h>
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Styles.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  struct Option {
+    Pinetime::Controllers::Settings::DoubleClickAction action;
+    const char* name;
+  };
+
+  constexpr std::array<Option, 2> options = {{
+    {Pinetime::Controllers::Settings::DoubleClickAction::GoToNotifications, "Notifications"},
+    {Pinetime::Controllers::Settings::DoubleClickAction::AudioNext, "Audio Next"},
+  }};
+
+  std::array<CheckboxList::Item, CheckboxList::MaxItems> CreateOptionArray() {
+    std::array<Pinetime::Applications::Screens::CheckboxList::Item, CheckboxList::MaxItems> optionArray;
+    for (size_t i = 0; i < CheckboxList::MaxItems; i++) {
+      if (i >= options.size()) {
+        optionArray[i].name = "";
+        optionArray[i].enabled = false;
+      } else {
+        optionArray[i].name = options[i].name;
+        optionArray[i].enabled = true;
+      }
+    }
+    return optionArray;
+  }
+
+  uint32_t GetDefaultOption(Pinetime::Controllers::Settings::DoubleClickAction currentOption) {
+    for (size_t i = 0; i < options.size(); i++) {
+      if (options[i].action == currentOption) {
+        return i;
+      }
+    }
+    return 0;
+  }
+}
+
+SettingDoubleClick::SettingDoubleClick(Pinetime::Controllers::Settings& settingsController)
+  : checkboxList(
+      0,
+      1,
+      "Double Click",
+      Symbols::angleDoubleRight,
+      GetDefaultOption(settingsController.GetDoubleClickAction()),
+      [&settings = settingsController](uint32_t index) {
+        settings.SetDoubleClickAction(options[index].action);
+        settings.SaveSettings();
+      },
+      CreateOptionArray()) {
+}
+
+SettingDoubleClick::~SettingDoubleClick() {
+  lv_obj_clean(lv_scr_act());
+}

--- a/src/displayapp/screens/settings/SettingDoubleClick.h
+++ b/src/displayapp/screens/settings/SettingDoubleClick.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <lvgl/lvgl.h>
+
+#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/CheckboxList.h"
+
+namespace Pinetime {
+
+  namespace Applications {
+    namespace Screens {
+
+      class SettingDoubleClick : public Screen {
+      public:
+        SettingDoubleClick(Pinetime::Controllers::Settings& settingsController);
+        ~SettingDoubleClick() override;
+
+      private:
+        CheckboxList checkboxList;
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/Settings.h
+++ b/src/displayapp/screens/settings/Settings.h
@@ -34,9 +34,10 @@ namespace Pinetime {
         static constexpr std::array<List::Applications, entriesPerScreen * nScreens> entries {{
           {Symbols::sun, "Display", Apps::SettingDisplay},
           {Symbols::eye, "Wake Up", Apps::SettingWakeUp},
+          {Symbols::angleDoubleRight, "Double Click", Apps::SettingDoubleClick},
           {Symbols::clock, "Time format", Apps::SettingTimeFormat},
-          {Symbols::home, "Watch face", Apps::SettingWatchFace},
 
+          {Symbols::home, "Watch face", Apps::SettingWatchFace},
           {Symbols::shoe, "Steps", Apps::SettingSteps},
           {Symbols::clock, "Date&Time", Apps::SettingSetDateTime},
           {Symbols::cloudSunRain, "Weather", Apps::SettingWeatherFormat},


### PR DESCRIPTION
Listening to music while doing other stuff I wanted to have an option to skip songs. For convenience you'd need to have the watch on the music screen purposely run into the display timeout to change the music quickly without first navigating to the music app. It might be worth discussing if the double click action is not a concrete "next" action but rather a  "jump to X" action.

One thing that I did not change (although might be desirable) is that if the watch has the "Audio Next" action selected to not wake up the display controller. Feel free to comment :^)