### PR TITLE
Fix bluetooth setting not actually changing bluetooth radio settings.

### DIFF
--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -402,7 +402,6 @@ void NimbleController::NotifyBatteryLevel(uint8_t level) {
 
 void NimbleController::EnableRadio() {
   bleController.EnableRadio();
-  bleController.Disconnect();
   fastAdvCount = 0;
   StartAdvertising();
 }


### PR DESCRIPTION
### Long Explanation
NimbleController.cpp was running bleController.Disconnect() each time NimbleController::EnableRadio() was called by SystemTask.cpp's case matching Messages::BleRadioEnableToggle. This meant that each time the bluetooth settings page was opened, the Messages::BleRadioEnableToggle case was matched and the setting variable bleRadioEnabled was set to false. This caused the conditionals for the checkboxList class call in SettingBluetooth.cpp to not allow toggling the bluetooth on and off, and caused the bluetooth status icon to dissappear in StatusIcons.cpp

### Short Explanation
The nimblecontroller was telling the bluetooth controller to disconnect when the radio was enabled, which was happening each time the bluetooth settings page was opened. This caused the toggles/checboxes in the bluetooth settings page to be un-changeable, and the bluetooth status icon to disappear.

(A large explanation for removing a single line of code... I know ;) )

This fixes #1961