### PR TITLE
Updated docker build scripts

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -74,7 +74,7 @@ CmakeGenerate() {
 CmakeBuild() {
   local target="$1"
   [ -n "$target" ] && target="--target $target"
-  cmake --build "$BUILD_DIR" --config $BUILD_TYPE $target -- -j$(nproc)
+  cmake --build "$BUILD_DIR" --config $BUILD_TYPE --DBUILD_DFU=1 $target -- -j$(nproc)
   BUILD_RESULT=$?
   return $BUILD_RESULT
 }

--- a/docker/post_build.sh.in
+++ b/docker/post_build.sh.in
@@ -8,14 +8,30 @@ export PROJECT_VERSION="@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT
 
 mkdir -p "$OUTPUT_DIR"
 
-cp "$SOURCES_DIR"/bootloader/bootloader-5.0.4.bin $OUTPUT_DIR/bootloader.bin
-cp "$BUILD_DIR/src/pinetime-mcuboot-app-image-$PROJECT_VERSION.bin" "$OUTPUT_DIR/pinetime-mcuboot-app-image-$PROJECT_VERSION.bin"
-cp "$BUILD_DIR/src/pinetime-mcuboot-app-dfu-$PROJECT_VERSION.zip" "$OUTPUT_DIR/pinetime-mcuboot-app-dfu-$PROJECT_VERSION.zip"
-
-cp "$BUILD_DIR/src/pinetime-mcuboot-recovery-loader-image-$PROJECT_VERSION.bin" "$OUTPUT_DIR/pinetime-mcuboot-recovery-loader-image-$PROJECT_VERSION.bin"
-cp "$BUILD_DIR/src/pinetime-mcuboot-recovery-loader-dfu-$PROJECT_VERSION.zip" "$OUTPUT_DIR/pinetime-mcuboot-recovery-loader-dfu-$PROJECT_VERSION.zip"
-
-cp "$BUILD_DIR/src/resources/infinitime-resources-$PROJECT_VERSION.zip" "$OUTPUT_DIR/infinitime-resources-$PROJECT_VERSION.zip"
+if test -f "$SOURCES_DIR"/bootloader/bootloader-5.0.4.bin; then
+    echo "copying bootloader"
+    cp "$SOURCES_DIR"/bootloader/bootloader-5.0.4.bin $OUTPUT_DIR/bootloader.bin
+fi
+if test -f "$BUILD_DIR/src/pinetime-mcuboot-app-image-$PROJECT_VERSION.bin"; then
+    echo "copying pinetime-mcuboot-app-image....bin"
+    cp "$BUILD_DIR/src/pinetime-mcuboot-app-image-$PROJECT_VERSION.bin" "$OUTPUT_DIR/pinetime-mcuboot-app-image-$PROJECT_VERSION.bin"
+fi
+if test -f "$BUILD_DIR/src/pinetime-mcuboot-app-dfu-$PROJECT_VERSION.zip"; then
+    echo "copying pinetime-mcuboot-app-dfu....zip"
+    cp "$BUILD_DIR/src/pinetime-mcuboot-app-dfu-$PROJECT_VERSION.zip" "$OUTPUT_DIR/pinetime-mcuboot-app-dfu-$PROJECT_VERSION.zip"
+fi
+if test -f "$BUILD_DIR/src/pinetime-mcuboot-recovery-loader-image-$PROJECT_VERSION.bin"; then
+    echo "copying pinetime-mcuboot-recovery-loader-image....bin"
+    cp "$BUILD_DIR/src/pinetime-mcuboot-recovery-loader-image-$PROJECT_VERSION.bin" "$OUTPUT_DIR/pinetime-mcuboot-recovery-loader-image-$PROJECT_VERSION.bin"
+fi
+if test -f "$BUILD_DIR/src/pinetime-mcuboot-recovery-loader-dfu-$PROJECT_VERSION.zip"; then
+    echo "copying pinetime-mcuboot-recovery-loader-dfu....zip"
+    cp "$BUILD_DIR/src/pinetime-mcuboot-recovery-loader-dfu-$PROJECT_VERSION.zip" "$OUTPUT_DIR/pinetime-mcuboot-recovery-loader-dfu-$PROJECT_VERSION.zip"
+fi
+if test -f "$BUILD_DIR/src/resources/infinitime-resources-$PROJECT_VERSION.zip"; then
+    echo "copying infinitime-resources....zip"
+    cp "$BUILD_DIR/src/resources/infinitime-resources-$PROJECT_VERSION.zip" "$OUTPUT_DIR/infinitime-resources-$PROJECT_VERSION.zip"
+fi 
 
 mkdir -p "$OUTPUT_DIR/src"
 cp $BUILD_DIR/src/*.bin "$OUTPUT_DIR/src/"
@@ -24,3 +40,4 @@ cp $BUILD_DIR/src/*.out "$OUTPUT_DIR/src/"
 cp $BUILD_DIR/src/*.map "$OUTPUT_DIR/src/"
 
 ls -RUv1 "$OUTPUT_DIR" | sed 's;^\([^/]\); \1;g'
+

--- a/docker/runBuild
+++ b/docker/runBuild
@@ -1,0 +1,9 @@
+#!/bin/sh
+#
+# Build just the pinetime mcuboot app (with DFU version) by executing:
+#   ./docker/runBuild pinetime-mcuboot-app
+#  from the main InfiniTime repository folder
+#
+#docker run --rm -it -v ${PWD}:/sources --user $(id -u):$(id -g) infinitime-build
+docker run --rm -it -v ${PWD}:/sources --user $(id -u):$(id -g) infinitime-build /opt/build.sh $1
+


### PR DESCRIPTION
Updated docker build scripts to provide a simple command line, and allow building of a single target (e.g. pinetime-mcuboot-app) without errors from post_build.sh

From the main InfiniTime repository folder I do:
`./docker/runBuild pinetime-mcuboot-app`
to create a dfu file for just the main InfiniTime firmware without re-building the other components.

I still haven't found out how to solve the issue with the version number not updating when you change it in CMakelists.txt - so might add that change to this Pull Request if I fix it tomorrow.