### PR TITLE
Fix git hash calculation with Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,6 +64,9 @@ RUN bash -c "source /opt/build.sh; GetMcuBoot;"
 
 # Add the infinitime user for connecting devcontainer
 RUN adduser infinitime
-    
+
+# Configure Git to accept the /sources directory as safe
+RUN git config --global --add safe.directory /sources
+
 ENV SOURCES_DIR /sources
 CMD ["/opt/build.sh"]


### PR DESCRIPTION
Fix error when compiling the Pinetime using the Docker image. If done with Docker, the container does not trust the /sources folder, leading to a blank response of the command that grabs the git commit `git rev-parse --short HEAD`.

```
fatal: detected dubious ownership in repository at '/sources'
To add an exception for this directory, call:

        git config --global --add safe.directory /sources
PROJECT_GIT_COMMIT_HASH_SUCCESS? 128

BUILD CONFIGURATION
-------------------
    * Mode : Release
    * Version : 1.3.0
    * Toolchain : /opt/gcc-arm-none-eabi-10.3-2021.10
    * GitRef(S) :
    * NRF52 SDK : /opt/nRF5_SDK_15.3.0_59ac345
    * Target device : PINETIME
    * Build DFU (using adafruit-nrfutil) : Enabled
    * Build resources : Enabled
```

If the `git config --global --add safe.directory /sources` is added to the Dockerfile, the problem is solved and the hash is added correctly.

Fixes #1842