### PR TITLE
Weather service improvements and improve memory usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose Debug or Release")
 project(pinetime VERSION 1.13.0 LANGUAGES C CXX ASM)
 
 set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 # set(CMAKE_GENERATOR "Unix Makefiles")
 set(CMAKE_C_EXTENSIONS OFF)

--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -685,7 +685,21 @@ namespace Pinetime {
         return false;
       }
 
-      timeline.push_back(std::move(event));
+      auto existingEvent = std::find_if(timeline.begin(), timeline.end(), [&event](const std::unique_ptr<WeatherData::TimelineHeader>& item) {
+        return event->eventType == item->eventType;
+      });
+
+      // Add the new event in the timeline (and remove the older one) if
+      // the timeline contains an event of the same type with a longer expiry.
+      // If an event with a shorter expiry already exists, keep it and drop the new one
+      if(existingEvent == timeline.end()) {
+        timeline.push_back(std::move(event));
+      } else if(event->expires < (*existingEvent)->expires) {
+        timeline.erase(existingEvent);
+        timeline.push_back(std::move(event));
+      } else {
+        // keep the existing event and to not add this one
+      }
       return true;
     }
 

--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -21,6 +21,17 @@
 #include "libs/QCBOR/inc/qcbor/qcbor.h"
 
 namespace {
+  constexpr bool EnableObscuration = false;
+  constexpr bool EnablePrecipitation = true;
+  constexpr bool EnableWind = false;
+  constexpr bool EnableTemperature = true;
+  constexpr bool EnableAirQuality = false;
+  constexpr bool EnableSpecial = false;
+  constexpr bool EnablePressure = false;
+  constexpr bool EnableLocation = false;
+  constexpr bool EnableClouds = true;
+  constexpr bool EnableHumidity = false;
+
   std::unique_ptr<Pinetime::Controllers::WeatherData::AirQuality>
   CreateAirQualityEvent(int64_t timestamp, uint32_t expires, const std::string& polluter, uint32_t amount) {
     auto airquality = std::make_unique<Pinetime::Controllers::WeatherData::AirQuality>();
@@ -311,209 +322,219 @@ namespace Pinetime {
         }
 
         switch (*optEventType) {
-          case WeatherData::eventtype::AirQuality: {
-            auto optPolluter = Get<std::string>(&decodeContext, "Polluter");
-            if (!optPolluter) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+          case WeatherData::eventtype::AirQuality:
+            if constexpr (EnableAirQuality) {
+              auto optPolluter = Get<std::string>(&decodeContext, "Polluter");
+              if (!optPolluter) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto optAmount = Get<uint32_t>(&decodeContext, "Amount");
-            if (!optAmount) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+              auto optAmount = Get<uint32_t>(&decodeContext, "Amount");
+              if (!optAmount) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto airQuality = CreateAirQualityEvent(*optTimestamp, *optExpires, *optPolluter, *optAmount);
-            if (!AddEventToTimeline(std::move(airQuality))) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              auto airQuality = CreateAirQualityEvent(*optTimestamp, *optExpires, *optPolluter, *optAmount);
+              if (!AddEventToTimeline(std::move(airQuality))) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
             }
             break;
-          }
-          case WeatherData::eventtype::Obscuration: {
-            auto optType = Get<WeatherData::obscurationtype>(&decodeContext, "Type");
-            if (!optType) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+          case WeatherData::eventtype::Obscuration:
+            if constexpr (EnableObscuration) {
+              auto optType = Get<WeatherData::obscurationtype>(&decodeContext, "Type");
+              if (!optType) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto optAmount = Get<uint16_t>(&decodeContext, "Amount");
-            if (!optAmount) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+              auto optAmount = Get<uint16_t>(&decodeContext, "Amount");
+              if (!optAmount) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto obscuration = CreateObscurationEvent(*optTimestamp, *optExpires, *optAmount);
-            if (!AddEventToTimeline(std::move(obscuration))) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              auto obscuration = CreateObscurationEvent(*optTimestamp, *optExpires, *optAmount);
+              if (!AddEventToTimeline(std::move(obscuration))) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
             }
             break;
-          }
-          case WeatherData::eventtype::Precipitation: {
-            auto optType = Get<WeatherData::precipitationtype>(&decodeContext, "Type");
-            if (optType) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+          case WeatherData::eventtype::Precipitation:
+            if constexpr (EnablePrecipitation) {
+              auto optType = Get<WeatherData::precipitationtype>(&decodeContext, "Type");
+              if (optType) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto optAmount = Get<uint8_t>(&decodeContext, "Amount");
-            if (!optAmount) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+              auto optAmount = Get<uint8_t>(&decodeContext, "Amount");
+              if (!optAmount) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto precipitation = CreatePrecipitationEvent(*optTimestamp, *optExpires, *optType, *optAmount);
-            if (!AddEventToTimeline(std::move(precipitation))) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              auto precipitation = CreatePrecipitationEvent(*optTimestamp, *optExpires, *optType, *optAmount);
+              if (!AddEventToTimeline(std::move(precipitation))) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
             }
             break;
-          }
-          case WeatherData::eventtype::Wind: {
-            auto optMin = Get<uint8_t>(&decodeContext, "SpeedMin");
-            if (!optMin) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+          case WeatherData::eventtype::Wind:
+            if constexpr (EnableWind) {
+              auto optMin = Get<uint8_t>(&decodeContext, "SpeedMin");
+              if (!optMin) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto optMax = Get<uint8_t>(&decodeContext, "SpeedMax");
-            if (!optMax) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+              auto optMax = Get<uint8_t>(&decodeContext, "SpeedMax");
+              if (!optMax) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto optDMin = Get<uint8_t>(&decodeContext, "DirectionMin");
-            if (!optDMin) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+              auto optDMin = Get<uint8_t>(&decodeContext, "DirectionMin");
+              if (!optDMin) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto optDMax = Get<uint8_t>(&decodeContext, "DirectionMax");
-            if (!optDMax) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+              auto optDMax = Get<uint8_t>(&decodeContext, "DirectionMax");
+              if (!optDMax) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto wind = CreateWindEvent(*optTimestamp, *optExpires, *optMin, *optMax, *optDMin, *optDMax);
-            if (!AddEventToTimeline(std::move(wind))) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              auto wind = CreateWindEvent(*optTimestamp, *optExpires, *optMin, *optMax, *optDMin, *optDMax);
+              if (!AddEventToTimeline(std::move(wind))) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
             }
             break;
-          }
-          case WeatherData::eventtype::Temperature: {
-            int64_t tmpTemperature = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Temperature", &tmpTemperature);
-            if (tmpTemperature < -32768 || tmpTemperature > 32767) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+          case WeatherData::eventtype::Temperature:
+            if constexpr (EnableTemperature) {
+              int64_t tmpTemperature = 0;
+              QCBORDecode_GetInt64InMapSZ(&decodeContext, "Temperature", &tmpTemperature);
+              if (tmpTemperature < -32768 || tmpTemperature > 32767) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            int64_t tmpDewPoint = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "DewPoint", &tmpDewPoint);
-            if (tmpDewPoint < -32768 || tmpDewPoint > 32767) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+              int64_t tmpDewPoint = 0;
+              QCBORDecode_GetInt64InMapSZ(&decodeContext, "DewPoint", &tmpDewPoint);
+              if (tmpDewPoint < -32768 || tmpDewPoint > 32767) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto temperature =
-              CreateTemperatureEvent(*optTimestamp, *optExpires, static_cast<int16_t>(tmpTemperature), static_cast<int16_t>(tmpDewPoint));
-            if (!AddEventToTimeline(std::move(temperature))) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              auto temperature =
+                CreateTemperatureEvent(*optTimestamp, *optExpires, static_cast<int16_t>(tmpTemperature), static_cast<int16_t>(tmpDewPoint));
+              if (!AddEventToTimeline(std::move(temperature))) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
             }
             break;
-          }
-          case WeatherData::eventtype::Special: {
-            auto optType = Get<WeatherData::specialtype>(&decodeContext, "Type");
-            if (!optType) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+          case WeatherData::eventtype::Special:
+            if constexpr (EnableSpecial) {
+              auto optType = Get<WeatherData::specialtype>(&decodeContext, "Type");
+              if (!optType) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto special = CreateSpecialEvent(*optTimestamp, *optExpires, *optType);
-            if (!AddEventToTimeline(std::move(special))) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              auto special = CreateSpecialEvent(*optTimestamp, *optExpires, *optType);
+              if (!AddEventToTimeline(std::move(special))) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
             }
             break;
-          }
-          case WeatherData::eventtype::Pressure: {
-            auto optPressure = Get<uint16_t>(&decodeContext, "Pressure");
-            if (!optPressure) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+          case WeatherData::eventtype::Pressure:
+            if constexpr (EnablePressure) {
+              auto optPressure = Get<uint16_t>(&decodeContext, "Pressure");
+              if (!optPressure) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto pressure = CreatePressureEvent(*optTimestamp, *optExpires, *optPressure);
-            if (!AddEventToTimeline(std::move(pressure))) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              auto pressure = CreatePressureEvent(*optTimestamp, *optExpires, *optPressure);
+              if (!AddEventToTimeline(std::move(pressure))) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
             }
             break;
-          }
-          case WeatherData::eventtype::Location: {
-            auto optLocation = Get<std::string>(&decodeContext, "Location");
-            if (!optLocation) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+          case WeatherData::eventtype::Location:
+            if constexpr (EnableLocation) {
+              auto optLocation = Get<std::string>(&decodeContext, "Location");
+              if (!optLocation) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto optAltitude = Get<int16_t>(&decodeContext, "Altitude");
-            if (!optAltitude) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+              auto optAltitude = Get<int16_t>(&decodeContext, "Altitude");
+              if (!optAltitude) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto optLatitude = Get<int32_t>(&decodeContext, "Latitude");
-            if (!optLatitude) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+              auto optLatitude = Get<int32_t>(&decodeContext, "Latitude");
+              if (!optLatitude) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto optLongitude = Get<int32_t>(&decodeContext, "Longitude");
-            if (!optLongitude) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+              auto optLongitude = Get<int32_t>(&decodeContext, "Longitude");
+              if (!optLongitude) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto location = CreateLocationEvent(*optTimestamp, *optExpires, *optLocation, *optAltitude, *optLatitude, *optLongitude);
-            if (!AddEventToTimeline(std::move(location))) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              auto location = CreateLocationEvent(*optTimestamp, *optExpires, *optLocation, *optAltitude, *optLatitude, *optLongitude);
+              if (!AddEventToTimeline(std::move(location))) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
             }
             break;
-          }
-          case WeatherData::eventtype::Clouds: {
-            auto optAmount = Get<uint8_t>(&decodeContext, "Amount");
-            if (!optAmount) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+          case WeatherData::eventtype::Clouds:
+            if constexpr (EnableClouds) {
+              auto optAmount = Get<uint8_t>(&decodeContext, "Amount");
+              if (!optAmount) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto clouds = CreateCloudsEvent(*optTimestamp, *optExpires, *optAmount);
-            if (!AddEventToTimeline(std::move(clouds))) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              auto clouds = CreateCloudsEvent(*optTimestamp, *optExpires, *optAmount);
+              if (!AddEventToTimeline(std::move(clouds))) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
             }
             break;
-          }
-          case WeatherData::eventtype::Humidity: {
-            auto optType = Get<uint8_t>(&decodeContext, "Humidity");
-            if (!optType) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-            }
+          case WeatherData::eventtype::Humidity:
+            if constexpr (EnableHumidity) {
+              auto optType = Get<uint8_t>(&decodeContext, "Humidity");
+              if (!optType) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
 
-            auto humidity = CreateHumidityEvent(*optTimestamp, *optExpires, *optType);
-            if (!AddEventToTimeline(std::move(humidity))) {
-              CleanUpQcbor(&decodeContext);
-              return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              auto humidity = CreateHumidityEvent(*optTimestamp, *optExpires, *optType);
+              if (!AddEventToTimeline(std::move(humidity))) {
+                CleanUpQcbor(&decodeContext);
+                return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+              }
             }
             break;
-          }
           default: {
             CleanUpQcbor(&decodeContext);
             return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;

--- a/src/components/ble/weather/WeatherService.h
+++ b/src/components/ble/weather/WeatherService.h
@@ -99,6 +99,8 @@ namespace Pinetime {
                               .value = {0xd0, 0x42, 0x19, 0x3a, 0x3b, 0x43, 0x23, 0x8e, 0xfe, 0x48, 0xfc, 0x78, y, x, 0x04, 0x00}};
       }
 
+      static constexpr size_t maxNbElements = 10;
+
       ble_uuid128_t weatherUuid {BaseUuid()};
 
       /**

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -537,11 +537,22 @@ void WatchFacePineTimeStyle::Refresh() {
     }
   }
 
-  if (weatherService.GetCurrentTemperature()->timestamp != 0 && weatherService.GetCurrentClouds()->timestamp != 0 &&
-      weatherService.GetCurrentPrecipitation()->timestamp != 0) {
+  const auto& newTemperatureEvent = weatherService.GetCurrentTemperature();
+  const auto& newCloudsEvent = weatherService.GetCurrentClouds();
+  const auto& newPrecipitationEvent = weatherService.GetCurrentPrecipitation();
+
+  if(newTemperatureEvent->timestamp == 0 && newCloudsEvent->timestamp == 0 && newPrecipitationEvent == 0) {
+    lv_label_set_text_static(temperature, "--");
+    lv_label_set_text(weatherIcon, Symbols::ban);
+    lv_obj_realign(temperature);
+    lv_obj_realign(weatherIcon);
+  }
+
+  // Assume 0 precipitation if no precipitation event were received
+  if (newTemperatureEvent->timestamp != 0 && newCloudsEvent->timestamp != 0 /*&& newPrecipitationEvent->timestamp !=0*/) {
     nowTemp = (weatherService.GetCurrentTemperature()->temperature / 100);
     clouds = (weatherService.GetCurrentClouds()->amount);
-    precip = (weatherService.GetCurrentPrecipitation()->amount);
+    precip = (newPrecipitationEvent->timestamp != 0) ? weatherService.GetCurrentPrecipitation()->amount : 0;
     if (nowTemp.IsUpdated()) {
       lv_label_set_text_fmt(temperature, "%d°", nowTemp.Get());
       if ((clouds <= 30) && (precip == 0)) {


### PR DESCRIPTION
This branch implements the suggestion I did in [this comment](https://github.com/InfiniTimeOrg/InfiniTime/pull/1822#issuecomment-1712842416) in #1822: 

 - Disable all weather events that are not processed by InfiniTime
 - Ensure that a single version of each event is stored in memory
 - Set the maximum number of events in the timeline to 10
 
Additionally, it also improves PTS : it now refreshes the weather info even if it didn't receive any precipitation event (assume no precipitation in that case).

I'm not satisfied with the policy that decides which "version" of the event will be stored in the timeline. The policy I implemented here 
 - adds the event if no event of the same type already exists
 - remove the old one and add the new one if the new one has a lower expiry time
 - otherwise, keep the one from the timeline 

I'm open to suggestions for a better policy :)