### PR TITLE
touchhandler: custom gesture detection

### DIFF
--- a/src/touchhandler/TouchHandler.cpp
+++ b/src/touchhandler/TouchHandler.cpp
@@ -3,30 +3,6 @@
 using namespace Pinetime::Controllers;
 using namespace Pinetime::Applications;
 
-namespace {
-  TouchEvents ConvertGesture(Pinetime::Drivers::Cst816S::Gestures gesture) {
-    switch (gesture) {
-      case Pinetime::Drivers::Cst816S::Gestures::SingleTap:
-        return TouchEvents::Tap;
-      case Pinetime::Drivers::Cst816S::Gestures::LongPress:
-        return TouchEvents::LongTap;
-      case Pinetime::Drivers::Cst816S::Gestures::DoubleTap:
-        return TouchEvents::DoubleTap;
-      case Pinetime::Drivers::Cst816S::Gestures::SlideRight:
-        return TouchEvents::SwipeRight;
-      case Pinetime::Drivers::Cst816S::Gestures::SlideLeft:
-        return TouchEvents::SwipeLeft;
-      case Pinetime::Drivers::Cst816S::Gestures::SlideDown:
-        return TouchEvents::SwipeDown;
-      case Pinetime::Drivers::Cst816S::Gestures::SlideUp:
-        return TouchEvents::SwipeUp;
-      case Pinetime::Drivers::Cst816S::Gestures::None:
-      default:
-        return TouchEvents::None;
-    }
-  }
-}
-
 Pinetime::Applications::TouchEvents TouchHandler::GestureGet() {
   auto returnGesture = gesture;
   gesture = Pinetime::Applications::TouchEvents::None;
@@ -34,33 +10,67 @@ Pinetime::Applications::TouchEvents TouchHandler::GestureGet() {
 }
 
 bool TouchHandler::ProcessTouchInfo(Drivers::Cst816S::TouchInfos info) {
+  bool swiping = false;
+
   if (!info.isValid) {
     return false;
   }
 
-  // Only a single gesture per touch
-  if (info.gesture != Pinetime::Drivers::Cst816S::Gestures::None) {
-    if (gestureReleased) {
-      if (info.gesture == Pinetime::Drivers::Cst816S::Gestures::SlideDown ||
-          info.gesture == Pinetime::Drivers::Cst816S::Gestures::SlideLeft ||
-          info.gesture == Pinetime::Drivers::Cst816S::Gestures::SlideUp ||
-          info.gesture == Pinetime::Drivers::Cst816S::Gestures::SlideRight ||
-          info.gesture == Pinetime::Drivers::Cst816S::Gestures::LongPress) {
-        if (info.touching) {
-          gesture = ConvertGesture(info.gesture);
-          gestureReleased = false;
-        }
+  // Keep the swipe state enabled till we stop touching the screen
+  if (currentTouchPoint.swiping) {
+    xSwipeDistance += currentTouchPoint.x - info.x;
+    ySwipeDistance += currentTouchPoint.y - info.y;
+    // Prevent the longTapCounter from increasing while swiping
+    longTapCounter = 0;
+    swiping = true;
+  // Enable the swipe state if we were touching last check, and the previous values are different from the current ones
+  } else if (currentTouchPoint.touching && (currentTouchPoint.x != info.x || currentTouchPoint.y != info.y)) {
+    swiping = true;
+  }
+
+
+  if (gestureReleased) {
+    // Vertical Swipes
+    if (std::abs(ySwipeDistance) >= minimumSwipeDistance) {
+      if (std::signbit(ySwipeDistance)) {
+        gesture = TouchEvents::SwipeDown;
+        gestureReleased = false;
       } else {
-        gesture = ConvertGesture(info.gesture);
+        gesture = TouchEvents::SwipeUp;
+        gestureReleased = false;
       }
+    // Horizontal Swipes
+    } else if (std::abs(xSwipeDistance) >= minimumSwipeDistance) {
+      if (std::signbit(xSwipeDistance)) {
+        gesture = TouchEvents::SwipeRight;
+        gestureReleased = false;
+      } else {
+        gesture = TouchEvents::SwipeLeft;
+        gestureReleased = false;
+      }
+    // Long Tap
+    } else if (longTapCounter >= longTapHoldTime) {
+      gesture = TouchEvents::LongTap;
+      gestureReleased = false;
+    // Double Tap
+    } else if (info.gesture == Pinetime::Drivers::Cst816S::Gestures::DoubleTap) {
+      gesture = TouchEvents::DoubleTap;
+    // Single Tap
+    } else if (info.touching) {
+      gesture = TouchEvents::Tap;
+      longTapCounter += 1;
     }
   }
 
   if (!info.touching) {
     gestureReleased = true;
+    swiping = false;
+    xSwipeDistance = 0;
+    ySwipeDistance = 0;
+    longTapCounter = 0;
   }
 
-  currentTouchPoint = {info.x, info.y, info.touching};
+  currentTouchPoint = {info.x, info.y, currentTouchPoint.x, currentTouchPoint.y, info.touching, swiping};
 
   return true;
 }

--- a/src/touchhandler/TouchHandler.h
+++ b/src/touchhandler/TouchHandler.h
@@ -2,6 +2,8 @@
 #include "drivers/Cst816s.h"
 #include "displayapp/TouchEvents.h"
 
+#include <cmath>
+
 namespace Pinetime {
   namespace Controllers {
     class TouchHandler {
@@ -9,7 +11,10 @@ namespace Pinetime {
       struct TouchPoint {
         int x;
         int y;
+        int previousX;
+        int previousY;
         bool touching;
+        bool swiping;
       };
 
       bool ProcessTouchInfo(Drivers::Cst816S::TouchInfos info);
@@ -29,9 +34,16 @@ namespace Pinetime {
       Pinetime::Applications::TouchEvents GestureGet();
 
     private:
+      const uint8_t minimumSwipeDistance = 65;
+      const uint8_t longTapHoldTime = 50;
+
       Pinetime::Applications::TouchEvents gesture;
       TouchPoint currentTouchPoint = {};
       bool gestureReleased = true;
+      // Total distance for a given swipe
+      int16_t xSwipeDistance = 0;
+      int16_t ySwipeDistance = 0;
+      uint16_t longTapCounter = 0;
     };
   }
 }


### PR DESCRIPTION
This PR implements InfiniTime's own code for detecting gestures within the TouchHandler, instead of using the gesture detection built-in to the Cst816S. The only gesture that hasn't been re-implemented is the DoubleTap because the built in DoubleTap detection works just fine as is.

This PR allows us to easily re-configure the gestures. Swiping works much more consistently now due to a lower distance required to be detected. The LongTap gesture is also greatly improved here, with a much lower hold duration, making it activate much more consistently.

I also plan to implement smooth scrolling in places like the app drawer and the settings screen. Re-implementing the gesture system is required for that, and it will depend on this PR