### PR TITLE
BatteryIcon: Change color with charge percentage

### DIFF
--- a/src/displayapp/screens/BatteryIcon.cpp
+++ b/src/displayapp/screens/BatteryIcon.cpp
@@ -29,15 +29,7 @@ void BatteryIcon::SetBatteryPercentage(uint8_t percentage) {
   lv_obj_set_height(batteryJuice, percentage * 14 / 100);
   lv_obj_realign(batteryJuice);
   if (colorOnLowBattery) {
-    static constexpr int lowBatteryThreshold = 15;
-    static constexpr int criticalBatteryThreshold = 5;
-    if (percentage > lowBatteryThreshold) {
-      SetColor(LV_COLOR_WHITE);
-    } else if (percentage > criticalBatteryThreshold) {
-      SetColor(LV_COLOR_ORANGE);
-    } else {
-      SetColor(Colors::deepOrange);
-    }
+    SetColor(ColorFromPercentage(percentage));
   }
 }
 


### PR DESCRIPTION
Silly little change to dynamically color the battery based on the charge left.

![battery](https://github.com/InfiniTimeOrg/InfiniTime/assets/259780/940b97a5-6c0c-4822-ba0c-1a3c7e7b675b)
