### PR TITLE
pinetimestyle: Round the displayed temperature

### DIFF
--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -548,7 +548,8 @@ void WatchFacePineTimeStyle::Refresh() {
       if (settingsController.GetWeatherFormat() == Controllers::Settings::WeatherFormat::Imperial) {
         temp = Controllers::SimpleWeatherService::CelsiusToFahrenheit(temp);
       }
-      lv_label_set_text_fmt(temperature, "%d°", temp / 100);
+      temp = temp / 100 + (temp % 100 >= 50 ? 1 : 0);
+      lv_label_set_text_fmt(temperature, "%d°", temp);
       lv_label_set_text(weatherIcon, Symbols::GetSymbol(optCurrentWeather->iconId));
       lv_obj_realign(temperature);
       lv_obj_realign(weatherIcon);


### PR DESCRIPTION
Instead of truncating. This fixes the displayed temperature being 1 degree lower than expected when using GadgetBridge.