### PR TITLE
Show blue icon when connected, grey when disconnected and hide when disabled

### DIFF
--- a/src/displayapp/widgets/StatusIcons.cpp
+++ b/src/displayapp/widgets/StatusIcons.cpp
@@ -37,10 +37,14 @@ void StatusIcons::Update() {
     batteryIcon.SetBatteryPercentage(batteryPercent);
   }
 
-  bleState = bleController.IsConnected();
   bleRadioEnabled = bleController.IsRadioEnabled();
-  if (bleState.IsUpdated() || bleRadioEnabled.IsUpdated()) {
-    lv_obj_set_hidden(bleIcon, !bleState.Get());
+  if (bleRadioEnabled.IsUpdated()) {
+    lv_obj_set_hidden(bleIcon, !bleRadioEnabled.Get());
+  }
+
+  bleState = bleController.IsConnected();
+  if (bleState.IsUpdated()) {
+    lv_obj_set_style_local_text_color(bleIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, bleState.Get()?LV_COLOR_BLUE:LV_COLOR_GRAY);
   }
 
   lv_obj_realign(container);


### PR DESCRIPTION
This PR changes behaviour of bluetooth icon display.

Previous behaviour was that the icon showed coloured white when enabled and connected.

New behaviou is that the icon shows blue when connected, grey when disconnected and is hidden when disabled. This provides more info in the same space and is consistent with many common implementations which may offer a more familiar workflow.