### PR TITLE
Improve weather service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose Debug or Release")
 project(pinetime VERSION 1.13.0 LANGUAGES C CXX ASM)
 
 set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 # set(CMAKE_GENERATOR "Unix Makefiles")
 set(CMAKE_C_EXTENSIONS OFF)

--- a/src/components/ble/weather/WeatherData.h
+++ b/src/components/ble/weather/WeatherData.h
@@ -199,6 +199,10 @@ namespace Pinetime {
          */
         uint32_t expires;
         /**
+         * Unique ID for this event
+         */
+        uint16_t eventID;
+        /**
          * What type of weather-related event
          */
         eventtype eventType;

--- a/src/components/ble/weather/WeatherData.h
+++ b/src/components/ble/weather/WeatherData.h
@@ -179,6 +179,8 @@ namespace Pinetime {
         eventtype eventType;
       };
 
+#pragma pack(1)
+
       /** The header used for further parsing */
       class TimelineHeader {
       public:
@@ -380,6 +382,8 @@ namespace Pinetime {
          */
         uint32_t amount;
       };
+
+#pragma pack()
     };
   }
 }

--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -16,9 +16,248 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 #include <algorithm>
+#include <cstdint>
 #include <qcbor/qcbor_spiffy_decode.h>
 #include "WeatherService.h"
 #include "libs/QCBOR/inc/qcbor/qcbor.h"
+
+namespace {
+  std::unique_ptr<Pinetime::Controllers::WeatherData::AirQuality>
+  CreateAirQualityEvent(uint64_t timestamp, uint32_t expires, const std::string& polluter, uint32_t amount) {
+    auto airquality = std::make_unique<Pinetime::Controllers::WeatherData::AirQuality>();
+    airquality->timestamp = timestamp;
+    airquality->eventType = Pinetime::Controllers::WeatherData::eventtype::AirQuality;
+    airquality->expires = expires;
+    airquality->polluter = polluter;
+    airquality->amount = amount;
+    return airquality;
+  }
+
+  std::unique_ptr<Pinetime::Controllers::WeatherData::Obscuration>
+  CreateObscurationEvent(uint64_t timestamp, uint32_t expires, uint16_t amount) {
+    auto obscuration = std::make_unique<Pinetime::Controllers::WeatherData::Obscuration>();
+    obscuration->timestamp = timestamp;
+    obscuration->eventType = Pinetime::Controllers::WeatherData::eventtype::Obscuration;
+    obscuration->expires = expires;
+    obscuration->amount = amount;
+    return obscuration;
+  }
+
+  std::unique_ptr<Pinetime::Controllers::WeatherData::Precipitation>
+  CreatePrecipitationEvent(uint64_t timestamp,
+                           uint32_t expires,
+                           Pinetime::Controllers::WeatherData::precipitationtype type,
+                           uint8_t amount) {
+    auto precipitation = std::make_unique<Pinetime::Controllers::WeatherData::Precipitation>();
+    precipitation->timestamp = timestamp;
+    precipitation->eventType = Pinetime::Controllers::WeatherData::eventtype::Precipitation;
+    precipitation->expires = expires;
+    precipitation->type = type;
+    precipitation->amount = amount;
+    return precipitation;
+  }
+
+  std::unique_ptr<Pinetime::Controllers::WeatherData::Wind>
+  CreateWindEvent(uint64_t timestamp, uint32_t expires, uint8_t speedMin, uint8_t speedMax, uint8_t directionMin, uint8_t directionMax) {
+    auto wind = std::make_unique<Pinetime::Controllers::WeatherData::Wind>();
+    wind->timestamp = timestamp;
+    wind->eventType = Pinetime::Controllers::WeatherData::eventtype::Wind;
+    wind->expires = expires;
+    wind->speedMin = speedMin;
+    wind->speedMax = speedMax;
+    wind->directionMin = directionMin;
+    wind->directionMax = directionMax;
+    return wind;
+  }
+
+  std::unique_ptr<Pinetime::Controllers::WeatherData::Temperature>
+  CreateTemperatureEvent(uint64_t timestamp, uint32_t expires, int16_t temperatureValue, uint16_t dewPoint) {
+    auto temperature = std::make_unique<Pinetime::Controllers::WeatherData::Temperature>();
+    temperature->timestamp = timestamp;
+    temperature->eventType = Pinetime::Controllers::WeatherData::eventtype::Temperature;
+    temperature->expires = expires;
+    temperature->temperature = temperatureValue;
+    temperature->dewPoint = dewPoint;
+    return temperature;
+  }
+
+  std::unique_ptr<Pinetime::Controllers::WeatherData::Special>
+  CreateSpecialEvent(uint64_t timestamp, uint32_t expires, Pinetime::Controllers::WeatherData::specialtype type) {
+    auto special = std::make_unique<Pinetime::Controllers::WeatherData::Special>();
+    special->timestamp = timestamp;
+    special->eventType = Pinetime::Controllers::WeatherData::eventtype::Special;
+    special->expires = expires;
+    special->type = type;
+    return special;
+  }
+
+  std::unique_ptr<Pinetime::Controllers::WeatherData::Pressure>
+  CreatePressureEvent(uint64_t timestamp, uint32_t expires, uint16_t pressureValue) {
+    auto pressure = std::make_unique<Pinetime::Controllers::WeatherData::Pressure>();
+    pressure->timestamp = timestamp;
+    pressure->eventType = Pinetime::Controllers::WeatherData::eventtype::Pressure;
+    pressure->expires = expires;
+    pressure->pressure = pressureValue;
+    return pressure;
+  }
+
+  std::unique_ptr<Pinetime::Controllers::WeatherData::Location> CreateLocationEvent(uint64_t timestamp,
+                                                                                    uint32_t expires,
+                                                                                    const std::string& locationValue,
+                                                                                    int16_t altitude,
+                                                                                    int32_t latitude,
+                                                                                    int32_t longitude) {
+    auto location = std::make_unique<Pinetime::Controllers::WeatherData::Location>();
+    location->timestamp = timestamp;
+    location->eventType = Pinetime::Controllers::WeatherData::eventtype::Location;
+    location->expires = expires;
+    location->location = locationValue;
+    location->altitude = altitude;
+    location->latitude = latitude;
+    location->longitude = longitude;
+    return location;
+  }
+
+  std::unique_ptr<Pinetime::Controllers::WeatherData::Clouds> CreateCloudsEvent(uint64_t timestamp, uint32_t expires, uint8_t amount) {
+    auto clouds = std::make_unique<Pinetime::Controllers::WeatherData::Clouds>();
+    clouds->timestamp = timestamp;
+    clouds->eventType = Pinetime::Controllers::WeatherData::eventtype::Clouds;
+    clouds->expires = expires;
+    clouds->amount = amount;
+    return clouds;
+  }
+
+  std::unique_ptr<Pinetime::Controllers::WeatherData::Humidity>
+  CreateHumidityEvent(uint64_t timestamp, uint32_t expires, uint8_t humidityValue) {
+    auto humidity = std::make_unique<Pinetime::Controllers::WeatherData::Humidity>();
+    humidity->timestamp = timestamp;
+    humidity->eventType = Pinetime::Controllers::WeatherData::eventtype::Humidity;
+    humidity->expires = expires;
+    humidity->humidity = humidityValue;
+    return humidity;
+  }
+
+  template <typename T>
+  std::optional<T> Get(QCBORDecodeContext* /*context*/, const char* /*field*/) = delete;
+
+  template <>
+  std::optional<uint64_t> Get<uint64_t>(QCBORDecodeContext* context, const char* field) {
+    int64_t tmp = 0;
+    QCBORDecode_GetInt64InMapSZ(context, field, &tmp);
+    if (QCBORDecode_GetError(context) != QCBOR_SUCCESS) {
+      return {};
+    }
+    return {static_cast<uint64_t>(tmp)};
+  }
+
+  template <>
+  std::optional<uint32_t> Get<uint32_t>(QCBORDecodeContext* context, const char* field) {
+    int64_t tmp = 0;
+    QCBORDecode_GetInt64InMapSZ(context, field, &tmp);
+    if (QCBORDecode_GetError(context) != QCBOR_SUCCESS || tmp < 0 || tmp > UINT32_MAX) {
+      return {};
+    }
+    return {static_cast<uint32_t>(tmp)};
+  }
+
+  template <>
+  std::optional<int32_t> Get<int32_t>(QCBORDecodeContext* context, const char* field) {
+    int64_t tmp = 0;
+    QCBORDecode_GetInt64InMapSZ(context, field, &tmp);
+    if (QCBORDecode_GetError(context) != QCBOR_SUCCESS || tmp < INT32_MIN || tmp > INT32_MAX) {
+      return {};
+    }
+    return {static_cast<int32_t>(tmp)};
+  }
+
+  template <>
+  std::optional<uint16_t> Get<uint16_t>(QCBORDecodeContext* context, const char* field) {
+    int64_t tmp = 0;
+    QCBORDecode_GetInt64InMapSZ(context, field, &tmp);
+    if (QCBORDecode_GetError(context) != QCBOR_SUCCESS || tmp < 0 || tmp > UINT16_MAX) {
+      return {};
+    }
+    return {static_cast<uint16_t>(tmp)};
+  }
+
+  template <>
+  std::optional<int16_t> Get<int16_t>(QCBORDecodeContext* context, const char* field) {
+    int64_t tmp = 0;
+    QCBORDecode_GetInt64InMapSZ(context, field, &tmp);
+    if (QCBORDecode_GetError(context) != QCBOR_SUCCESS || tmp < INT16_MIN || tmp > INT16_MAX) {
+      return {};
+    }
+    return {static_cast<int16_t>(tmp)};
+  }
+
+  template <>
+  std::optional<uint8_t> Get<uint8_t>(QCBORDecodeContext* context, const char* field) {
+    int64_t tmp = 0;
+    QCBORDecode_GetInt64InMapSZ(context, field, &tmp);
+    if (QCBORDecode_GetError(context) != QCBOR_SUCCESS || tmp < 0 || tmp > UINT8_MAX) {
+      return {};
+    }
+    return {static_cast<uint8_t>(tmp)};
+  }
+
+  template <>
+  std::optional<Pinetime::Controllers::WeatherData::eventtype>
+  Get<Pinetime::Controllers::WeatherData::eventtype>(QCBORDecodeContext* context, const char* field) {
+    int64_t tmp = 0;
+    QCBORDecode_GetInt64InMapSZ(context, field, &tmp);
+    if (QCBORDecode_GetError(context) != QCBOR_SUCCESS || tmp < 0 ||
+        tmp >= static_cast<int64_t>(Pinetime::Controllers::WeatherData::eventtype::Length)) {
+      return {};
+    }
+    return {static_cast<Pinetime::Controllers::WeatherData::eventtype>(tmp)};
+  }
+
+  template <>
+  std::optional<std::string> Get<std::string>(QCBORDecodeContext* context, const char* field) {
+    UsefulBufC stringBuf;
+    QCBORDecode_GetTextStringInMapSZ(context, field, &stringBuf);
+    if (UsefulBuf_IsNULLOrEmptyC(stringBuf) != 0) {
+      return {};
+    }
+    return {std::string(static_cast<const char*>(stringBuf.ptr), stringBuf.len)};
+  }
+
+  template <>
+  std::optional<Pinetime::Controllers::WeatherData::obscurationtype>
+  Get<Pinetime::Controllers::WeatherData::obscurationtype>(QCBORDecodeContext* context, const char* field) {
+    int64_t tmp = 0;
+    QCBORDecode_GetInt64InMapSZ(context, field, &tmp);
+    if (QCBORDecode_GetError(context) != QCBOR_SUCCESS || tmp < 0 ||
+        tmp >= static_cast<int64_t>(Pinetime::Controllers::WeatherData::obscurationtype::Length)) {
+      return {};
+    }
+    return {static_cast<Pinetime::Controllers::WeatherData::obscurationtype>(tmp)};
+  }
+
+  template <>
+  std::optional<Pinetime::Controllers::WeatherData::precipitationtype>
+  Get<Pinetime::Controllers::WeatherData::precipitationtype>(QCBORDecodeContext* context, const char* field) {
+    int64_t tmp = 0;
+    QCBORDecode_GetInt64InMapSZ(context, field, &tmp);
+    if (QCBORDecode_GetError(context) != QCBOR_SUCCESS || tmp < 0 ||
+        tmp >= static_cast<int64_t>(Pinetime::Controllers::WeatherData::precipitationtype::Length)) {
+      return {};
+    }
+    return {static_cast<Pinetime::Controllers::WeatherData::precipitationtype>(tmp)};
+  }
+
+  template <>
+  std::optional<Pinetime::Controllers::WeatherData::specialtype>
+  Get<Pinetime::Controllers::WeatherData::specialtype>(QCBORDecodeContext* context, const char* field) {
+    int64_t tmp = 0;
+    QCBORDecode_GetInt64InMapSZ(context, field, &tmp);
+    if (QCBORDecode_GetError(context) != QCBOR_SUCCESS || tmp < 0 ||
+        tmp >= static_cast<int64_t>(Pinetime::Controllers::WeatherData::specialtype::Length)) {
+      return {};
+    }
+    return {static_cast<Pinetime::Controllers::WeatherData::specialtype>(tmp)};
+  }
+}
 
 int WeatherCallback(uint16_t /*connHandle*/, uint16_t /*attrHandle*/, struct ble_gatt_access_ctxt* ctxt, void* arg) {
   return static_cast<Pinetime::Controllers::WeatherService*>(arg)->OnCommand(ctxt);
@@ -54,87 +293,69 @@ namespace Pinetime {
         // KINDLY provide us a fixed-length map
         QCBORDecode_EnterMap(&decodeContext, nullptr);
         // Always encodes to the smallest number of bytes based on the value
-        int64_t tmpTimestamp = 0;
-        QCBORDecode_GetInt64InMapSZ(&decodeContext, "Timestamp", &tmpTimestamp);
-        if (QCBORDecode_GetError(&decodeContext) != QCBOR_SUCCESS) {
+
+        auto optTimestamp = Get<uint64_t>(&decodeContext, "Timestamp");
+        if (!optTimestamp) {
           CleanUpQcbor(&decodeContext);
           return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
         }
-        int64_t tmpExpires = 0;
-        QCBORDecode_GetInt64InMapSZ(&decodeContext, "Expires", &tmpExpires);
-        if (QCBORDecode_GetError(&decodeContext) != QCBOR_SUCCESS || tmpExpires < 0 || tmpExpires > 4294967295) {
+
+        auto optExpires = Get<uint32_t>(&decodeContext, "Expires");
+        if (!optExpires) {
+          CleanUpQcbor(&decodeContext);
+          return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+        }
+
+        auto optEventType = Get<Pinetime::Controllers::WeatherData::eventtype>(&decodeContext, "EventType");
+        if (!optEventType) {
           CleanUpQcbor(&decodeContext);
           return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
         }
 
         // Do not add already expired events
         uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-        if (static_cast<uint64_t>(tmpTimestamp + tmpExpires) < currentTimestamp) {
-          CleanUpQcbor(&decodeContext);
-          return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
-        }
-
-        int64_t tmpEventType = 0;
-        QCBORDecode_GetInt64InMapSZ(&decodeContext, "EventType", &tmpEventType);
-        if (QCBORDecode_GetError(&decodeContext) != QCBOR_SUCCESS || tmpEventType < 0 ||
-            tmpEventType >= static_cast<int64_t>(WeatherData::eventtype::Length)) {
+        if (static_cast<uint64_t>(*optTimestamp + *optExpires) < currentTimestamp) {
           CleanUpQcbor(&decodeContext);
           return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
         }
 
         TidyTimeline();
 
-        switch (static_cast<WeatherData::eventtype>(tmpEventType)) {
+        switch (*optEventType) {
           case WeatherData::eventtype::AirQuality: {
-            std::unique_ptr<WeatherData::AirQuality> airquality = std::make_unique<WeatherData::AirQuality>();
-            airquality->timestamp = tmpTimestamp;
-            airquality->eventType = static_cast<WeatherData::eventtype>(tmpEventType);
-            airquality->expires = tmpExpires;
-
-            UsefulBufC stringBuf; // TODO: Everything ok with lifecycle here?
-            QCBORDecode_GetTextStringInMapSZ(&decodeContext, "Polluter", &stringBuf);
-            if (UsefulBuf_IsNULLOrEmptyC(stringBuf) != 0) {
+            auto optPolluter = Get<std::string>(&decodeContext, "Polluter");
+            if (!optPolluter) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            airquality->polluter = std::string(static_cast<const char*>(stringBuf.ptr), stringBuf.len);
 
-            int64_t tmpAmount = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Amount", &tmpAmount);
-            if (tmpAmount < 0 || tmpAmount > 4294967295) {
+            auto optAmount = Get<uint32_t>(&decodeContext, "Amount");
+            if (!optAmount) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            airquality->amount = tmpAmount; // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
-            if (!AddEventToTimeline(std::move(airquality))) {
+            auto airQuality = CreateAirQualityEvent(*optTimestamp, *optExpires, *optPolluter, *optAmount);
+            if (!AddEventToTimeline(std::move(airQuality))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
             break;
           }
           case WeatherData::eventtype::Obscuration: {
-            std::unique_ptr<WeatherData::Obscuration> obscuration = std::make_unique<WeatherData::Obscuration>();
-            obscuration->timestamp = tmpTimestamp;
-            obscuration->eventType = static_cast<WeatherData::eventtype>(tmpEventType);
-            obscuration->expires = tmpExpires;
-
-            int64_t tmpType = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Type", &tmpType);
-            if (tmpType < 0 || tmpType >= static_cast<int64_t>(WeatherData::obscurationtype::Length)) {
+            auto optType = Get<WeatherData::obscurationtype>(&decodeContext, "Type");
+            if (!optType) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            obscuration->type = static_cast<WeatherData::obscurationtype>(tmpType);
 
-            int64_t tmpAmount = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Amount", &tmpAmount);
-            if (tmpAmount < 0 || tmpAmount > 65535) {
+            auto optAmount = Get<uint16_t>(&decodeContext, "Amount");
+            if (!optAmount) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            obscuration->amount = tmpAmount; // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
+            auto obscuration = CreateObscurationEvent(*optTimestamp, *optExpires, *optAmount);
             if (!AddEventToTimeline(std::move(obscuration))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -142,27 +363,19 @@ namespace Pinetime {
             break;
           }
           case WeatherData::eventtype::Precipitation: {
-            std::unique_ptr<WeatherData::Precipitation> precipitation = std::make_unique<WeatherData::Precipitation>();
-            precipitation->timestamp = tmpTimestamp;
-            precipitation->eventType = static_cast<WeatherData::eventtype>(tmpEventType);
-            precipitation->expires = tmpExpires;
-
-            int64_t tmpType = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Type", &tmpType);
-            if (tmpType < 0 || tmpType >= static_cast<int64_t>(WeatherData::precipitationtype::Length)) {
+            auto optType = Get<WeatherData::precipitationtype>(&decodeContext, "Type");
+            if (optType) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            precipitation->type = static_cast<WeatherData::precipitationtype>(tmpType);
 
-            int64_t tmpAmount = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Amount", &tmpAmount);
-            if (tmpAmount < 0 || tmpAmount > 255) {
+            auto optAmount = Get<uint8_t>(&decodeContext, "Amount");
+            if (!optAmount) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            precipitation->amount = tmpAmount; // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
+            auto precipitation = CreatePrecipitationEvent(*optTimestamp, *optExpires, *optType, *optAmount);
             if (!AddEventToTimeline(std::move(precipitation))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -170,43 +383,31 @@ namespace Pinetime {
             break;
           }
           case WeatherData::eventtype::Wind: {
-            std::unique_ptr<WeatherData::Wind> wind = std::make_unique<WeatherData::Wind>();
-            wind->timestamp = tmpTimestamp;
-            wind->eventType = static_cast<WeatherData::eventtype>(tmpEventType);
-            wind->expires = tmpExpires;
-
-            int64_t tmpMin = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "SpeedMin", &tmpMin);
-            if (tmpMin < 0 || tmpMin > 255) {
+            auto optMin = Get<uint8_t>(&decodeContext, "SpeedMin");
+            if (!optMin) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            wind->speedMin = tmpMin; // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
-            int64_t tmpMax = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "SpeedMin", &tmpMax);
-            if (tmpMax < 0 || tmpMax > 255) {
+            auto optMax = Get<uint8_t>(&decodeContext, "SpeedMax");
+            if (!optMax) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            wind->speedMax = tmpMax; // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
-            int64_t tmpDMin = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "DirectionMin", &tmpDMin);
-            if (tmpDMin < 0 || tmpDMin > 255) {
+            auto optDMin = Get<uint8_t>(&decodeContext, "DirectionMin");
+            if (!optDMin) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            wind->directionMin = tmpDMin; // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
-            int64_t tmpDMax = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "DirectionMax", &tmpDMax);
-            if (tmpDMax < 0 || tmpDMax > 255) {
+            auto optDMax = Get<uint8_t>(&decodeContext, "DirectionMax");
+            if (!optDMax) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            wind->directionMax = tmpDMax; // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
+            auto wind = CreateWindEvent(*optTimestamp, *optExpires, *optMin, *optMax, *optDMin, *optDMax);
             if (!AddEventToTimeline(std::move(wind))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -214,29 +415,19 @@ namespace Pinetime {
             break;
           }
           case WeatherData::eventtype::Temperature: {
-            std::unique_ptr<WeatherData::Temperature> temperature = std::make_unique<WeatherData::Temperature>();
-            temperature->timestamp = tmpTimestamp;
-            temperature->eventType = static_cast<WeatherData::eventtype>(tmpEventType);
-            temperature->expires = tmpExpires;
-
-            int64_t tmpTemperature = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Temperature", &tmpTemperature);
-            if (tmpTemperature < -32768 || tmpTemperature > 32767) {
+            auto optTemperature = Get<int16_t>(&decodeContext, "Temperature");
+            if (!optTemperature) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            temperature->temperature =
-              static_cast<int16_t>(tmpTemperature); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
-            int64_t tmpDewPoint = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "DewPoint", &tmpDewPoint);
-            if (tmpDewPoint < -32768 || tmpDewPoint > 32767) {
+            auto optDewPoint = Get<int16_t>(&decodeContext, "DewPoint");
+            if (!optDewPoint) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            temperature->dewPoint =
-              static_cast<int16_t>(tmpDewPoint); // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
+            auto temperature = CreateTemperatureEvent(*optTimestamp, *optExpires, *optTemperature, *optDewPoint);
             if (!AddEventToTimeline(std::move(temperature))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -244,19 +435,13 @@ namespace Pinetime {
             break;
           }
           case WeatherData::eventtype::Special: {
-            std::unique_ptr<WeatherData::Special> special = std::make_unique<WeatherData::Special>();
-            special->timestamp = tmpTimestamp;
-            special->eventType = static_cast<WeatherData::eventtype>(tmpEventType);
-            special->expires = tmpExpires;
-
-            int64_t tmpType = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Type", &tmpType);
-            if (tmpType < 0 || tmpType >= static_cast<int64_t>(WeatherData::specialtype::Length)) {
+            auto optType = Get<WeatherData::specialtype>(&decodeContext, "Type");
+            if (!optType) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            special->type = static_cast<WeatherData::specialtype>(tmpType);
 
+            auto special = CreateSpecialEvent(*optTimestamp, *optExpires, *optType);
             if (!AddEventToTimeline(std::move(special))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -264,19 +449,13 @@ namespace Pinetime {
             break;
           }
           case WeatherData::eventtype::Pressure: {
-            std::unique_ptr<WeatherData::Pressure> pressure = std::make_unique<WeatherData::Pressure>();
-            pressure->timestamp = tmpTimestamp;
-            pressure->eventType = static_cast<WeatherData::eventtype>(tmpEventType);
-            pressure->expires = tmpExpires;
-
-            int64_t tmpPressure = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Pressure", &tmpPressure);
-            if (tmpPressure < 0 || tmpPressure >= 65535) {
+            auto optPressure = Get<uint16_t>(&decodeContext, "Pressure");
+            if (!optPressure) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            pressure->pressure = tmpPressure; // NOLINT(bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions)
 
+            auto pressure = CreatePressureEvent(*optTimestamp, *optExpires, *optPressure);
             if (!AddEventToTimeline(std::move(pressure))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -284,43 +463,31 @@ namespace Pinetime {
             break;
           }
           case WeatherData::eventtype::Location: {
-            std::unique_ptr<WeatherData::Location> location = std::make_unique<WeatherData::Location>();
-            location->timestamp = tmpTimestamp;
-            location->eventType = static_cast<WeatherData::eventtype>(tmpEventType);
-            location->expires = tmpExpires;
-
-            UsefulBufC stringBuf; // TODO: Everything ok with lifecycle here?
-            QCBORDecode_GetTextStringInMapSZ(&decodeContext, "Location", &stringBuf);
-            if (UsefulBuf_IsNULLOrEmptyC(stringBuf) != 0) {
+            auto optLocation = Get<std::string>(&decodeContext, "Location");
+            if (!optLocation) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            location->location = std::string(static_cast<const char*>(stringBuf.ptr), stringBuf.len);
 
-            int64_t tmpAltitude = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Altitude", &tmpAltitude);
-            if (tmpAltitude < -32768 || tmpAltitude >= 32767) {
+            auto optAltitude = Get<int16_t>(&decodeContext, "Altitude");
+            if (!optAltitude) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            location->altitude = static_cast<int16_t>(tmpAltitude);
 
-            int64_t tmpLatitude = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Latitude", &tmpLatitude);
-            if (tmpLatitude < -2147483648 || tmpLatitude >= 2147483647) {
+            auto optLatitude = Get<int32_t>(&decodeContext, "Latitude");
+            if (!optLatitude) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            location->latitude = static_cast<int32_t>(tmpLatitude);
 
-            int64_t tmpLongitude = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Longitude", &tmpLongitude);
-            if (tmpLongitude < -2147483648 || tmpLongitude >= 2147483647) {
+            auto optLongitude = Get<int32_t>(&decodeContext, "Longitude");
+            if (!optLongitude) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            location->latitude = static_cast<int32_t>(tmpLongitude);
 
+            auto location = CreateLocationEvent(*optTimestamp, *optExpires, *optLocation, *optAltitude, *optLatitude, *optLongitude);
             if (!AddEventToTimeline(std::move(location))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -328,19 +495,13 @@ namespace Pinetime {
             break;
           }
           case WeatherData::eventtype::Clouds: {
-            std::unique_ptr<WeatherData::Clouds> clouds = std::make_unique<WeatherData::Clouds>();
-            clouds->timestamp = tmpTimestamp;
-            clouds->eventType = static_cast<WeatherData::eventtype>(tmpEventType);
-            clouds->expires = tmpExpires;
-
-            int64_t tmpAmount = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Amount", &tmpAmount);
-            if (tmpAmount < 0 || tmpAmount > 255) {
+            auto optAmount = Get<uint8_t>(&decodeContext, "Amount");
+            if (!optAmount) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            clouds->amount = static_cast<uint8_t>(tmpAmount);
 
+            auto clouds = CreateCloudsEvent(*optTimestamp, *optExpires, *optAmount);
             if (!AddEventToTimeline(std::move(clouds))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -348,19 +509,13 @@ namespace Pinetime {
             break;
           }
           case WeatherData::eventtype::Humidity: {
-            std::unique_ptr<WeatherData::Humidity> humidity = std::make_unique<WeatherData::Humidity>();
-            humidity->timestamp = tmpTimestamp;
-            humidity->eventType = static_cast<WeatherData::eventtype>(tmpEventType);
-            humidity->expires = tmpExpires;
-
-            int64_t tmpType = 0;
-            QCBORDecode_GetInt64InMapSZ(&decodeContext, "Humidity", &tmpType);
-            if (tmpType < 0 || tmpType >= 255) {
+            auto optType = Get<uint8_t>(&decodeContext, "Humidity");
+            if (!optType) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
-            humidity->humidity = static_cast<uint8_t>(tmpType);
 
+            auto humidity = CreateHumidityEvent(*optTimestamp, *optExpires, *optType);
             if (!AddEventToTimeline(std::move(humidity))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -380,7 +535,9 @@ namespace Pinetime {
         if (QCBORDecode_Finish(&decodeContext) != QCBOR_SUCCESS) {
           return BLE_ATT_ERR_INSUFFICIENT_RES;
         }
-      } else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
+      }
+
+      else if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
         // Encode
         uint8_t buffer[64];
         QCBOREncodeContext encodeContext;
@@ -467,7 +624,7 @@ namespace Pinetime {
     }
 
     bool WeatherService::AddEventToTimeline(std::unique_ptr<WeatherData::TimelineHeader> event) {
-      if (timeline.size() == timeline.max_size()) {
+      if (timeline.size() == maxNbElements) {
         return false;
       }
 

--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -401,112 +401,51 @@ namespace Pinetime {
       return 0;
     }
 
-    std::unique_ptr<WeatherData::Clouds>& WeatherService::GetCurrentClouds() {
+    std::unique_ptr<WeatherData::TimelineHeader>& WeatherService::GetCurrentEvent(WeatherData::eventtype eventType) {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
       for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Clouds && currentTimestamp >= header->timestamp &&
-            IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Clouds>&>(header);
+        if (header->eventType == eventType && currentTimestamp >= header->timestamp && IsEventStillValid(header, currentTimestamp)) {
+          return header;
         }
       }
 
-      return reinterpret_cast<std::unique_ptr<WeatherData::Clouds>&>(*this->nullHeader);
+      return *this->nullHeader;
+    }
+
+    std::unique_ptr<WeatherData::Clouds>& WeatherService::GetCurrentClouds() {
+      return reinterpret_cast<std::unique_ptr<WeatherData::Clouds>&>(GetCurrentEvent(WeatherData::eventtype::Clouds));
     }
 
     std::unique_ptr<WeatherData::Obscuration>& WeatherService::GetCurrentObscuration() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Obscuration && currentTimestamp >= header->timestamp &&
-            IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Obscuration>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Obscuration>&>(*this->nullHeader);
+      return reinterpret_cast<std::unique_ptr<WeatherData::Obscuration>&>(GetCurrentEvent(WeatherData::eventtype::Obscuration));
     }
 
     std::unique_ptr<WeatherData::Precipitation>& WeatherService::GetCurrentPrecipitation() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Precipitation && currentTimestamp >= header->timestamp &&
-            IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Precipitation>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Precipitation>&>(*this->nullHeader);
+      return reinterpret_cast<std::unique_ptr<WeatherData::Precipitation>&>(GetCurrentEvent(WeatherData::eventtype::Precipitation));
     }
 
     std::unique_ptr<WeatherData::Wind>& WeatherService::GetCurrentWind() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Wind && currentTimestamp >= header->timestamp &&
-            IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Wind>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Wind>&>(*this->nullHeader);
+      return reinterpret_cast<std::unique_ptr<WeatherData::Wind>&>(GetCurrentEvent(WeatherData::eventtype::Wind));
     }
 
     std::unique_ptr<WeatherData::Temperature>& WeatherService::GetCurrentTemperature() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Temperature && currentTimestamp >= header->timestamp &&
-            IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Temperature>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Temperature>&>(*this->nullHeader);
+      return reinterpret_cast<std::unique_ptr<WeatherData::Temperature>&>(GetCurrentEvent(WeatherData::eventtype::Temperature));
     }
 
     std::unique_ptr<WeatherData::Humidity>& WeatherService::GetCurrentHumidity() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Humidity && currentTimestamp >= header->timestamp &&
-            IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Humidity>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Humidity>&>(*this->nullHeader);
+      return reinterpret_cast<std::unique_ptr<WeatherData::Humidity>&>(GetCurrentEvent(WeatherData::eventtype::Humidity));
     }
 
     std::unique_ptr<WeatherData::Pressure>& WeatherService::GetCurrentPressure() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Pressure && currentTimestamp >= header->timestamp &&
-            IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Pressure>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Pressure>&>(*this->nullHeader);
+      return reinterpret_cast<std::unique_ptr<WeatherData::Pressure>&>(GetCurrentEvent(WeatherData::eventtype::Pressure));
     }
 
     std::unique_ptr<WeatherData::Location>& WeatherService::GetCurrentLocation() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::Location && currentTimestamp >= header->timestamp &&
-            IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::Location>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::Location>&>(*this->nullHeader);
+      return reinterpret_cast<std::unique_ptr<WeatherData::Location>&>(GetCurrentEvent(WeatherData::eventtype::Location));
     }
 
     std::unique_ptr<WeatherData::AirQuality>& WeatherService::GetCurrentQuality() {
-      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
-      for (auto&& header : this->timeline) {
-        if (header->eventType == WeatherData::eventtype::AirQuality && currentTimestamp >= header->timestamp &&
-            IsEventStillValid(header, currentTimestamp)) {
-          return reinterpret_cast<std::unique_ptr<WeatherData::AirQuality>&>(header);
-        }
-      }
-
-      return reinterpret_cast<std::unique_ptr<WeatherData::AirQuality>&>(*this->nullHeader);
+      return reinterpret_cast<std::unique_ptr<WeatherData::AirQuality>&>(GetCurrentEvent(WeatherData::eventtype::AirQuality));
     }
 
     size_t WeatherService::GetTimelineLength() const {

--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -413,13 +413,17 @@ namespace Pinetime {
 
     std::unique_ptr<WeatherData::TimelineHeader>& WeatherService::GetCurrentEvent(WeatherData::eventtype eventType) {
       uint64_t currentTimestamp = GetCurrentUnixTimestamp();
+      auto* best = this->nullHeader;
       for (auto&& header : this->timeline) {
         if (header->eventType == eventType && currentTimestamp >= header->timestamp && IsEventStillValid(header, currentTimestamp)) {
-          return header;
+          if ((*best)->timestamp == 0 || header->expires < (*best)->expires ||
+              (header->expires == (*best)->expires && header->timestamp > (*best)->timestamp)) {
+            best = &header;
+          }
         }
       }
 
-      return *this->nullHeader;
+      return *best;
     }
 
     std::unique_ptr<WeatherData::Clouds>& WeatherService::GetCurrentClouds() {

--- a/src/components/ble/weather/WeatherService.cpp
+++ b/src/components/ble/weather/WeatherService.cpp
@@ -22,119 +22,142 @@
 #include "libs/QCBOR/inc/qcbor/qcbor.h"
 
 namespace {
-  std::unique_ptr<Pinetime::Controllers::WeatherData::AirQuality>
-  CreateAirQualityEvent(uint64_t timestamp, uint32_t expires, const std::string& polluter, uint32_t amount) {
-    auto airquality = std::make_unique<Pinetime::Controllers::WeatherData::AirQuality>();
-    airquality->timestamp = timestamp;
-    airquality->eventType = Pinetime::Controllers::WeatherData::eventtype::AirQuality;
-    airquality->expires = expires;
-    airquality->polluter = polluter;
-    airquality->amount = amount;
-    return airquality;
+  void CreateAirQualityEvent(std::unique_ptr<Pinetime::Controllers::WeatherData::AirQuality>& event,
+                             uint64_t timestamp,
+                             uint32_t expires,
+                             uint16_t id,
+                             const std::string& polluter,
+                             uint32_t amount) {
+    event->timestamp = timestamp;
+    event->eventType = Pinetime::Controllers::WeatherData::eventtype::AirQuality;
+    event->expires = expires;
+    event->eventID = id;
+    event->polluter = polluter;
+    event->amount = amount;
   }
 
-  std::unique_ptr<Pinetime::Controllers::WeatherData::Obscuration>
-  CreateObscurationEvent(uint64_t timestamp, uint32_t expires, uint16_t amount) {
-    auto obscuration = std::make_unique<Pinetime::Controllers::WeatherData::Obscuration>();
-    obscuration->timestamp = timestamp;
-    obscuration->eventType = Pinetime::Controllers::WeatherData::eventtype::Obscuration;
-    obscuration->expires = expires;
-    obscuration->amount = amount;
-    return obscuration;
+  void CreateObscurationEvent(std::unique_ptr<Pinetime::Controllers::WeatherData::Obscuration>& event,
+                              uint64_t timestamp,
+                              uint32_t expires,
+                              uint16_t id,
+                              uint16_t amount) {
+    event->timestamp = timestamp;
+    event->eventType = Pinetime::Controllers::WeatherData::eventtype::Obscuration;
+    event->expires = expires;
+    event->eventID = id;
+    event->amount = amount;
   }
 
-  std::unique_ptr<Pinetime::Controllers::WeatherData::Precipitation>
-  CreatePrecipitationEvent(uint64_t timestamp,
+  void CreatePrecipitationEvent(std::unique_ptr<Pinetime::Controllers::WeatherData::Precipitation>& event,
+                                uint64_t timestamp,
+                                uint32_t expires,
+                                uint16_t id,
+                                Pinetime::Controllers::WeatherData::precipitationtype type,
+                                uint8_t amount) {
+    event->timestamp = timestamp;
+    event->eventType = Pinetime::Controllers::WeatherData::eventtype::Precipitation;
+    event->expires = expires;
+    event->eventID = id;
+    event->type = type;
+    event->amount = amount;
+  }
+
+  void CreateWindEvent(std::unique_ptr<Pinetime::Controllers::WeatherData::Wind>& event,
+                       uint64_t timestamp,
+                       uint32_t expires,
+                       uint16_t id,
+                       uint8_t speedMin,
+                       uint8_t speedMax,
+                       uint8_t directionMin,
+                       uint8_t directionMax) {
+    event->timestamp = timestamp;
+    event->eventType = Pinetime::Controllers::WeatherData::eventtype::Wind;
+    event->expires = expires;
+    event->eventID = id;
+    event->speedMin = speedMin;
+    event->speedMax = speedMax;
+    event->directionMin = directionMin;
+    event->directionMax = directionMax;
+  }
+
+  void CreateTemperatureEvent(std::unique_ptr<Pinetime::Controllers::WeatherData::Temperature>& event,
+                              uint64_t timestamp,
+                              uint32_t expires,
+                              uint16_t id,
+                              int16_t temperatureValue,
+                              uint16_t dewPoint) {
+    event->timestamp = timestamp;
+    event->eventType = Pinetime::Controllers::WeatherData::eventtype::Temperature;
+    event->expires = expires;
+    event->eventID = id;
+    event->temperature = temperatureValue;
+    event->dewPoint = dewPoint;
+  }
+
+  void CreateSpecialEvent(std::unique_ptr<Pinetime::Controllers::WeatherData::Special>& event,
+                          uint64_t timestamp,
+                          uint32_t expires,
+                          uint16_t id,
+                          Pinetime::Controllers::WeatherData::specialtype type) {
+    event->timestamp = timestamp;
+    event->eventType = Pinetime::Controllers::WeatherData::eventtype::Special;
+    event->expires = expires;
+    event->eventID = id;
+    event->type = type;
+  }
+
+  void CreatePressureEvent(std::unique_ptr<Pinetime::Controllers::WeatherData::Pressure>& event,
+                           uint64_t timestamp,
                            uint32_t expires,
-                           Pinetime::Controllers::WeatherData::precipitationtype type,
-                           uint8_t amount) {
-    auto precipitation = std::make_unique<Pinetime::Controllers::WeatherData::Precipitation>();
-    precipitation->timestamp = timestamp;
-    precipitation->eventType = Pinetime::Controllers::WeatherData::eventtype::Precipitation;
-    precipitation->expires = expires;
-    precipitation->type = type;
-    precipitation->amount = amount;
-    return precipitation;
+                           uint16_t id,
+                           uint16_t pressureValue) {
+    event->timestamp = timestamp;
+    event->eventType = Pinetime::Controllers::WeatherData::eventtype::Pressure;
+    event->expires = expires;
+    event->eventID = id;
+    event->pressure = pressureValue;
   }
 
-  std::unique_ptr<Pinetime::Controllers::WeatherData::Wind>
-  CreateWindEvent(uint64_t timestamp, uint32_t expires, uint8_t speedMin, uint8_t speedMax, uint8_t directionMin, uint8_t directionMax) {
-    auto wind = std::make_unique<Pinetime::Controllers::WeatherData::Wind>();
-    wind->timestamp = timestamp;
-    wind->eventType = Pinetime::Controllers::WeatherData::eventtype::Wind;
-    wind->expires = expires;
-    wind->speedMin = speedMin;
-    wind->speedMax = speedMax;
-    wind->directionMin = directionMin;
-    wind->directionMax = directionMax;
-    return wind;
+  void CreateLocationEvent(std::unique_ptr<Pinetime::Controllers::WeatherData::Location>& event,
+                           uint64_t timestamp,
+                           uint32_t expires,
+                           uint16_t id,
+                           const std::string& locationValue,
+                           int16_t altitude,
+                           int32_t latitude,
+                           int32_t longitude) {
+    event->timestamp = timestamp;
+    event->eventType = Pinetime::Controllers::WeatherData::eventtype::Location;
+    event->expires = expires;
+    event->eventID = id;
+    event->location = locationValue;
+    event->altitude = altitude;
+    event->latitude = latitude;
+    event->longitude = longitude;
   }
 
-  std::unique_ptr<Pinetime::Controllers::WeatherData::Temperature>
-  CreateTemperatureEvent(uint64_t timestamp, uint32_t expires, int16_t temperatureValue, uint16_t dewPoint) {
-    auto temperature = std::make_unique<Pinetime::Controllers::WeatherData::Temperature>();
-    temperature->timestamp = timestamp;
-    temperature->eventType = Pinetime::Controllers::WeatherData::eventtype::Temperature;
-    temperature->expires = expires;
-    temperature->temperature = temperatureValue;
-    temperature->dewPoint = dewPoint;
-    return temperature;
+  void CreateCloudsEvent(std::unique_ptr<Pinetime::Controllers::WeatherData::Clouds>& event,
+                         uint64_t timestamp,
+                         uint32_t expires,
+                         uint16_t id,
+                         uint8_t amount) {
+    event->timestamp = timestamp;
+    event->eventType = Pinetime::Controllers::WeatherData::eventtype::Clouds;
+    event->expires = expires;
+    event->eventID = id;
+    event->amount = amount;
   }
 
-  std::unique_ptr<Pinetime::Controllers::WeatherData::Special>
-  CreateSpecialEvent(uint64_t timestamp, uint32_t expires, Pinetime::Controllers::WeatherData::specialtype type) {
-    auto special = std::make_unique<Pinetime::Controllers::WeatherData::Special>();
-    special->timestamp = timestamp;
-    special->eventType = Pinetime::Controllers::WeatherData::eventtype::Special;
-    special->expires = expires;
-    special->type = type;
-    return special;
-  }
-
-  std::unique_ptr<Pinetime::Controllers::WeatherData::Pressure>
-  CreatePressureEvent(uint64_t timestamp, uint32_t expires, uint16_t pressureValue) {
-    auto pressure = std::make_unique<Pinetime::Controllers::WeatherData::Pressure>();
-    pressure->timestamp = timestamp;
-    pressure->eventType = Pinetime::Controllers::WeatherData::eventtype::Pressure;
-    pressure->expires = expires;
-    pressure->pressure = pressureValue;
-    return pressure;
-  }
-
-  std::unique_ptr<Pinetime::Controllers::WeatherData::Location> CreateLocationEvent(uint64_t timestamp,
-                                                                                    uint32_t expires,
-                                                                                    const std::string& locationValue,
-                                                                                    int16_t altitude,
-                                                                                    int32_t latitude,
-                                                                                    int32_t longitude) {
-    auto location = std::make_unique<Pinetime::Controllers::WeatherData::Location>();
-    location->timestamp = timestamp;
-    location->eventType = Pinetime::Controllers::WeatherData::eventtype::Location;
-    location->expires = expires;
-    location->location = locationValue;
-    location->altitude = altitude;
-    location->latitude = latitude;
-    location->longitude = longitude;
-    return location;
-  }
-
-  std::unique_ptr<Pinetime::Controllers::WeatherData::Clouds> CreateCloudsEvent(uint64_t timestamp, uint32_t expires, uint8_t amount) {
-    auto clouds = std::make_unique<Pinetime::Controllers::WeatherData::Clouds>();
-    clouds->timestamp = timestamp;
-    clouds->eventType = Pinetime::Controllers::WeatherData::eventtype::Clouds;
-    clouds->expires = expires;
-    clouds->amount = amount;
-    return clouds;
-  }
-
-  std::unique_ptr<Pinetime::Controllers::WeatherData::Humidity>
-  CreateHumidityEvent(uint64_t timestamp, uint32_t expires, uint8_t humidityValue) {
-    auto humidity = std::make_unique<Pinetime::Controllers::WeatherData::Humidity>();
-    humidity->timestamp = timestamp;
-    humidity->eventType = Pinetime::Controllers::WeatherData::eventtype::Humidity;
-    humidity->expires = expires;
-    humidity->humidity = humidityValue;
-    return humidity;
+  void CreateHumidityEvent(std::unique_ptr<Pinetime::Controllers::WeatherData::Humidity>& event,
+                           uint64_t timestamp,
+                           uint32_t expires,
+                           uint16_t id,
+                           uint8_t humidityValue) {
+    event->timestamp = timestamp;
+    event->eventType = Pinetime::Controllers::WeatherData::eventtype::Humidity;
+    event->expires = expires;
+    event->eventID = id;
+    event->humidity = humidityValue;
   }
 
   template <typename T>
@@ -268,6 +291,7 @@ namespace Pinetime {
     WeatherService::WeatherService(const DateTime& dateTimeController) : dateTimeController(dateTimeController) {
       nullHeader = &nullTimelineheader;
       nullTimelineheader->timestamp = 0;
+      nullTimelineheader->expires = 0;
     }
 
     void WeatherService::Init() {
@@ -281,13 +305,14 @@ namespace Pinetime {
 
     int WeatherService::OnCommand(struct ble_gatt_access_ctxt* ctxt) {
       if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
-        const uint8_t packetLen = OS_MBUF_PKTLEN(ctxt->om); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        const uint16_t packetLen = OS_MBUF_PKTLEN(ctxt->om); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         if (packetLen <= 0) {
           return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
         }
+
         // Decode
         QCBORDecodeContext decodeContext;
-        UsefulBufC encodedCbor = {ctxt->om->om_data, OS_MBUF_PKTLEN(ctxt->om)}; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        UsefulBufC encodedCbor = {ctxt->om->om_data, packetLen};
 
         QCBORDecode_Init(&decodeContext, encodedCbor, QCBOR_DECODE_MODE_NORMAL);
         // KINDLY provide us a fixed-length map
@@ -319,7 +344,20 @@ namespace Pinetime {
           return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
         }
 
+        auto optID = Get<uint16_t>(&decodeContext, "EventID");
+        if (!optID) {
+          CleanUpQcbor(&decodeContext);
+          return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+        }
+
         TidyTimeline();
+
+        std::unique_ptr<WeatherData::TimelineHeader>& existingEvent = GetEventByID(*optEventType, *optID);
+        bool useExisting = IsEventStillValid(existingEvent, currentTimestamp);
+        if (!useExisting && GetTimelineLength() >= maxNbElements) {
+          CleanUpQcbor(&decodeContext);
+          return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
+        }
 
         switch (*optEventType) {
           case WeatherData::eventtype::AirQuality: {
@@ -335,7 +373,18 @@ namespace Pinetime {
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
 
-            auto airQuality = CreateAirQualityEvent(*optTimestamp, *optExpires, *optPolluter, *optAmount);
+            if (useExisting) {
+              CreateAirQualityEvent(reinterpret_cast<std::unique_ptr<WeatherData::AirQuality>&>(existingEvent),
+                                    *optTimestamp,
+                                    *optExpires,
+                                    *optID,
+                                    *optPolluter,
+                                    *optAmount);
+              break;
+            }
+
+            auto airQuality = std::make_unique<WeatherData::AirQuality>();
+            CreateAirQualityEvent(airQuality, *optTimestamp, *optExpires, *optID, *optPolluter, *optAmount);
             if (!AddEventToTimeline(std::move(airQuality))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -355,7 +404,17 @@ namespace Pinetime {
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
 
-            auto obscuration = CreateObscurationEvent(*optTimestamp, *optExpires, *optAmount);
+            if (useExisting) {
+              CreateObscurationEvent(reinterpret_cast<std::unique_ptr<WeatherData::Obscuration>&>(existingEvent),
+                                     *optTimestamp,
+                                     *optExpires,
+                                     *optID,
+                                     *optAmount);
+              break;
+            }
+
+            auto obscuration = std::make_unique<WeatherData::Obscuration>();
+            CreateObscurationEvent(obscuration, *optTimestamp, *optExpires, *optID, *optAmount);
             if (!AddEventToTimeline(std::move(obscuration))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -375,7 +434,18 @@ namespace Pinetime {
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
 
-            auto precipitation = CreatePrecipitationEvent(*optTimestamp, *optExpires, *optType, *optAmount);
+            if (useExisting) {
+              CreatePrecipitationEvent(reinterpret_cast<std::unique_ptr<WeatherData::Precipitation>&>(existingEvent),
+                                       *optTimestamp,
+                                       *optExpires,
+                                       *optID,
+                                       *optType,
+                                       *optAmount);
+              break;
+            }
+
+            auto precipitation = std::make_unique<WeatherData::Precipitation>();
+            CreatePrecipitationEvent(precipitation, *optTimestamp, *optExpires, *optID, *optType, *optAmount);
             if (!AddEventToTimeline(std::move(precipitation))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -407,7 +477,20 @@ namespace Pinetime {
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
 
-            auto wind = CreateWindEvent(*optTimestamp, *optExpires, *optMin, *optMax, *optDMin, *optDMax);
+            if (useExisting) {
+              CreateWindEvent(reinterpret_cast<std::unique_ptr<WeatherData::Wind>&>(existingEvent),
+                              *optTimestamp,
+                              *optExpires,
+                              *optID,
+                              *optMin,
+                              *optMax,
+                              *optDMin,
+                              *optDMax);
+              break;
+            }
+
+            auto wind = std::make_unique<WeatherData::Wind>();
+            CreateWindEvent(wind, *optTimestamp, *optExpires, *optID, *optMin, *optMax, *optDMin, *optDMax);
             if (!AddEventToTimeline(std::move(wind))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -427,7 +510,18 @@ namespace Pinetime {
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
 
-            auto temperature = CreateTemperatureEvent(*optTimestamp, *optExpires, *optTemperature, *optDewPoint);
+            if (useExisting) {
+              CreateTemperatureEvent(reinterpret_cast<std::unique_ptr<WeatherData::Temperature>&>(existingEvent),
+                                     *optTimestamp,
+                                     *optExpires,
+                                     *optID,
+                                     *optTemperature,
+                                     *optDewPoint);
+              break;
+            }
+
+            auto temperature = std::make_unique<WeatherData::Temperature>();
+            CreateTemperatureEvent(temperature, *optTimestamp, *optExpires, *optID, *optTemperature, *optDewPoint);
             if (!AddEventToTimeline(std::move(temperature))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -441,7 +535,17 @@ namespace Pinetime {
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
 
-            auto special = CreateSpecialEvent(*optTimestamp, *optExpires, *optType);
+            if (useExisting) {
+              CreateSpecialEvent(reinterpret_cast<std::unique_ptr<WeatherData::Special>&>(existingEvent),
+                                 *optTimestamp,
+                                 *optExpires,
+                                 *optID,
+                                 *optType);
+              break;
+            }
+
+            auto special = std::make_unique<WeatherData::Special>();
+            CreateSpecialEvent(special, *optTimestamp, *optExpires, *optID, *optType);
             if (!AddEventToTimeline(std::move(special))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -455,7 +559,17 @@ namespace Pinetime {
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
 
-            auto pressure = CreatePressureEvent(*optTimestamp, *optExpires, *optPressure);
+            if (useExisting) {
+              CreatePressureEvent(reinterpret_cast<std::unique_ptr<WeatherData::Pressure>&>(existingEvent),
+                                  *optTimestamp,
+                                  *optExpires,
+                                  *optID,
+                                  *optPressure);
+              break;
+            }
+
+            auto pressure = std::make_unique<WeatherData::Pressure>();
+            CreatePressureEvent(pressure, *optTimestamp, *optExpires, *optID, *optPressure);
             if (!AddEventToTimeline(std::move(pressure))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -487,7 +601,20 @@ namespace Pinetime {
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
 
-            auto location = CreateLocationEvent(*optTimestamp, *optExpires, *optLocation, *optAltitude, *optLatitude, *optLongitude);
+            if (useExisting) {
+              CreateLocationEvent(reinterpret_cast<std::unique_ptr<WeatherData::Location>&>(existingEvent),
+                                  *optTimestamp,
+                                  *optExpires,
+                                  *optID,
+                                  *optLocation,
+                                  *optAltitude,
+                                  *optLatitude,
+                                  *optLongitude);
+              break;
+            }
+
+            auto location = std::make_unique<WeatherData::Location>();
+            CreateLocationEvent(location, *optTimestamp, *optExpires, *optID, *optLocation, *optAltitude, *optLatitude, *optLongitude);
             if (!AddEventToTimeline(std::move(location))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -501,7 +628,17 @@ namespace Pinetime {
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
 
-            auto clouds = CreateCloudsEvent(*optTimestamp, *optExpires, *optAmount);
+            if (useExisting) {
+              CreateCloudsEvent(reinterpret_cast<std::unique_ptr<WeatherData::Clouds>&>(existingEvent),
+                                *optTimestamp,
+                                *optExpires,
+                                *optID,
+                                *optAmount);
+              break;
+            }
+
+            auto clouds = std::make_unique<WeatherData::Clouds>();
+            CreateCloudsEvent(clouds, *optTimestamp, *optExpires, *optID, *optAmount);
             if (!AddEventToTimeline(std::move(clouds))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -515,7 +652,17 @@ namespace Pinetime {
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
             }
 
-            auto humidity = CreateHumidityEvent(*optTimestamp, *optExpires, *optType);
+            if (useExisting) {
+              CreateHumidityEvent(reinterpret_cast<std::unique_ptr<WeatherData::Humidity>&>(existingEvent),
+                                  *optTimestamp,
+                                  *optExpires,
+                                  *optID,
+                                  *optType);
+              break;
+            }
+
+            auto humidity = std::make_unique<WeatherData::Humidity>();
+            CreateHumidityEvent(humidity, *optTimestamp, *optExpires, *optID, *optType);
             if (!AddEventToTimeline(std::move(humidity))) {
               CleanUpQcbor(&decodeContext);
               return BLE_ATT_ERR_INVALID_ATTR_VALUE_LEN;
@@ -581,6 +728,17 @@ namespace Pinetime {
       }
 
       return *best;
+    }
+
+    std::unique_ptr<WeatherData::TimelineHeader>& WeatherService::GetEventByID(WeatherData::eventtype eventType, uint16_t id) {
+      uint64_t currentTimestamp = GetCurrentUnixTimestamp();
+      for (auto&& header : this->timeline) {
+        if (header->eventType == eventType && IsEventStillValid(header, currentTimestamp) && header->eventID == id) {
+          return header;
+        }
+      }
+
+      return *this->nullHeader;
     }
 
     std::unique_ptr<WeatherData::Clouds>& WeatherService::GetCurrentClouds() {

--- a/src/components/ble/weather/WeatherService.h
+++ b/src/components/ble/weather/WeatherService.h
@@ -99,6 +99,8 @@ namespace Pinetime {
                               .value = {0xd0, 0x42, 0x19, 0x3a, 0x3b, 0x43, 0x23, 0x8e, 0xfe, 0x48, 0xfc, 0x78, y, x, 0x04, 0x00}};
       }
 
+      static constexpr size_t maxNbElements = 10;
+
       ble_uuid128_t weatherUuid {BaseUuid()};
 
       /**

--- a/src/components/ble/weather/WeatherService.h
+++ b/src/components/ble/weather/WeatherService.h
@@ -146,6 +146,8 @@ namespace Pinetime {
       static bool CompareTimelineEvents(const std::unique_ptr<WeatherData::TimelineHeader>& first,
                                         const std::unique_ptr<WeatherData::TimelineHeader>& second);
 
+      std::unique_ptr<WeatherData::TimelineHeader>& GetCurrentEvent(WeatherData::eventtype eventType);
+
       /**
        * Returns current UNIX timestamp
        */

--- a/src/components/ble/weather/WeatherService.h
+++ b/src/components/ble/weather/WeatherService.h
@@ -150,6 +150,8 @@ namespace Pinetime {
 
       std::unique_ptr<WeatherData::TimelineHeader>& GetCurrentEvent(WeatherData::eventtype eventType);
 
+      std::unique_ptr<WeatherData::TimelineHeader>& GetEventByID(WeatherData::eventtype eventType, uint16_t ID);
+
       /**
        * Returns current UNIX timestamp
        */


### PR DESCRIPTION
This pull request adds a number of changes to WeatherService and WeatherData that improve its functionality and stability. These changes are partially based on @faxe1008's work in #1822, @JF002's work in #1860 and my work in #1882.

The change I made to #1822 is to not use a template function for the general GetCurrent function, but rather let the GetCurrent* functions do the cast themselves. This reduces the number of functions created in total.

One of the big improvements is the addition of an event ID. This ID will allow companion apps to update values they have already sent with new information, allowing them to operate statelessly.
This is a BREAKING CHANGE to the WeatherService API, meaning that companion apps will need to update to add an EventID field to the CBOR data for every event that they send. If this PR gets approved, I will make prepare patches for all the companion apps that implement WeatherService to make the change smoother.

I propose that we create a list of standardised IDs for events that most companion apps will implement, which will allow the user to switch companion apps and have the weather data update seamlessly.
Companion apps will then also be able to create their own IDs outside of the standard ones that won't be affected by other companions.

One change I would still like to make is to move away from using std::strings and switch to using std::array, to reduce the uncertainty of how long the string might be.

@JF002 @Avamander @faxe1008 could you please give some feedback on these changes.

Fixes #1786, #1788 and #1877.