### PR TITLE
Update incorrect icon in weather settings

### DIFF
--- a/src/displayapp/screens/settings/SettingWeatherFormat.cpp
+++ b/src/displayapp/screens/settings/SettingWeatherFormat.cpp
@@ -49,7 +49,7 @@ SettingWeatherFormat::SettingWeatherFormat(Pinetime::Controllers::Settings& sett
       0,
       1,
       "Weather format",
-      Symbols::clock,
+      Symbols::cloudSunRain,
       GetDefaultOption(settingsController.GetWeatherFormat()),
       [&settings = settingsController](uint32_t index) {
         settings.SetWeatherFormat(options[index].weatherFormat);


### PR DESCRIPTION
The icon used in the WeatherFormatSetting.cpp file was incorrect. This PR changes the icon to the cloudSunRain symbol.

(This is a second PR because I accidentally committed an unrelated change to the branch being used for the first PR. Sorry about that!)