### PR TITLE
Add option to keep display on always

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -212,11 +212,11 @@ void DisplayApp::Refresh() {
       }
       queueTimeout = lv_task_handler();
 
-      if (!systemTask->IsSleepDisabled() && IsPastDimTime()) {
+      if (settingsController.GetScreenTimeOut() && !systemTask->IsSleepDisabled() && IsPastDimTime()) {
         if (!isDimmed) {
           DimScreen();
         }
-        if (IsPastSleepTime()) {
+        if (settingsController.GetScreenTimeOut() && IsPastSleepTime()) {
           systemTask->PushMessage(System::Messages::GoToSleep);
           state = States::Idle;
         }

--- a/src/displayapp/screens/settings/SettingDisplay.cpp
+++ b/src/displayapp/screens/settings/SettingDisplay.cpp
@@ -43,10 +43,13 @@ SettingDisplay::SettingDisplay(Pinetime::Applications::DisplayApp* app, Pinetime
   lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
 
-  char buffer[4];
+  char buffer[5];
   for (unsigned int i = 0; i < options.size(); i++) {
     cbOption[i] = lv_checkbox_create(container1, nullptr);
-    snprintf(buffer, sizeof(buffer), "%2" PRIu16 "s", options[i] / 1000);
+    if (options[i])
+      snprintf(buffer, sizeof(buffer), "%2" PRIu16 "s", options[i] / 1000);
+    else
+      sprintf(buffer, " On");
     lv_checkbox_set_text(cbOption[i], buffer);
     cbOption[i]->user_data = this;
     lv_obj_set_event_cb(cbOption[i], event_handler);

--- a/src/displayapp/screens/settings/SettingDisplay.h
+++ b/src/displayapp/screens/settings/SettingDisplay.h
@@ -21,7 +21,7 @@ namespace Pinetime {
 
       private:
         DisplayApp* app;
-        static constexpr std::array<uint16_t, 6> options = {5000, 7000, 10000, 15000, 20000, 30000};
+        static constexpr std::array<uint16_t, 6> options = {5000, 10000, 15000, 30000, 60000, 0};
 
         Controllers::Settings& settingsController;
         lv_obj_t* cbOption[options.size()];


### PR DESCRIPTION
The PR adds an option to keep the watch display always on. Previously there were options to keep the diplay on for:

- 5s
- 7s
- 10s
- 15s
- 20s
- 30s

This change offers options:

- 5s
- 10s
- 15s
- 30s
- 60s
- On (always on)

Display can still be turned off (sleep) with button press.

There may be apps or workflows that require the display to remain on until manually turned off or where the available durations are not sufficient.