### PR TITLE
Split declaration and implementation of GetSymbol

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -394,6 +394,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/Error.cpp
         displayapp/screens/Alarm.cpp
         displayapp/screens/Styles.cpp
+        displayapp/screens/WeatherSymbols.cpp
         displayapp/Colors.cpp
         displayapp/widgets/Counter.cpp
         displayapp/widgets/PageIndicator.cpp

--- a/src/displayapp/screens/WeatherSymbols.cpp
+++ b/src/displayapp/screens/WeatherSymbols.cpp
@@ -1,0 +1,36 @@
+#include "displayapp/screens/WeatherSymbols.h"
+
+const char* Pinetime::Applications::Screens::Symbols::GetSymbol(const Pinetime::Controllers::SimpleWeatherService::Icons icon) {
+  switch (icon) {
+    case Pinetime::Controllers::SimpleWeatherService::Icons::Sun:
+      return Symbols::sun;
+      break;
+    case Pinetime::Controllers::SimpleWeatherService::Icons::CloudsSun:
+      return Symbols::cloudSun;
+      break;
+    case Pinetime::Controllers::SimpleWeatherService::Icons::Clouds:
+      return Symbols::cloud;
+      break;
+    case Pinetime::Controllers::SimpleWeatherService::Icons::BrokenClouds:
+      return Symbols::cloudMeatball;
+      break;
+    case Pinetime::Controllers::SimpleWeatherService::Icons::Thunderstorm:
+      return Symbols::bolt;
+      break;
+    case Pinetime::Controllers::SimpleWeatherService::Icons::Snow:
+      return Symbols::snowflake;
+      break;
+    case Pinetime::Controllers::SimpleWeatherService::Icons::CloudShowerHeavy:
+      return Symbols::cloudShowersHeavy;
+      break;
+    case Pinetime::Controllers::SimpleWeatherService::Icons::CloudSunRain:
+      return Symbols::cloudSunRain;
+      break;
+    case Pinetime::Controllers::SimpleWeatherService::Icons::Smog:
+      return Symbols::smog;
+      break;
+    default:
+      return Symbols::ban;
+      break;
+  }
+}

--- a/src/displayapp/screens/WeatherSymbols.h
+++ b/src/displayapp/screens/WeatherSymbols.h
@@ -6,40 +6,7 @@ namespace Pinetime {
   namespace Applications {
     namespace Screens {
       namespace Symbols {
-        const char* GetSymbol(const Pinetime::Controllers::SimpleWeatherService::Icons icon) {
-          switch (icon) {
-            case Pinetime::Controllers::SimpleWeatherService::Icons::Sun:
-              return Symbols::sun;
-              break;
-            case Pinetime::Controllers::SimpleWeatherService::Icons::CloudsSun:
-              return Symbols::cloudSun;
-              break;
-            case Pinetime::Controllers::SimpleWeatherService::Icons::Clouds:
-              return Symbols::cloud;
-              break;
-            case Pinetime::Controllers::SimpleWeatherService::Icons::BrokenClouds:
-              return Symbols::cloudMeatball;
-              break;
-            case Pinetime::Controllers::SimpleWeatherService::Icons::Thunderstorm:
-              return Symbols::bolt;
-              break;
-            case Pinetime::Controllers::SimpleWeatherService::Icons::Snow:
-              return Symbols::snowflake;
-              break;
-            case Pinetime::Controllers::SimpleWeatherService::Icons::CloudShowerHeavy:
-              return Symbols::cloudShowersHeavy;
-              break;
-            case Pinetime::Controllers::SimpleWeatherService::Icons::CloudSunRain:
-              return Symbols::cloudSunRain;
-              break;
-            case Pinetime::Controllers::SimpleWeatherService::Icons::Smog:
-              return Symbols::smog;
-              break;
-            default:
-              return Symbols::ban;
-              break;
-          }
-        }
+        const char* GetSymbol(const Pinetime::Controllers::SimpleWeatherService::Icons icon);
       }
     }
   }


### PR DESCRIPTION
When I was adding the new `SimpleWeatherService` to my Star Trek Watchface, the linker got confused about multiple implementations of `Pinetime::Applications::Screens::Symbols::GetSymbol`.
Including `WeatherSymbols.h` in two different files declared and implemented it two times.

This fixes that problem, by splitting the declaration and implementation of said function.