### PR TITLE
WatchFacePineTimeStyle: Fix conditional in weather display

### DIFF
--- a/src/displayapp/screens/WatchFacePineTimeStyle.cpp
+++ b/src/displayapp/screens/WatchFacePineTimeStyle.cpp
@@ -540,7 +540,6 @@ void WatchFacePineTimeStyle::Refresh() {
   }
 
   currentWeather = weatherService.Current();
-
   if (currentWeather.IsUpdated()) {
     auto optCurrentWeather = currentWeather.Get();
     if (optCurrentWeather) {
@@ -551,12 +550,10 @@ void WatchFacePineTimeStyle::Refresh() {
       temp = temp / 100 + (temp % 100 >= 50 ? 1 : 0);
       lv_label_set_text_fmt(temperature, "%d°", temp);
       lv_label_set_text(weatherIcon, Symbols::GetSymbol(optCurrentWeather->iconId));
-      lv_obj_realign(temperature);
-      lv_obj_realign(weatherIcon);
+    } else {
+      lv_label_set_text(temperature, "--");
+      lv_label_set_text(weatherIcon, Symbols::ban);
     }
-  } else {
-    lv_label_set_text(temperature, "--");
-    lv_label_set_text(weatherIcon, Symbols::ban);
     lv_obj_realign(temperature);
     lv_obj_realign(weatherIcon);
   }


### PR DESCRIPTION
Since returning a valid weather is always considered an updated value, if the current weather is empty, the face will attempt to display the temperature and icon as empty values, rather than clearing the labels.