### PR TITLE
Fix bluetooth setting : emit the radio toggle message only if the value of the setting changed

### DIFF
--- a/src/displayapp/screens/settings/SettingBluetooth.cpp
+++ b/src/displayapp/screens/settings/SettingBluetooth.cpp
@@ -36,17 +36,19 @@ namespace {
 
 SettingBluetooth::SettingBluetooth(Pinetime::Applications::DisplayApp* app, Pinetime::Controllers::Settings& settingsController)
   : app {app},
+    settings {settingsController},
     checkboxList(
       0,
       1,
       "Bluetooth",
       Symbols::bluetooth,
       settingsController.GetBleRadioEnabled() ? 0 : 1,
-      [&settings = settingsController](uint32_t index) {
+      [this](uint32_t index) {
         const bool priorMode = settings.GetBleRadioEnabled();
         const bool newMode = options[index].radioEnabled;
         if (newMode != priorMode) {
           settings.SetBleRadioEnabled(newMode);
+          this->app->PushMessage(Pinetime::Applications::Display::Messages::BleRadioEnableToggle);
         }
       },
       CreateOptionArray()) {
@@ -54,6 +56,4 @@ SettingBluetooth::SettingBluetooth(Pinetime::Applications::DisplayApp* app, Pine
 
 SettingBluetooth::~SettingBluetooth() {
   lv_obj_clean(lv_scr_act());
-  // Pushing the message in the OnValueChanged function causes a freeze?
-  app->PushMessage(Pinetime::Applications::Display::Messages::BleRadioEnableToggle);
 }

--- a/src/displayapp/screens/settings/SettingBluetooth.h
+++ b/src/displayapp/screens/settings/SettingBluetooth.h
@@ -20,6 +20,7 @@ namespace Pinetime {
 
       private:
         DisplayApp* app;
+        Pinetime::Controllers::Settings& settings;
         CheckboxList checkboxList;
       };
     }


### PR DESCRIPTION
Emit the message BleRadioEnableToggle to DisplayApp only if the enable state of the radio has actually changed.

This fixes an issue where the BLE connected logo would disappear when opening and closing the BLE setting (without changing it) while InfiniTime was already connected to a companion app.

This fix is based on the work done by @JustScott in #1972 and also thanks to the very detailed description of the issue by @rambonette in #1961.

I think this fix makes more sense since we do not actually need to call `NimbleController::EnableRadio()` again if the radio was previously enabled and need to stay enabled. 

This change also removed the need to send the message in `SettingBluetooth::~SettingBluetooth()` by capturing this in the lambda (which is called in `CheckboxList::~CheckboxList()` which is destroyed before `SettingBluetooth`.

What do think about this @JustScott?

Fixes #1961.