### PR TITLE
lowersleep: Improve algorithm by checking wrist angle

### DIFF
--- a/src/components/motion/MotionController.h
+++ b/src/components/motion/MotionController.h
@@ -21,7 +21,7 @@ namespace Pinetime {
       void Update(int16_t x, int16_t y, int16_t z, uint32_t nbSteps);
 
       int16_t X() const {
-        return x;
+        return xHistory[0];
       }
 
       int16_t Y() const {
@@ -76,11 +76,14 @@ namespace Pinetime {
       struct AccelStats {
         static constexpr uint8_t numHistory = 2;
 
+        int16_t xMean = 0;
         int16_t yMean = 0;
         int16_t zMean = 0;
+        int16_t prevXMean = 0;
         int16_t prevYMean = 0;
         int16_t prevZMean = 0;
 
+        uint32_t xVariance = 0;
         uint32_t yVariance = 0;
         uint32_t zVariance = 0;
       };
@@ -89,9 +92,8 @@ namespace Pinetime {
 
       AccelStats stats = {};
 
-      int16_t lastX = 0;
-      int16_t x = 0;
       static constexpr uint8_t histSize = 8;
+      Utility::CircularBuffer<int16_t, histSize> xHistory = {};
       Utility::CircularBuffer<int16_t, histSize> yHistory = {};
       Utility::CircularBuffer<int16_t, histSize> zHistory = {};
       int32_t accumulatedSpeed = 0;


### PR DESCRIPTION
Inspired by @darkdragon-001 https://github.com/InfiniTimeOrg/InfiniTime/pull/827#issuecomment-1881580414.

Checks if the user's wrist is pointing towards the floor, rather than only the amount of roll. It will turn off the display if the watch is angled at 60 degrees or more, and rotated at least 30 degrees within the last ~600ms.