### PR TITLE
Fix conflicts of min and max from stl_algo.h included from stdatomic

### DIFF
--- a/src/components/ble/HeartRateService.h
+++ b/src/components/ble/HeartRateService.h
@@ -2,9 +2,9 @@
 #define min // workaround: nimble's min/max macros conflict with libstdc++
 #define max
 #include <host/ble_gap.h>
-#include <atomic>
 #undef max
 #undef min
+#include <atomic>
 
 namespace Pinetime {
   namespace Controllers {


### PR DESCRIPTION
This issue was observed when attempting to compile the file `HeartRateController.cpp` as an individual object file with x86 gcc by using `compile_commands.json` generated by running `bear` on the project's build command.

Here is the error log - 

```bash
/usr/include/c++/11/bits/stl_algobase.h:230:9: error: expected unqualified-id before ‘const’
  230 |     min(const _Tp& __a, const _Tp& __b)
      |         ^~~~~
/usr/include/c++/11/bits/stl_algobase.h:230:9: error: expected ‘)’ before ‘const’
  230 |     min(const _Tp& __a, const _Tp& __b)
      |        ~^~~~~
      |         )
/usr/include/c++/11/bits/stl_algobase.h:254:9: error: expected unqualified-id before ‘const’
  254 |     max(const _Tp& __a, const _Tp& __b)
      |         ^~~~~
/usr/include/c++/11/bits/stl_algobase.h:254:9: error: expected ‘)’ before ‘const’
  254 |     max(const _Tp& __a, const _Tp& __b)
      |        ~^~~~~
      |         )
/usr/include/c++/11/bits/stl_algobase.h:278:9: error: expected unqualified-id before ‘const’
  278 |     min(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |         ^~~~~
/usr/include/c++/11/bits/stl_algobase.h:278:9: error: expected ‘)’ before ‘const’
  278 |     min(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |        ~^~~~~
      |         )
/usr/include/c++/11/bits/stl_algobase.h:300:9: error: expected unqualified-id before ‘const’
  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |         ^~~~~
/usr/include/c++/11/bits/stl_algobase.h:300:9: error: expected ‘)’ before ‘const’
  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |        ~^~~~~
      |         )
/usr/include/c++/11/bits/stl_algobase.h: In static member function ‘static constexpr std::ptrdiff_t std::__lexicographical_compare<true>::__3way(const _Tp*, const _Tp*, const _Up*, const _Up*)’:
/usr/include/c++/11/bits/stl_algobase.h:1355:44: error: expected unqualified-id before ‘(’ token
 1355 |           if (const size_t __len = std::min(__len1, __len2))
      |                                            ^
In file included from /usr/include/c++/11/bits/stl_algo.h:60,
                 from /usr/include/c++/11/string:52,
                 from /usr/include/c++/11/stdexcept:39,
                 from /usr/include/c++/11/system_error:41,
                 from /usr/include/c++/11/bits/std_mutex.h:39,
                 from /usr/include/c++/11/bits/atomic_wait.h:49,
                 from /usr/include/c++/11/bits/atomic_base.h:41,
                 from /usr/include/c++/11/atomic:41,
                 from ~/Infinitime/src/components/ble/HeartRateService.h:5,
                 from ~/Infinitime/src/components/heartrate/HeartRateController.h:4```

The exact compilation command run was -  

```bash
g++ -DBOARD_PCA10040 -DCLOCK_CONFIG_LF_SRC=1 -DCONFIG_GPIO_AS_PINRESET -DDRIVER_PINMAP_PINETIME -DFREERTOS -DMYNEWT_VAL_BLE_LL_RFMGMT_ENABLE_TIME=1500 -DNDEBUG -DNIMBLE_CFG_CONTROLLER -DNRF52 -DNRF52832 -DNRF52832_XXAA -DNRF52_PAN_12 -DNRF52_PAN_15 -DNRF52_PAN_20 -DNRF52_PAN_31 -DNRF52_PAN_36 -DNRF52_PAN_51 -DNRF52_PAN_54 -DNRF52_PAN_55 -DNRF52_PAN_58 -DNRF52_PAN_64 -DNRF52_PAN_74 -DOS_CPUTIME_FREQ -DTARGET_DEVICE_NAME="PINETIME" -DTARGET_DEVICE_PINETIME -D__HEAP_SIZE=0 -D__STACK_SIZE=1024 -I~/Infinitime/build/src -I~/Infinitime/build/src/displayapp/apps -isystem ~/Infinitime/src/. -isystem ~/Infinitime/src/.. -isystem ~/Infinitime/src/libs -isystem ~/Infinitime/src/FreeRTOS -isystem ~/Infinitime/src/libs/mynewt-nimble/porting/npl/freertos/include -isystem ~/Infinitime/src/libs/mynewt-nimble/nimble/include -isystem ~/Infinitime/src/libs/mynewt-nimble/porting/nimble/include -isystem ~/Infinitime/src/libs/mynewt-nimble/nimble/host/include -isystem ~/Infinitime/src/libs/mynewt-nimble/nimble/controller/include -isystem ~/Infinitime/src/libs/mynewt-nimble/nimble/transport/ram/include -isystem ~/Infinitime/src/libs/mynewt-nimble/nimble/drivers/nrf52/include -isystem ~/Infinitime/src/libs/mynewt-nimble/ext/tinycrypt/include -isystem ~/Infinitime/src/libs/mynewt-nimble/nimble/host/services/gap/include -isystem ~/Infinitime/src/libs/mynewt-nimble/nimble/host/services/gatt/include -isystem ~/Infinitime/src/libs/mynewt-nimble/nimble/host/util/include -isystem ~/Infinitime/src/libs/mynewt-nimble/nimble/host/store/ram/include -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/drivers_nrf/nrf_soc_nosd -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/boards -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/softdevice/common -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/integration/nrfx -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/integration/nrfx/legacy -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/modules/nrfx -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/modules/nrfx/drivers/include -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/modules/nrfx/hal -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/modules/nrfx/mdk -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/external/freertos/source/include -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/toolchain/cmsis/include -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/atomic -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/atomic_fifo -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/atomic_flags -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/balloc -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/bootloader/ble_dfu -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/cli -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/crc16 -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/crc32 -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/crypto -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/csense -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/csense_drv -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/delay -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/ecc -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/experimental_section_vars -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/experimental_task_manager -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/fds -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/fstorage -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/gfx -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/gpiote -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/hardfault -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/hci -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/led_softblink -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/log -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/log/src -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/low_power_pwm -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/mem_manager -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/memobj -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/mpu -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/mutex -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/pwm -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/pwr_mgmt -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/queue -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/ringbuf -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/scheduler -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/sdcard -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/slip -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/sortlist -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/spi_mngr -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/stack_guard -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/strerror -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/svc -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/timer -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/usbd -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/usbd/class/audio -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/usbd/class/cdc -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/usbd/class/cdc/acm -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/usbd/class/hid -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/usbd/class/hid/generic -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/usbd/class/hid/kbd -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/usbd/class/hid/mouse -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/usbd/class/msc -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/components/libraries/util -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/external/segger_rtt -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/external/fprintf -isystem ~/Infinitime/src/../nRF5_SDK_15.3.0_59ac345/external/thedotfactory_fonts  -m32 -O0 -std=c++20 -c -o test.o ~/Infinitime/src/components/heartrate/HeartRateController.cpp
```

Note that the issue does not occur when this file is compiled with `-std=c++17`. Nevertheless, the proposed patch fixes the issue from it's root cause by ensuring `min` and `max` are undefined before including `stdatomic`