### PR TITLE
ApplicationList: Reset app menu screen when loading watch face

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -446,6 +446,7 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
       else {
         currentScreen.reset(userWatchFaces[0].create(controllers));
       }
+      settingsController.SetAppMenu(0);
     } break;
     case Apps::Error:
       currentScreen = std::make_unique<Screens::Error>(bootError);


### PR DESCRIPTION
This prevents the application list from loading in the last used screen and instead goes back to the first screen whenever the watch face is loaded.

Fixes #2006