### PR TITLE
Open battery app when charging

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -362,7 +362,16 @@ void DisplayApp::Refresh() {
         break;
       case Messages::OnChargingEvent:
         RestoreBrightness();
-        motorController.RunForDuration(15);
+	if (batteryController.IsCharging() && currentApp == Apps::Clock) {
+	  // Open the battery app if on the clock screen
+	  LoadNewScreen(Apps::BatteryInfo, DisplayApp::FullRefreshDirections::None);
+	} else if (!batteryController.IsCharging() && currentApp == Apps::BatteryInfo) {
+	  // Close the battery app after being unplugged
+	  LoadNewScreen(Apps::Clock, DisplayApp::FullRefreshDirections::None);
+	} else {
+	  // Vibrate normally otherwise as to not close any open app
+	  motorController.RunForDuration(15);
+	}
         break;
     }
   }


### PR DESCRIPTION
This change makes the battery info app open upon putting the watch on the charger, if the current app is the clock (as to not close any app that might be running). If the watch is taken off the charger while the battery app is open, it returns to the clock. 

This pr also removes the vibration while charging if the battery app is opened/closed, which should help prevent #724.