### PR TITLE
Update NPM installation for containers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,13 @@
 FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=20
 RUN apt-get update -qq \
+    && apt-get install -y ca-certificates curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update -qq \
     && apt-get install -y \
 # x86_64 / generic packages
       bash \
@@ -9,13 +15,13 @@ RUN apt-get update -qq \
       cmake \
       git \
       make \
+      nodejs \
       python3 \
       python3-pip \
       python-is-python3 \
       tar \
       unzip \
       wget \
-      curl \
       # aarch64 packages
       libffi-dev \
       libssl-dev \
@@ -28,8 +34,6 @@ RUN apt-get update -qq \
       libpango-1.0-0 \
       ibpango1.0-dev \
       libpangocairo-1.0-0 \
-    && curl -sL https://deb.nodesource.com/setup_18.x | bash - \
-    && apt-get install -y nodejs \
     && rm -rf /var/cache/apt/* /var/lib/apt/lists/*;
 
 # Git needed for PROJECT_GIT_COMMIT_HASH variable setting


### PR DESCRIPTION
This resolves a deprecation warning with the `nodejs` package (#1846).