### PR TITLE
Music: Replace placeholder text

### DIFF
--- a/src/displayapp/screens/Music.cpp
+++ b/src/displayapp/screens/Music.cpp
@@ -117,7 +117,7 @@ Music::Music(Pinetime::Controllers::MusicService& music) : musicService(music) {
   lv_obj_align(txtArtist, nullptr, LV_ALIGN_IN_LEFT_MID, 12, MIDDLE_OFFSET + 1 * FONT_HEIGHT);
   lv_label_set_align(txtArtist, LV_ALIGN_IN_LEFT_MID);
   lv_obj_set_width(txtArtist, LV_HOR_RES - 12);
-  lv_label_set_text_static(txtArtist, "Artist Name");
+  lv_label_set_text_static(txtArtist, "Waiting for");
 
   txtTrack = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtTrack, LV_LABEL_LONG_SROLL_CIRC);
@@ -125,7 +125,7 @@ Music::Music(Pinetime::Controllers::MusicService& music) : musicService(music) {
 
   lv_label_set_align(txtTrack, LV_ALIGN_IN_LEFT_MID);
   lv_obj_set_width(txtTrack, LV_HOR_RES - 12);
-  lv_label_set_text_static(txtTrack, "This is a very long getTrack name");
+  lv_label_set_text_static(txtTrack, "track information..");
 
   /** Init animation */
   imgDisc = lv_img_create(lv_scr_act(), nullptr);
@@ -204,6 +204,8 @@ void Music::Refresh() {
 void Music::UpdateLength() {
   if (totalLength > (99 * 60 * 60)) {
     lv_label_set_text_static(txtTrackDuration, "Inf/Inf");
+  } else if (totalLength == 0) {
+    lv_label_set_text_static(txtTrackDuration, "--:--/--:--");
   } else if (totalLength > (99 * 60)) {
     lv_label_set_text_fmt(txtTrackDuration,
                           "%02d:%02d/%02d:%02d",


### PR DESCRIPTION
When starting the Music app, you can see a flash of the placeholder developer text that appears.

[A video showing entering and exiting the music app, and the flash of placeholder text when entering](https://github.com/InfiniTimeOrg/InfiniTime/assets/35016761/a3ccc4bc-8164-47f2-b5bf-10dbd0e8d07e)

In some cases, the placeholder can actually stay. It appears to be when a companion app is connected but no music data is available.

This simply changes the placeholder text to the waiting text, to prevent that extra flash changing from the placeholder to the waiting state.

In the case where the placeholder stays, I also found that it will change to `00:00/00:00`, rather than `--:--/--:--`. This is a similar unnecessary flash of text, so when the total length is zero, it will show dashes instead.