### PR TITLE
Improve weather service

### DIFF
--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -401,103 +401,52 @@ namespace Pinetime {
       return 0;
     }
 
-    std::unique_ptr<WeatherData::Clouds>& WeatherService::GetCurrentClouds() {
+    template <class T>
+    std::unique_ptr<T>& WeatherService::GetEventOfType(WeatherData::eventtype eventType) {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Clouds && IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Clouds>&>(header);
+        if (header->eventType == eventType && IsEventStillValid(header, currentTimestamp)) {
+          return reinterpret_cast<std::unique_ptr<T>&>(header);
         }
       }
 
-      return reinterpret_cast<std::unique_ptr<WeatherData::Clouds>&>(*this->nullHeader);
+      return reinterpret_cast<std::unique_ptr<T>&>(*this->nullHeader);
+    }
+
+    std::unique_ptr<WeatherData::Clouds>& WeatherService::GetCurrentClouds() {
+      return GetEventOfType<WeatherData::Clouds>(WeatherData::eventtype::Clouds);
     }
 
     std::unique_ptr<WeatherData::Obscuration>& WeatherService::GetCurrentObscuration() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Obscuration && IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Obscuration>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Obscuration>&>(*this->nullHeader);
+      return GetEventOfType<WeatherData::Obscuration>(WeatherData::eventtype::Obscuration);
     }
 
     std::unique_ptr<WeatherData::Precipitation>& WeatherService::GetCurrentPrecipitation() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Precipitation && IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Precipitation>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Precipitation>&>(*this->nullHeader);
+      return GetEventOfType<WeatherData::Precipitation>(WeatherData::eventtype::Precipitation);
     }
 
     std::unique_ptr<WeatherData::Wind>& WeatherService::GetCurrentWind() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Wind && IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Wind>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Wind>&>(*this->nullHeader);
+      return GetEventOfType<WeatherData::Wind>(WeatherData::eventtype::Wind);
     }
 
     std::unique_ptr<WeatherData::Temperature>& WeatherService::GetCurrentTemperature() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Temperature && IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Temperature>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Temperature>&>(*this->nullHeader);
+      return GetEventOfType<WeatherData::Temperature>(WeatherData::eventtype::Temperature);
     }
 
     std::unique_ptr<WeatherData::Humidity>& WeatherService::GetCurrentHumidity() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Humidity && IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Humidity>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Humidity>&>(*this->nullHeader);
+      return GetEventOfType<WeatherData::Humidity>(WeatherData::eventtype::Humidity);
     }
 
     std::unique_ptr<WeatherData::Pressure>& WeatherService::GetCurrentPressure() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Pressure && IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Pressure>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Pressure>&>(*this->nullHeader);
+      return GetEventOfType<WeatherData::Pressure>(WeatherData::eventtype::Pressure);
     }
 
     std::unique_ptr<WeatherData::Location>& WeatherService::GetCurrentLocation() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Location && IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Location>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Location>&>(*this->nullHeader);
+      return GetEventOfType<WeatherData::Location>(WeatherData::eventtype::Location);
     }
 
     std::unique_ptr<WeatherData::AirQuality>& WeatherService::GetCurrentQuality() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::AirQuality && IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::AirQuality>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::AirQuality>&>(*this->nullHeader);
+      return GetEventOfType<WeatherData::AirQuality>(WeatherData::eventtype::AirQuality);
     }
 
     size_t WeatherService::GetTimelineLength() const {

--- a/src/components/ble/weather/WeatherService.h
+++ b/src/components/ble/weather/WeatherService.h
@@ -146,6 +146,9 @@ namespace Pinetime {
       static bool CompareTimelineEvents(const std::unique_ptr<WeatherData::TimelineHeader>& first,
                                         const std::unique_ptr<WeatherData::TimelineHeader>& second);
 
+      template <class T>
+      std::unique_ptr<T>& GetEventOfType(WeatherData::eventtype eventType);
+
       /**
        * Returns current UNIX timestamp
        */

--- a/src/components/ble/weather/WeatherService.h
+++ b/src/components/ble/weather/WeatherService.h
@@ -87,6 +87,10 @@ namespace Pinetime {
        */
       bool HasTimelineEventOfType(WeatherData::eventtype type) const;
 
+      const std::vector<std::unique_ptr<WeatherData::TimelineHeader>>& GetEventTimeline() const {
+        return timeline;
+      }
+
     private:
       // 00040000-78fc-48fe-8e23-433b3a1942d0
       static constexpr ble_uuid128_t BaseUuid() {

--- a/src/displayapp/Apps.h
+++ b/src/displayapp/Apps.h
@@ -37,6 +37,7 @@ namespace Pinetime {
       SettingChimes,
       SettingShakeThreshold,
       SettingBluetooth,
+      Weather,
       Error
     };
   }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -540,11 +540,10 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
     case Apps::Metronome:
       currentScreen = std::make_unique<Screens::Metronome>(motorController, *systemTask);
       break;
-    /* Weather debug app
+    /* Weather debug app*/
     case Apps::Weather:
       currentScreen = std::make_unique<Screens::Weather>(this, systemTask->nimble().weather());
       break;
-    */
     case Apps::Steps:
       currentScreen = std::make_unique<Screens::Steps>(motionController, settingsController);
       break;

--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -52,7 +52,7 @@ namespace Pinetime {
           {"2", Apps::Twos},
           {Symbols::drum, Apps::Metronome},
           {Symbols::map, Apps::Navigation},
-          {Symbols::none, Apps::None},
+          {"W", Apps::Weather},
 
           // {"M", Apps::Motion},
         }};

--- a/src/displayapp/screens/Weather.h
+++ b/src/displayapp/screens/Weather.h
@@ -28,7 +28,9 @@ namespace Pinetime {
 
         Controllers::WeatherService& weatherService;
 
-        ScreenList<5> screens;
+        ScreenList<6> screens;
+
+        std::unique_ptr<Screen> CreateTimelineStatsPage();
 
         std::unique_ptr<Screen> CreateScreenTemperature();
 


### PR DESCRIPTION
I wanted to investigate this issue:
[https://github.com/InfiniTimeOrg/InfiniTime/issues/1788](https://github.com/InfiniTimeOrg/InfiniTime/issues/1788)

I found some things that could be refactored, and also some issues with the current implementation:

- Already expired events are added to the timeline and deleted right afterwards. This causes unnecessary alloc/free churn and I suspect more heap fragmentation. 
- The tidying of the timeline happens after the addition of the pending event. This means that if the vector is at its capacity limit it will need to reallocate even if there are expired events that could be cleaned beforehand. 

Further investigation needs to be done here:
- Is the CBOR code (especially the one using UsefullBufC) leaking memory? (Couldnt figure out that quickly what the library expects in terms of cleanup)
- Maybe using a fixed size array and no heap allocation? This will increase the flash size, but there is less potential for runtime alloc errors?