### PR TITLE
Fix motion service not updating when sleeping

### DIFF
--- a/src/components/ble/MotionService.cpp
+++ b/src/components/ble/MotionService.cpp
@@ -120,3 +120,7 @@ void MotionService::UnsubscribeNotification(uint16_t attributeHandle) {
   else if (attributeHandle == motionValuesHandle)
     motionValuesNoficationEnabled = false;
 }
+
+bool MotionService::IsMotionNotificationSubscribed() const {
+  return motionValuesNoficationEnabled;
+}

--- a/src/components/ble/MotionService.h
+++ b/src/components/ble/MotionService.h
@@ -21,6 +21,7 @@ namespace Pinetime {
 
       void SubscribeNotification(uint16_t attributeHandle);
       void UnsubscribeNotification(uint16_t attributeHandle);
+      bool IsMotionNotificationSubscribed() const;
 
     private:
       NimbleController& nimble;

--- a/src/components/motion/MotionController.h
+++ b/src/components/motion/MotionController.h
@@ -62,6 +62,10 @@ namespace Pinetime {
         this->service = service;
       }
 
+      Pinetime::Controllers::MotionService* GetService() const {
+        return service;
+      }
+
     private:
       uint32_t nbSteps = 0;
       uint32_t currentTripSteps = 0;

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -417,9 +417,9 @@ void SystemTask::UpdateMotion() {
     return;
   }
 
-  if (state == SystemTaskState::Sleeping &&
-      !(settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist) ||
-        settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::Shake) || bleController.IsConnected())) {
+  if (state == SystemTaskState::Sleeping && !(settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist) ||
+                                              settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::Shake) ||
+                                              motionController.GetService()->IsMotionNotificationSubscribed())) {
     return;
   }
 

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -417,8 +417,9 @@ void SystemTask::UpdateMotion() {
     return;
   }
 
-  if (state == SystemTaskState::Sleeping && !(settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist) ||
-                                              settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::Shake))) {
+  if (state == SystemTaskState::Sleeping &&
+      !(settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist) ||
+        settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::Shake) || bleController.IsConnected())) {
     return;
   }
 


### PR DESCRIPTION
This PR fixes the motion service not being updated when the device is sleeping. This would only happen in the case that there is no motion-based wake-up mode enabled.

Thanks to @apilat for the implementation.

Fixes #1843.
Supersedes #1207.