### PR TITLE
Rationalise use of status in faces.

### DIFF
--- a/src/displayapp/screens/WatchFaceAnalog.cpp
+++ b/src/displayapp/screens/WatchFaceAnalog.cpp
@@ -1,9 +1,6 @@
 #include "displayapp/screens/WatchFaceAnalog.h"
 #include <cmath>
 #include <lvgl/lvgl.h>
-#include "displayapp/screens/BatteryIcon.h"
-#include "displayapp/screens/BleIcon.h"
-#include "displayapp/screens/Symbols.h"
 #include "displayapp/screens/NotificationIcon.h"
 #include "components/settings/Settings.h"
 #include "displayapp/InfiniTimeTheme.h"
@@ -47,12 +44,12 @@ WatchFaceAnalog::WatchFaceAnalog(Controllers::DateTime& dateTimeController,
                                  Controllers::NotificationManager& notificationManager,
                                  Controllers::Settings& settingsController)
   : currentDateTime {{}},
-    batteryIcon(true),
     dateTimeController {dateTimeController},
-    batteryController {batteryController},
-    bleController {bleController},
     notificationManager {notificationManager},
-    settingsController {settingsController} {
+    settingsController {settingsController},
+    statusIcons(batteryController, bleController) {
+
+  statusIcons.Create();
 
   sHour = 99;
   sMinute = 99;
@@ -93,17 +90,6 @@ WatchFaceAnalog::WatchFaceAnalog(Controllers::DateTime& dateTimeController,
   lv_label_set_text_static(twelve, "12");
   lv_obj_set_pos(twelve, 110, 10);
   lv_obj_set_style_local_text_color(twelve, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_AQUA);
-
-  batteryIcon.Create(lv_scr_act());
-  lv_obj_align(batteryIcon.GetObject(), nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
-
-  plugIcon = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_static(plugIcon, Symbols::plug);
-  lv_obj_align(plugIcon, nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
-
-  bleIcon = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_static(bleIcon, "");
-  lv_obj_align(bleIcon, nullptr, LV_ALIGN_IN_TOP_RIGHT, -30, 0);
 
   notificationIcon = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_color(notificationIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_LIME);
@@ -213,38 +199,8 @@ void WatchFaceAnalog::UpdateClock() {
   }
 }
 
-void WatchFaceAnalog::SetBatteryIcon() {
-  auto batteryPercent = batteryPercentRemaining.Get();
-  batteryIcon.SetBatteryPercentage(batteryPercent);
-}
-
 void WatchFaceAnalog::Refresh() {
-  isCharging = batteryController.IsCharging();
-  if (isCharging.IsUpdated()) {
-    if (isCharging.Get()) {
-      lv_obj_set_hidden(batteryIcon.GetObject(), true);
-      lv_obj_set_hidden(plugIcon, false);
-    } else {
-      lv_obj_set_hidden(batteryIcon.GetObject(), false);
-      lv_obj_set_hidden(plugIcon, true);
-      SetBatteryIcon();
-    }
-  }
-  if (!isCharging.Get()) {
-    batteryPercentRemaining = batteryController.PercentRemaining();
-    if (batteryPercentRemaining.IsUpdated()) {
-      SetBatteryIcon();
-    }
-  }
-
-  bleState = bleController.IsConnected();
-  if (bleState.IsUpdated()) {
-    if (bleState.Get()) {
-      lv_label_set_text_static(bleIcon, Symbols::bluetooth);
-    } else {
-      lv_label_set_text_static(bleIcon, "");
-    }
-  }
+  statusIcons.Update();
 
   notificationState = notificationManager.AreNewNotificationsAvailable();
 

--- a/src/displayapp/screens/WatchFaceAnalog.h
+++ b/src/displayapp/screens/WatchFaceAnalog.h
@@ -6,10 +6,9 @@
 #include <memory>
 #include "displayapp/screens/Screen.h"
 #include "components/datetime/DateTimeController.h"
-#include "components/battery/BatteryController.h"
 #include "components/ble/BleController.h"
+#include "displayapp/widgets/StatusIcons.h"
 #include "components/ble/NotificationManager.h"
-#include "displayapp/screens/BatteryIcon.h"
 #include "utility/DirtyValue.h"
 
 namespace Pinetime {
@@ -38,9 +37,6 @@ namespace Pinetime {
       private:
         uint8_t sHour, sMinute, sSecond;
 
-        Utility::DirtyValue<uint8_t> batteryPercentRemaining {0};
-        Utility::DirtyValue<bool> isCharging {};
-        Utility::DirtyValue<bool> bleState {};
         Utility::DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>> currentDateTime;
         Utility::DirtyValue<bool> notificationState {false};
         using days = std::chrono::duration<int32_t, std::ratio<86400>>; // TODO: days is standard in c++20
@@ -70,22 +66,16 @@ namespace Pinetime {
         lv_style_t second_line_style;
 
         lv_obj_t* label_date_day;
-        lv_obj_t* plugIcon;
         lv_obj_t* notificationIcon;
-        lv_obj_t* bleIcon;
-
-        BatteryIcon batteryIcon;
 
         const Controllers::DateTime& dateTimeController;
-        const Controllers::Battery& batteryController;
-        const Controllers::Ble& bleController;
         Controllers::NotificationManager& notificationManager;
         Controllers::Settings& settingsController;
 
         void UpdateClock();
-        void SetBatteryIcon();
 
         lv_task_t* taskRefresh;
+        Widgets::StatusIcons statusIcons;
       };
     }
 

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -4,8 +4,6 @@
 #include <cstdio>
 #include "displayapp/screens/NotificationIcon.h"
 #include "displayapp/screens/Symbols.h"
-#include "components/battery/BatteryController.h"
-#include "components/ble/BleController.h"
 #include "components/ble/NotificationManager.h"
 #include "components/heartrate/HeartRateController.h"
 #include "components/motion/MotionController.h"

--- a/src/displayapp/screens/WatchFaceDigital.h
+++ b/src/displayapp/screens/WatchFaceDigital.h
@@ -41,10 +41,6 @@ namespace Pinetime {
         uint8_t displayedHour = -1;
         uint8_t displayedMinute = -1;
 
-        Utility::DirtyValue<uint8_t> batteryPercentRemaining {};
-        Utility::DirtyValue<bool> powerPresent {};
-        Utility::DirtyValue<bool> bleState {};
-        Utility::DirtyValue<bool> bleRadioEnabled {};
         Utility::DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::minutes>> currentDateTime {};
         Utility::DirtyValue<uint32_t> stepCount {};
         Utility::DirtyValue<uint8_t> heartbeat {};


### PR DESCRIPTION
This PR adds StatusIcons to WatchFaceAnalog. This rationalises the use of StatusIcons that was previously used on many screens but not the analogue watchface. The core advantage is that we have common code that reduces undesirable or unexpected behaviour, e.g. changes to StatusIcons would not be evident in the analouge watch face.