### PR TITLE
Restore brightness level when closing the Flashlight application

### DIFF
--- a/src/displayapp/screens/FlashLight.cpp
+++ b/src/displayapp/screens/FlashLight.cpp
@@ -15,7 +15,7 @@ namespace {
 }
 
 FlashLight::FlashLight(System::SystemTask& systemTask, Controllers::BrightnessController& brightnessController)
-  : systemTask {systemTask}, brightnessController {brightnessController} {
+  : systemTask {systemTask}, brightnessController {brightnessController}, backupBrightnessLevel {brightnessController.Level()} {
 
   brightnessController.Set(Controllers::BrightnessController::Levels::Low);
 
@@ -52,6 +52,7 @@ FlashLight::FlashLight(System::SystemTask& systemTask, Controllers::BrightnessCo
 FlashLight::~FlashLight() {
   lv_obj_clean(lv_scr_act());
   lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  brightnessController.Set(backupBrightnessLevel);
   systemTask.PushMessage(Pinetime::System::Messages::EnableSleeping);
 }
 

--- a/src/displayapp/screens/FlashLight.h
+++ b/src/displayapp/screens/FlashLight.h
@@ -27,7 +27,7 @@ namespace Pinetime {
         Controllers::BrightnessController& brightnessController;
 
         Controllers::BrightnessController::Levels brightnessLevel = Controllers::BrightnessController::Levels::High;
-
+        Controllers::BrightnessController::Levels backupBrightnessLevel;
         lv_obj_t* flashLight;
         lv_obj_t* backgroundAction;
         lv_obj_t* indicators[3];


### PR DESCRIPTION
The brightness level is stored when entering the app, and restored when closing it. Based on another fixed suggested by @serosi in #1907.

Fixes #1751.