### PR TITLE
Show alarm controller state in status icons

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -526,6 +526,7 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
                                                                  settingsController,
                                                                  batteryController,
                                                                  bleController,
+                                                                 alarmController,
                                                                  dateTimeController,
                                                                  filesystem,
                                                                  std::move(apps));
@@ -580,7 +581,8 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
                                                                brightnessController,
                                                                motorController,
                                                                settingsController,
-                                                               bleController);
+                                                               bleController,
+                                                               alarmController);
       break;
     case Apps::Settings:
       currentScreen = std::make_unique<Screens::Settings>(this, settingsController);

--- a/src/displayapp/screens/ApplicationList.cpp
+++ b/src/displayapp/screens/ApplicationList.cpp
@@ -21,6 +21,7 @@ ApplicationList::ApplicationList(DisplayApp* app,
                                  Pinetime::Controllers::Settings& settingsController,
                                  const Pinetime::Controllers::Battery& batteryController,
                                  const Pinetime::Controllers::Ble& bleController,
+                                 const Pinetime::Controllers::AlarmController& alarmController,
                                  Controllers::DateTime& dateTimeController,
                                  Pinetime::Controllers::FS& filesystem,
                                  std::array<Tile::Applications, UserAppTypes::Count>&& apps)
@@ -28,6 +29,7 @@ ApplicationList::ApplicationList(DisplayApp* app,
     settingsController {settingsController},
     batteryController {batteryController},
     bleController {bleController},
+    alarmController {alarmController},
     dateTimeController {dateTimeController},
     filesystem {filesystem},
     apps {std::move(apps)},
@@ -59,6 +61,7 @@ std::unique_ptr<Screen> ApplicationList::CreateScreen(unsigned int screenNum) co
                                          settingsController,
                                          batteryController,
                                          bleController,
+                                         alarmController,
                                          dateTimeController,
                                          pageApps);
 }

--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -18,6 +18,7 @@ namespace Pinetime {
                                  Pinetime::Controllers::Settings& settingsController,
                                  const Pinetime::Controllers::Battery& batteryController,
                                  const Pinetime::Controllers::Ble& bleController,
+                                 const Pinetime::Controllers::AlarmController& alarmController,
                                  Controllers::DateTime& dateTimeController,
                                  Pinetime::Controllers::FS& filesystem,
                                  std::array<Tile::Applications, UserAppTypes::Count>&& apps);
@@ -32,6 +33,7 @@ namespace Pinetime {
         Controllers::Settings& settingsController;
         const Pinetime::Controllers::Battery& batteryController;
         const Pinetime::Controllers::Ble& bleController;
+        const Pinetime::Controllers::AlarmController& alarmController;
         Controllers::DateTime& dateTimeController;
         Pinetime::Controllers::FS& filesystem;
         std::array<Tile::Applications, UserAppTypes::Count> apps;

--- a/src/displayapp/screens/Tile.cpp
+++ b/src/displayapp/screens/Tile.cpp
@@ -29,9 +29,13 @@ Tile::Tile(uint8_t screenID,
            Controllers::Settings& settingsController,
            const Controllers::Battery& batteryController,
            const Controllers::Ble& bleController,
+           const Controllers::AlarmController& alarmController,
            Controllers::DateTime& dateTimeController,
            std::array<Applications, 6>& applications)
-  : app {app}, dateTimeController {dateTimeController}, pageIndicator(screenID, numScreens), statusIcons(batteryController, bleController) {
+  : app {app},
+    dateTimeController {dateTimeController},
+    pageIndicator(screenID, numScreens),
+    statusIcons(batteryController, bleController, alarmController) {
 
   settingsController.SetAppMenu(screenID);
 

--- a/src/displayapp/screens/Tile.h
+++ b/src/displayapp/screens/Tile.h
@@ -28,6 +28,7 @@ namespace Pinetime {
                       Controllers::Settings& settingsController,
                       const Controllers::Battery& batteryController,
                       const Controllers::Ble& bleController,
+                      const Controllers::AlarmController& alarmController,
                       Controllers::DateTime& dateTimeController,
                       std::array<Applications, 6>& applications);
 

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -19,6 +19,7 @@ using namespace Pinetime::Applications::Screens;
 WatchFaceDigital::WatchFaceDigital(Controllers::DateTime& dateTimeController,
                                    const Controllers::Battery& batteryController,
                                    const Controllers::Ble& bleController,
+                                   const Controllers::AlarmController& alarmController,
                                    Controllers::NotificationManager& notificationManager,
                                    Controllers::Settings& settingsController,
                                    Controllers::HeartRateController& heartRateController,
@@ -31,7 +32,7 @@ WatchFaceDigital::WatchFaceDigital(Controllers::DateTime& dateTimeController,
     heartRateController {heartRateController},
     motionController {motionController},
     weatherService {weatherService},
-    statusIcons(batteryController, bleController) {
+    statusIcons(batteryController, bleController, alarmController) {
 
   statusIcons.Create();
 

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -17,6 +17,7 @@ namespace Pinetime {
     class Settings;
     class Battery;
     class Ble;
+    class AlarmController;
     class NotificationManager;
     class HeartRateController;
     class MotionController;
@@ -30,6 +31,7 @@ namespace Pinetime {
         WatchFaceDigital(Controllers::DateTime& dateTimeController,
                          const Controllers::Battery& batteryController,
                          const Controllers::Ble& bleController,
+                         const Controllers::AlarmController& alarmController,
                          Controllers::NotificationManager& notificationManager,
                          Controllers::Settings& settingsController,
                          Controllers::HeartRateController& heartRateController,
@@ -84,6 +86,7 @@ namespace Pinetime {
         return new Screens::WatchFaceDigital(controllers.dateTimeController,
                                              controllers.batteryController,
                                              controllers.bleController,
+                                             controllers.alarmController,
                                              controllers.notificationManager,
                                              controllers.settingsController,
                                              controllers.heartRateController,

--- a/src/displayapp/screens/settings/QuickSettings.cpp
+++ b/src/displayapp/screens/settings/QuickSettings.cpp
@@ -33,13 +33,14 @@ QuickSettings::QuickSettings(Pinetime::Applications::DisplayApp* app,
                              Controllers::BrightnessController& brightness,
                              Controllers::MotorController& motorController,
                              Pinetime::Controllers::Settings& settingsController,
-                             const Controllers::Ble& bleController)
+                             const Controllers::Ble& bleController,
+                             const Controllers::AlarmController& alarmController)
   : app {app},
     dateTimeController {dateTimeController},
     brightness {brightness},
     motorController {motorController},
     settingsController {settingsController},
-    statusIcons(batteryController, bleController) {
+    statusIcons(batteryController, bleController, alarmController) {
 
   statusIcons.Create();
 

--- a/src/displayapp/screens/settings/QuickSettings.h
+++ b/src/displayapp/screens/settings/QuickSettings.h
@@ -23,7 +23,8 @@ namespace Pinetime {
                       Controllers::BrightnessController& brightness,
                       Controllers::MotorController& motorController,
                       Pinetime::Controllers::Settings& settingsController,
-                      const Controllers::Ble& bleController);
+                      const Controllers::Ble& bleController,
+                      const Controllers::AlarmController& alarmController);
 
         ~QuickSettings() override;
 

--- a/src/displayapp/widgets/StatusIcons.cpp
+++ b/src/displayapp/widgets/StatusIcons.cpp
@@ -1,10 +1,13 @@
 #include "displayapp/widgets/StatusIcons.h"
 #include "displayapp/screens/Symbols.h"
+#include "components/alarm/AlarmController.h"
 
 using namespace Pinetime::Applications::Widgets;
 
-StatusIcons::StatusIcons(const Controllers::Battery& batteryController, const Controllers::Ble& bleController)
-  : batteryIcon(true), batteryController {batteryController}, bleController {bleController} {
+StatusIcons::StatusIcons(const Controllers::Battery& batteryController,
+                         const Controllers::Ble& bleController,
+                         const Controllers::AlarmController& alarmController)
+  : batteryIcon(true), batteryController {batteryController}, bleController {bleController}, alarmController {alarmController} {
 }
 
 void StatusIcons::Create() {
@@ -19,6 +22,9 @@ void StatusIcons::Create() {
 
   batteryPlug = lv_label_create(container, nullptr);
   lv_label_set_text_static(batteryPlug, Screens::Symbols::plug);
+
+  alarmIcon = lv_label_create(container, nullptr);
+  lv_label_set_text_static(alarmIcon, Screens::Symbols::bell);
 
   batteryIcon.Create(container);
 
@@ -35,6 +41,11 @@ void StatusIcons::Update() {
   if (batteryPercentRemaining.IsUpdated()) {
     auto batteryPercent = batteryPercentRemaining.Get();
     batteryIcon.SetBatteryPercentage(batteryPercent);
+  }
+
+  alarmEnabled = alarmController.IsEnabled();
+  if (alarmEnabled.IsUpdated()) {
+    lv_obj_set_hidden(alarmIcon, !alarmEnabled.Get());
   }
 
   bleState = bleController.IsConnected();

--- a/src/displayapp/widgets/StatusIcons.h
+++ b/src/displayapp/widgets/StatusIcons.h
@@ -5,6 +5,7 @@
 #include "displayapp/screens/Screen.h"
 #include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
+#include "components/alarm/AlarmController.h"
 #include "displayapp/screens/BatteryIcon.h"
 #include "utility/DirtyValue.h"
 
@@ -13,7 +14,9 @@ namespace Pinetime {
     namespace Widgets {
       class StatusIcons {
       public:
-        StatusIcons(const Controllers::Battery& batteryController, const Controllers::Ble& bleController);
+        StatusIcons(const Controllers::Battery& batteryController,
+                    const Controllers::Ble& bleController,
+                    const Controllers::AlarmController& alarmController);
         void Align();
         void Create();
 
@@ -27,13 +30,16 @@ namespace Pinetime {
         Screens::BatteryIcon batteryIcon;
         const Pinetime::Controllers::Battery& batteryController;
         const Controllers::Ble& bleController;
+        const Controllers::AlarmController& alarmController;
 
         Utility::DirtyValue<uint8_t> batteryPercentRemaining {};
         Utility::DirtyValue<bool> powerPresent {};
         Utility::DirtyValue<bool> bleState {};
         Utility::DirtyValue<bool> bleRadioEnabled {};
+        Utility::DirtyValue<bool> alarmEnabled {};
 
         lv_obj_t* bleIcon;
+        lv_obj_t* alarmIcon;
         lv_obj_t* batteryPlug;
         lv_obj_t* container;
       };


### PR DESCRIPTION
I would like to know if the alarm is active on Watch Face Digital screen. 

I made an prototype with InfiniSim and it looks that it works as expected:

![screenshot-alarm-indicator](https://github.com/user-attachments/assets/ddbc31f0-57ba-4bd9-a3b1-7fee385ee1a5) ![InfiniSim_2024-12-22_141530](https://github.com/user-attachments/assets/e4287bf6-7d34-4e50-958d-d9cfeea69837)



However, I have only sealed version of PineTime and this is my first attempt to make something for embedded device. I will be happy if someone can check if this actually works on real device. I am looking forward for your feedback. 
