### PR TITLE
Fix calculation of number of app screens

### DIFF
--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -38,8 +38,7 @@ namespace Pinetime {
 
         static constexpr int appsPerScreen = 6;
 
-        // Increment this when more space is needed
-        static constexpr int nScreens = (UserAppTypes::Count / appsPerScreen) + 1;
+        static constexpr int nScreens = CEIL_DIV(UserAppTypes::Count, appsPerScreen);
 
         ScreenList<nScreens> screens;
       };

--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -38,7 +38,7 @@ namespace Pinetime {
 
         static constexpr int appsPerScreen = 6;
 
-        static constexpr int nScreens = CEIL_DIV(UserAppTypes::Count, appsPerScreen);
+        static constexpr int nScreens = (UserAppTypes::Count - 1) / appsPerScreen + 1;
 
         ScreenList<nScreens> screens;
       };


### PR DESCRIPTION
Was testing an extra app (so 12 in total) and noticed the extra screen added
Also removed the old comment

There might be a nicer C++ way to do this than this macro I spotted lying around, but I can't find one