### PR TITLE
apps: Restore app list order

### DIFF
--- a/src/displayapp/Apps.h
+++ b/src/displayapp/Apps.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstddef>
+
 namespace Pinetime {
   namespace Applications {
     enum class Apps {
@@ -49,17 +50,17 @@ namespace Pinetime {
       static constexpr size_t Count = sizeof...(As);
     };
 
-    using UserAppTypes = TypeList<Apps::Alarm,
-                                  Apps::HeartRate,
-                                  Apps::Paint,
-                                  Apps::Metronome,
-                                  Apps::Music,
-                                  Apps::Navigation,
-                                  Apps::Paddle,
-                                  Apps::Steps,
-                                  Apps::StopWatch,
+    using UserAppTypes = TypeList<Apps::StopWatch,
+                                  Apps::Alarm,
                                   Apps::Timer,
-                                  Apps::Twos
+                                  Apps::Steps,
+                                  Apps::HeartRate,
+                                  Apps::Music,
+                                  Apps::Paint,
+                                  Apps::Paddle,
+                                  Apps::Twos,
+                                  Apps::Metronome,
+                                  Apps::Navigation
                                   /*
                                   Apps::Weather,
                                   Apps::Motion


### PR DESCRIPTION
The build-time selection PR updated the order, this restores what it was before. I feel this has more frequently used apps on the first page, and less frequently used ones on the second. If someone has a better order, please tell me.