### PR TITLE
Fix OOB flash write when DFU interrupted

### DIFF
--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -357,6 +357,8 @@ void DfuService::DfuImage::Init(size_t chunkSize, size_t totalSize, uint16_t exp
   this->totalSize = totalSize;
   this->expectedCrc = expectedCrc;
   this->ready = true;
+  totalWriteIndex = 0;
+  bufferWriteIndex = 0;
 }
 
 void DfuService::DfuImage::Append(uint8_t* data, size_t size) {


### PR DESCRIPTION
If a DFU is restarted, the write indices aren't reset causing the image to be written out of bounds. The CRC check prevents the faulty image from booting but LittleFS still gets nuked.

There are other issues with DFU if the central is acting maliciously, but this resolves a corruption encountered in normal usage. If a DFU fails for whatever reason (bad bluetooth signal, whatever), the user is likely to retry the update which will fail if they do not reboot first due to this issue.