### PR TITLE
Simple Weather Service : Fix timestamp

### DIFF
--- a/doc/SimpleWeatherService.md
+++ b/doc/SimpleWeatherService.md
@@ -28,7 +28,7 @@ The byte array must contain the following data:
 
  - [0] : Message type = `0`
  - [1] : Message version = `0`
- - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of nanoseconds elapsed since 1 JAN 1970)
+ - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of seconds elapsed since 1 JAN 1970)
  - [10, 11] : Current temperature (°C * 100)
  - [12, 13] : Minimum temperature (°C * 100)
  - [14, 15] : Maximum temperature (°C * 100)
@@ -50,7 +50,7 @@ The byte array must contain the following data:
 
   - [0] : Message type = `0`
   - [1] : Message version = `0`
-  - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of nanoseconds elapsed since 1 JAN 1970)
+  - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of seconds elapsed since 1 JAN 1970)
   - [10] Number of days (Max 5, fields for unused days should be set to `0`)
   - [11,12] Day 0 Minimum temperature (°C * 100)
   - [13,14] Day 0 Maximum temperature (°C * 100)

--- a/doc/SimpleWeatherService.md
+++ b/doc/SimpleWeatherService.md
@@ -28,7 +28,7 @@ The byte array must contain the following data:
 
  - [0] : Message type = `0`
  - [1] : Message version = `0`
- - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of seconds elapsed since 1 JAN 1970)
+ - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of seconds elapsed since 1 JAN 1970)  in local time (the same timezone than the one used to set the time)
  - [10, 11] : Current temperature (°C * 100)
  - [12, 13] : Minimum temperature (°C * 100)
  - [14, 15] : Maximum temperature (°C * 100)
@@ -50,7 +50,7 @@ The byte array must contain the following data:
 
   - [0] : Message type = `0`
   - [1] : Message version = `0`
-  - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of seconds elapsed since 1 JAN 1970)
+  - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of seconds elapsed since 1 JAN 1970) in local time (the same timezone than the one used to set the time)
   - [10] Number of days (Max 5, fields for unused days should be set to `0`)
   - [11,12] Day 0 Minimum temperature (°C * 100)
   - [13,14] Day 0 Maximum temperature (°C * 100)

--- a/doc/SimpleWeatherService.md
+++ b/doc/SimpleWeatherService.md
@@ -28,7 +28,7 @@ The byte array must contain the following data:
 
  - [0] : Message type = `0`
  - [1] : Message version = `0`
- - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of seconds elapsed since 1 JAN 1970)  in local time (the same timezone than the one used to set the time)
+ - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of seconds elapsed since 1 JAN 1970)  in local time (the same timezone as the one used to set the time)
  - [10, 11] : Current temperature (°C * 100)
  - [12, 13] : Minimum temperature (°C * 100)
  - [14, 15] : Maximum temperature (°C * 100)
@@ -50,7 +50,7 @@ The byte array must contain the following data:
 
   - [0] : Message type = `0`
   - [1] : Message version = `0`
-  - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of seconds elapsed since 1 JAN 1970) in local time (the same timezone than the one used to set the time)
+  - [2][3][4][5][6][7][8][9] : Timestamp (64 bits UNIX timestamp, number of seconds elapsed since 1 JAN 1970) in local time (the same timezone as the one used to set the time)
   - [10] Number of days (Max 5, fields for unused days should be set to `0`)
   - [11,12] Day 0 Minimum temperature (°C * 100)
   - [13,14] Day 0 Maximum temperature (°C * 100)

--- a/src/components/ble/SimpleWeatherService.cpp
+++ b/src/components/ble/SimpleWeatherService.cpp
@@ -127,7 +127,7 @@ int SimpleWeatherService::OnCommand(struct ble_gatt_access_ctxt* ctxt) {
 
 std::optional<SimpleWeatherService::CurrentWeather> SimpleWeatherService::Current() const {
   if (currentWeather) {
-    auto currentTime = dateTimeController.UTCDateTime().time_since_epoch();
+    auto currentTime = dateTimeController.CurrentDateTime().time_since_epoch();
     auto weatherTpSecond = std::chrono::seconds {currentWeather->timestamp};
     auto weatherTp = std::chrono::duration_cast<std::chrono::seconds>(weatherTpSecond);
     auto delta = currentTime - weatherTp;
@@ -141,7 +141,7 @@ std::optional<SimpleWeatherService::CurrentWeather> SimpleWeatherService::Curren
 
 std::optional<SimpleWeatherService::Forecast> SimpleWeatherService::GetForecast() const {
   if (forecast) {
-    auto currentTime = dateTimeController.UTCDateTime().time_since_epoch();
+    auto currentTime = dateTimeController.CurrentDateTime().time_since_epoch();
     auto weatherTpSecond = std::chrono::seconds {forecast->timestamp};
     auto weatherTp = std::chrono::duration_cast<std::chrono::seconds>(weatherTpSecond);
     auto delta = currentTime - weatherTp;


### PR DESCRIPTION
In the documentation, specify that the timestamp is expressed in seconds from epoch (instead of nanoseconds). SimpleWeatherService now uses "localtime" (GetCurrentDateTime()) instead of UTC time.