### PR TITLE
workflows: Fix InfiniSim CI build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,10 +61,10 @@ jobs:
   build-simulator:
     runs-on: ubuntu-22.04
     steps:
-    - name: Install SDL2 development package
+    - name: Install SDL2 and libpng development package
       run:  |
         sudo apt-get update
-        sudo apt-get -y install libsdl2-dev
+        sudo apt-get -y install libsdl2-dev libpng-dev
 
     - name: Install Ninja
       run:  |
@@ -82,7 +82,7 @@ jobs:
     - name: Get InfiniSim repo
       run:  |
         git clone https://github.com/InfiniTimeOrg/InfiniSim.git --depth 1 --branch main
-        git -C InfiniSim submodule update --init lv_drivers libpng
+        git -C InfiniSim submodule update --init lv_drivers
 
     - name: CMake
       # disable BUILD_RESOURCES as this is already done when building the firmware


### PR DESCRIPTION
InfiniSim has removed the libpng submodule and moved it to a system dependency. See InfiniTimeOrg/InfiniSim#119.