### PR TITLE
weather: Fix GetCurrent* functions returning future events

### DIFF
--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -404,7 +404,8 @@ namespace Pinetime {
     std::unique_ptr<WeatherData::Clouds>& WeatherService::GetCurrentClouds() {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Clouds && IsEventStillValid(header, currentTimestamp)) {
+        if (header->eventType == WeatherData::eventtype::Clouds && currentTimestamp >= header->timestamp &&
+            IsEventStillValid(header, currentTimestamp)) {
           return reinterpret_cast<std::unique_ptr<WeatherData::Clouds>&>(header);
         }
       }
@@ -415,7 +416,8 @@ namespace Pinetime {
     std::unique_ptr<WeatherData::Obscuration>& WeatherService::GetCurrentObscuration() {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Obscuration && IsEventStillValid(header, currentTimestamp)) {
+        if (header->eventType == WeatherData::eventtype::Obscuration && currentTimestamp >= header->timestamp &&
+            IsEventStillValid(header, currentTimestamp)) {
           return reinterpret_cast<std::unique_ptr<WeatherData::Obscuration>&>(header);
         }
       }
@@ -426,7 +428,8 @@ namespace Pinetime {
     std::unique_ptr<WeatherData::Precipitation>& WeatherService::GetCurrentPrecipitation() {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Precipitation && IsEventStillValid(header, currentTimestamp)) {
+        if (header->eventType == WeatherData::eventtype::Precipitation && currentTimestamp >= header->timestamp &&
+            IsEventStillValid(header, currentTimestamp)) {
           return reinterpret_cast<std::unique_ptr<WeatherData::Precipitation>&>(header);
         }
       }
@@ -437,7 +440,8 @@ namespace Pinetime {
     std::unique_ptr<WeatherData::Wind>& WeatherService::GetCurrentWind() {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Wind && IsEventStillValid(header, currentTimestamp)) {
+        if (header->eventType == WeatherData::eventtype::Wind && currentTimestamp >= header->timestamp &&
+            IsEventStillValid(header, currentTimestamp)) {
           return reinterpret_cast<std::unique_ptr<WeatherData::Wind>&>(header);
         }
       }
@@ -448,7 +452,8 @@ namespace Pinetime {
     std::unique_ptr<WeatherData::Temperature>& WeatherService::GetCurrentTemperature() {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Temperature && IsEventStillValid(header, currentTimestamp)) {
+        if (header->eventType == WeatherData::eventtype::Temperature && currentTimestamp >= header->timestamp &&
+            IsEventStillValid(header, currentTimestamp)) {
           return reinterpret_cast<std::unique_ptr<WeatherData::Temperature>&>(header);
         }
       }
@@ -459,7 +464,8 @@ namespace Pinetime {
     std::unique_ptr<WeatherData::Humidity>& WeatherService::GetCurrentHumidity() {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Humidity && IsEventStillValid(header, currentTimestamp)) {
+        if (header->eventType == WeatherData::eventtype::Humidity && currentTimestamp >= header->timestamp &&
+            IsEventStillValid(header, currentTimestamp)) {
           return reinterpret_cast<std::unique_ptr<WeatherData::Humidity>&>(header);
         }
       }
@@ -470,7 +476,8 @@ namespace Pinetime {
     std::unique_ptr<WeatherData::Pressure>& WeatherService::GetCurrentPressure() {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Pressure && IsEventStillValid(header, currentTimestamp)) {
+        if (header->eventType == WeatherData::eventtype::Pressure && currentTimestamp >= header->timestamp &&
+            IsEventStillValid(header, currentTimestamp)) {
           return reinterpret_cast<std::unique_ptr<WeatherData::Pressure>&>(header);
         }
       }
@@ -481,7 +488,8 @@ namespace Pinetime {
     std::unique_ptr<WeatherData::Location>& WeatherService::GetCurrentLocation() {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Location && IsEventStillValid(header, currentTimestamp)) {
+        if (header->eventType == WeatherData::eventtype::Location && currentTimestamp >= header->timestamp &&
+            IsEventStillValid(header, currentTimestamp)) {
           return reinterpret_cast<std::unique_ptr<WeatherData::Location>&>(header);
         }
       }
@@ -492,7 +500,8 @@ namespace Pinetime {
     std::unique_ptr<WeatherData::AirQuality>& WeatherService::GetCurrentQuality() {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::AirQuality && IsEventStillValid(header, currentTimestamp)) {
+        if (header->eventType == WeatherData::eventtype::AirQuality && currentTimestamp >= header->timestamp &&
+            IsEventStillValid(header, currentTimestamp)) {
           return reinterpret_cast<std::unique_ptr<WeatherData::AirQuality>&>(header);
         }
       }


### PR DESCRIPTION
It was potentially possible that an event with a timestamp in the future could be returned as a current event.