### PR TITLE
SimpleWeatherService: Add forecast operator overrides

### DIFF
--- a/src/components/ble/SimpleWeatherService.cpp
+++ b/src/components/ble/SimpleWeatherService.cpp
@@ -158,3 +158,16 @@ bool SimpleWeatherService::CurrentWeather::operator==(const SimpleWeatherService
          this->maxTemperature == other.maxTemperature && this->minTemperature == other.maxTemperature &&
          std::strcmp(this->location.data(), other.location.data()) == 0;
 }
+
+bool SimpleWeatherService::Forecast::Day::operator==(const SimpleWeatherService::Forecast::Day& other) const {
+  return this->iconId == other.iconId && this->maxTemperature == other.maxTemperature && this->minTemperature == other.maxTemperature;
+}
+
+bool SimpleWeatherService::Forecast::operator==(const SimpleWeatherService::Forecast& other) const {
+  for (int i = 0; i < this->nbDays; i++) {
+    if (this->days[i] != other.days[i]) {
+      return false;
+    }
+  }
+  return this->timestamp == other.timestamp && this->nbDays == other.nbDays;
+}

--- a/src/components/ble/SimpleWeatherService.h
+++ b/src/components/ble/SimpleWeatherService.h
@@ -96,9 +96,13 @@ namespace Pinetime {
           int16_t minTemperature;
           int16_t maxTemperature;
           Icons iconId;
+
+          bool operator==(const Day& other) const;
         };
 
         std::array<Day, MaxNbForecastDays> days;
+
+        bool operator==(const Forecast& other) const;
       };
 
       std::optional<CurrentWeather> Current() const;


### PR DESCRIPTION
Any screen that relies on DirtyValue to display up-to-date forecast data would require the struct to provide an operator override for comparison.