### PR TITLE
Fix chimes

### DIFF
--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -342,8 +342,12 @@ void SystemTask::Work() {
           if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep &&
               settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::Hours &&
               alarmController.State() != AlarmController::AlarmState::Alerting) {
+            // if sleeping, we can't send a chime to displayApp yet (SPI flash switched off)
+            // request running first and repush the chime message
             if (state == SystemTaskState::Sleeping) {
               GoToRunning();
+              PushMessage(msg);
+            } else {
               displayApp.PushMessage(Pinetime::Applications::Display::Messages::Chime);
             }
           }
@@ -353,8 +357,12 @@ void SystemTask::Work() {
           if (settingsController.GetNotificationStatus() != Controllers::Settings::Notification::Sleep &&
               settingsController.GetChimeOption() == Controllers::Settings::ChimesOption::HalfHours &&
               alarmController.State() != AlarmController::AlarmState::Alerting) {
+            // if sleeping, we can't send a chime to displayApp yet (SPI flash switched off)
+            // request running first and repush the chime message
             if (state == SystemTaskState::Sleeping) {
               GoToRunning();
+              PushMessage(msg);
+            } else {
               displayApp.PushMessage(Pinetime::Applications::Display::Messages::Chime);
             }
           }


### PR DESCRIPTION
Only thing notable here is that pushing two messages at once increases the chance of the systemTask queue getting full (which deadlocks the task as it waits forever on queue push). But I don't think it ever should fill up (10 entries), so I think it's OK.

Closes #1411