### PR TITLE
Update incorrect icon in weather settings

### DIFF
--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -116,7 +116,7 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(Controllers::DateTime& dateTimeCo
   weatherIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(weatherIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_text_font(weatherIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &fontawesome_weathericons);
-  lv_label_set_text(weatherIcon, Symbols::cloudSunRain);
+  lv_label_set_text(weatherIcon, Symbols::ban);
   lv_obj_align(weatherIcon, sidebar, LV_ALIGN_IN_TOP_MID, 0, 35);
   lv_obj_set_auto_realign(weatherIcon, true);
   if (settingsController.GetPTSWeather() == Pinetime::Controllers::Settings::PTSWeather::On) {
@@ -128,6 +128,7 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(Controllers::DateTime& dateTimeCo
   temperature = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(temperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_align(temperature, sidebar, LV_ALIGN_IN_TOP_MID, 0, 65);
+  lv_label_set_text_static(temperature, "--");
   if (settingsController.GetPTSWeather() == Pinetime::Controllers::Settings::PTSWeather::On) {
     lv_obj_set_hidden(temperature, false);
   } else {

--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -116,7 +116,7 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(Controllers::DateTime& dateTimeCo
   weatherIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(weatherIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_set_style_local_text_font(weatherIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &fontawesome_weathericons);
-  lv_label_set_text(weatherIcon, Symbols::ban);
+  lv_label_set_text(weatherIcon, Symbols::cloudSunRain);
   lv_obj_align(weatherIcon, sidebar, LV_ALIGN_IN_TOP_MID, 0, 35);
   lv_obj_set_auto_realign(weatherIcon, true);
   if (settingsController.GetPTSWeather() == Pinetime::Controllers::Settings::PTSWeather::On) {
@@ -128,7 +128,6 @@ WatchFacePineTimeStyle::WatchFacePineTimeStyle(Controllers::DateTime& dateTimeCo
   temperature = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(temperature, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   lv_obj_align(temperature, sidebar, LV_ALIGN_IN_TOP_MID, 0, 65);
-  lv_label_set_text_static(temperature, "--");
   if (settingsController.GetPTSWeather() == Pinetime::Controllers::Settings::PTSWeather::On) {
     lv_obj_set_hidden(temperature, false);
   } else {

--- a/src/displayapp/screens/settings/SettingWeatherFormat.cpp
+++ b/src/displayapp/screens/settings/SettingWeatherFormat.cpp
@@ -49,7 +49,7 @@ SettingWeatherFormat::SettingWeatherFormat(Pinetime::Controllers::Settings& sett
       0,
       1,
       "Weather format",
-      Symbols::clock,
+      Symbols::cloudSunRain,
       GetDefaultOption(settingsController.GetWeatherFormat()),
       [&settings = settingsController](uint32_t index) {
         settings.SetWeatherFormat(options[index].weatherFormat);

--- a/src/displayapp/screens/settings/SettingWeatherFormat.cpp
+++ b/src/displayapp/screens/settings/SettingWeatherFormat.cpp
@@ -49,7 +49,7 @@ SettingWeatherFormat::SettingWeatherFormat(Pinetime::Controllers::Settings& sett
       0,
       1,
       "Weather format",
-      Symbols::cloudSunRain,
+      Symbols::clock,
       GetDefaultOption(settingsController.GetWeatherFormat()),
       [&settings = settingsController](uint32_t index) {
         settings.SetWeatherFormat(options[index].weatherFormat);


### PR DESCRIPTION
The icon used in the WeatherFormatSetting.cpp file was incorrect. This PR changes the icon to the cloudSunRain symbol.