### PR TITLE
Allow zero app to be selected at build time

### DIFF
--- a/src/displayapp/screens/ApplicationList.h
+++ b/src/displayapp/screens/ApplicationList.h
@@ -38,7 +38,7 @@ namespace Pinetime {
 
         static constexpr int appsPerScreen = 6;
 
-        static constexpr int nScreens = (UserAppTypes::Count - 1) / appsPerScreen + 1;
+        static constexpr int nScreens = UserAppTypes::Count > 0 ? (UserAppTypes::Count - 1) / appsPerScreen + 1 : 1;
 
         ScreenList<nScreens> screens;
       };


### PR DESCRIPTION
Fix 'nScreens' calculation in ApplicationList so that we can build the project with zero user app selected.