### PR TITLE
Subpixel font rendering

### DIFF
--- a/src/displayapp/fonts/generate.py
+++ b/src/displayapp/fonts/generate.py
@@ -18,8 +18,10 @@ class Source(object):
         self.symbols = d.get('symbols')
 
 
-def gen_lvconv_line(lv_font_conv: str, dest: str, size: int, bpp: int, sources: typing.List[Source], compress:bool=False):
+def gen_lvconv_line(lv_font_conv: str, dest: str, size: int, bpp: int, sources: typing.List[Source], compress:bool=False, subpixel:bool=False):
     args = [lv_font_conv, '--size', str(size), '--output', dest, '--bpp', str(bpp), '--format', 'lvgl']
+    if subpixel:
+        args.append('--lcd')
     if not compress:
         args.append('--no-compress')
     for source in sources:

--- a/src/libs/lv_conf.h
+++ b/src/libs/lv_conf.h
@@ -432,7 +432,7 @@ typedef void* lv_indev_drv_user_data_t;            /*Type of user data in the in
 #define LV_USE_FONT_COMPRESSED 1
 
 /* Enable subpixel rendering */
-#define LV_USE_FONT_SUBPX 0
+#define LV_USE_FONT_SUBPX 1
 #if LV_USE_FONT_SUBPX
 /* Set the pixel order of the display.
  * Important only if "subpx fonts" are used.


### PR DESCRIPTION
I've enabled support for subpixel fonts in the lv_conf.h file and the generate.py script. The "subpixel" boolean option can be added to the options in the fonts.json file to generate subpixel fonts.