### PR TITLE
Continuous time updates

### DIFF
--- a/src/components/ble/SimpleWeatherService.cpp
+++ b/src/components/ble/SimpleWeatherService.cpp
@@ -80,7 +80,7 @@ int WeatherCallback(uint16_t /*connHandle*/, uint16_t /*attrHandle*/, struct ble
   return static_cast<Pinetime::Controllers::SimpleWeatherService*>(arg)->OnCommand(ctxt);
 }
 
-SimpleWeatherService::SimpleWeatherService(const DateTime& dateTimeController) : dateTimeController(dateTimeController) {
+SimpleWeatherService::SimpleWeatherService(DateTime& dateTimeController) : dateTimeController(dateTimeController) {
 }
 
 void SimpleWeatherService::Init() {

--- a/src/components/ble/SimpleWeatherService.h
+++ b/src/components/ble/SimpleWeatherService.h
@@ -40,7 +40,7 @@ namespace Pinetime {
 
     class SimpleWeatherService {
     public:
-      explicit SimpleWeatherService(const DateTime& dateTimeController);
+      explicit SimpleWeatherService(DateTime& dateTimeController);
 
       void Init();
 
@@ -140,7 +140,7 @@ namespace Pinetime {
 
       uint16_t eventHandle {};
 
-      const Pinetime::Controllers::DateTime& dateTimeController;
+      Pinetime::Controllers::DateTime& dateTimeController;
 
       std::optional<CurrentWeather> currentWeather;
       std::optional<Forecast> forecast;

--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -1,6 +1,7 @@
 #include "components/datetime/DateTimeController.h"
 #include <libraries/log/nrf_log.h>
 #include <systemtask/SystemTask.h>
+#include <hal/nrf_rtc.h>
 
 using namespace Pinetime::Controllers;
 
@@ -12,11 +13,16 @@ namespace {
 }
 
 DateTime::DateTime(Controllers::Settings& settingsController) : settingsController {settingsController} {
+  mutex = xSemaphoreCreateMutex();
+  ASSERT(mutex != nullptr);
+  xSemaphoreGive(mutex);
 }
 
 void DateTime::SetCurrentTime(std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> t) {
+  xSemaphoreTake(mutex, portMAX_DELAY);
   this->currentDateTime = t;
-  UpdateTime(previousSystickCounter); // Update internal state without updating the time
+  UpdateTime(previousSystickCounter, true); // Update internal state without updating the time
+  xSemaphoreGive(mutex);
 }
 
 void DateTime::SetTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, uint8_t minute, uint8_t second) {
@@ -29,13 +35,15 @@ void DateTime::SetTime(uint16_t year, uint8_t month, uint8_t day, uint8_t hour, 
     /* .tm_year = */ year - 1900,
   };
 
-  tm.tm_isdst = -1; // Use DST value from local time zone
-  currentDateTime = std::chrono::system_clock::from_time_t(std::mktime(&tm));
-
   NRF_LOG_INFO("%d %d %d ", day, month, year);
   NRF_LOG_INFO("%d %d %d ", hour, minute, second);
 
-  UpdateTime(previousSystickCounter);
+  tm.tm_isdst = -1; // Use DST value from local time zone
+
+  xSemaphoreTake(mutex, portMAX_DELAY);
+  currentDateTime = std::chrono::system_clock::from_time_t(std::mktime(&tm));
+  UpdateTime(previousSystickCounter, true);
+  xSemaphoreGive(mutex);
 
   systemTask->PushMessage(System::Messages::OnNewTime);
 }
@@ -45,25 +53,34 @@ void DateTime::SetTimeZone(int8_t timezone, int8_t dst) {
   dstOffset = dst;
 }
 
-void DateTime::UpdateTime(uint32_t systickCounter) {
+std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> DateTime::CurrentDateTime() {
+  xSemaphoreTake(mutex, portMAX_DELAY);
+  UpdateTime(nrf_rtc_counter_get(portNRF_RTC_REG), false);
+  xSemaphoreGive(mutex);
+  return currentDateTime;
+}
+
+void DateTime::UpdateTime(uint32_t systickCounter, bool forceUpdate) {
   // Handle systick counter overflow
   uint32_t systickDelta = 0;
   if (systickCounter < previousSystickCounter) {
-    systickDelta = 0xffffff - previousSystickCounter;
+    systickDelta = static_cast<uint32_t>(portNRF_RTC_MAXTICKS) - previousSystickCounter;
     systickDelta += systickCounter + 1;
   } else {
     systickDelta = systickCounter - previousSystickCounter;
   }
 
-  /*
-   * 1000 ms = 1024 ticks
-   */
-  auto correctedDelta = systickDelta / 1024;
-  auto rest = systickDelta % 1024;
+  auto correctedDelta = systickDelta / configTICK_RATE_HZ;
+  // If a second hasn't passed, there is nothing to do
+  // If the time has been changed, set forceUpdate to trigger internal state updates
+  if (correctedDelta == 0 && !forceUpdate) {
+    return;
+  }
+  auto rest = systickDelta % configTICK_RATE_HZ;
   if (systickCounter >= rest) {
     previousSystickCounter = systickCounter - rest;
   } else {
-    previousSystickCounter = 0xffffff - (rest - systickCounter);
+    previousSystickCounter = static_cast<uint32_t>(portNRF_RTC_MAXTICKS) - (rest - systickCounter - 1);
   }
 
   currentDateTime += std::chrono::seconds(correctedDelta);

--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -2,6 +2,7 @@
 #include <libraries/log/nrf_log.h>
 #include <systemtask/SystemTask.h>
 #include <hal/nrf_rtc.h>
+#include "nrf_assert.h"
 
 using namespace Pinetime::Controllers;
 

--- a/src/components/datetime/DateTimeController.h
+++ b/src/components/datetime/DateTimeController.h
@@ -5,6 +5,8 @@
 #include <ctime>
 #include <string>
 #include "components/settings/Settings.h"
+#include <FreeRTOS.h>
+#include <semphr.h>
 
 namespace Pinetime {
   namespace System {
@@ -44,8 +46,6 @@ namespace Pinetime {
        * dst field.
        */
       void SetTimeZone(int8_t timezone, int8_t dst);
-
-      void UpdateTime(uint32_t systickCounter);
 
       uint16_t Year() const {
         return 1900 + localTime.tm_year;
@@ -124,12 +124,10 @@ namespace Pinetime {
       static const char* MonthShortToStringLow(Months month);
       static const char* DayOfWeekShortToStringLow(Days day);
 
-      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> CurrentDateTime() const {
-        return currentDateTime;
-      }
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> CurrentDateTime();
 
-      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> UTCDateTime() const {
-        return currentDateTime - std::chrono::seconds((tzOffset + dstOffset) * 15 * 60);
+      std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> UTCDateTime() {
+        return CurrentDateTime() - std::chrono::seconds((tzOffset + dstOffset) * 15 * 60);
       }
 
       std::chrono::seconds Uptime() const {
@@ -141,9 +139,13 @@ namespace Pinetime {
       std::string FormattedTime();
 
     private:
+      void UpdateTime(uint32_t systickCounter, bool forceUpdate);
+
       std::tm localTime;
       int8_t tzOffset = 0;
       int8_t dstOffset = 0;
+
+      SemaphoreHandle_t mutex = nullptr;
 
       uint32_t previousSystickCounter = 0;
       std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> currentDateTime;

--- a/src/components/datetime/TODO.md
+++ b/src/components/datetime/TODO.md
@@ -1,0 +1,41 @@
+# Refactoring needed
+
+## Context
+
+The [PR #2041 - Continuous time updates](https://github.com/InfiniTimeOrg/InfiniTime/pull/2041) highlighted some
+limitations in the design of DateTimeController: the granularity of the time returned by `DateTime::CurrentDateTime()`
+is limited by the frequency at which SystemTask calls `DateTime::UpdateTime()`, which is currently set to 100ms.
+
+@mark9064 provided more details
+in [this comment](https://github.com/InfiniTimeOrg/InfiniTime/pull/2041#issuecomment-2048528967).
+
+The [PR #2041 - Continuous time updates](https://github.com/InfiniTimeOrg/InfiniTime/pull/2041) provided some changes
+to `DateTime` controller that improves the granularity of the time returned by `DateTime::CurrentDateTime()`.
+
+However, the review showed that `DateTime` cannot be `const` anymore, even when it's only used to get the current time,
+since `DateTime::CurrentDateTime()` changes the internal state of the instance.
+
+We tried to identify alternative implementation that would have maintained the "const correctness" but we eventually
+figured that this would lead to a re-design of `DateTime` which was out of scope of the initial PR (Continuous time
+updates and always on display).
+
+So we decided to merge this PR #2041 and agree to fix/improve `DateTime` later on.
+
+## What needs to be done?
+
+Improve/redesign `DateTime` so that it
+
+* provides a very granular (ideally down to the millisecond) date and time via `CurrentDateTime()`.
+* can be declared/passed as `const` when it's only used to **get** the time.
+* limits the use of mutex as much as possible (an ideal implementation would not use any mutex, but this might not be
+  possible).
+* improves the design of `DateTime::Seconds()`, `DateTime::Minutes()`, `DateTime::Hours()`, etc as
+  explained [in this comment](https://github.com/InfiniTimeOrg/InfiniTime/pull/2054#pullrequestreview-2037033105).
+
+Once this redesign is implemented, all instances/references to `DateTime` should be reviewed and updated to use `const`
+where appropriate.
+
+Please check the following PR to get more context about this redesign:
+
+* [#2041 - Continuous time updates by @mark9064](https://github.com/InfiniTimeOrg/InfiniTime/pull/2041)
+* [#2054 - Continuous time update - Alternative implementation to #2041 by @JF002](https://github.com/InfiniTimeOrg/InfiniTime/pull/2054)

--- a/src/displayapp/screens/WatchFaceAnalog.h
+++ b/src/displayapp/screens/WatchFaceAnalog.h
@@ -75,7 +75,7 @@ namespace Pinetime {
 
         BatteryIcon batteryIcon;
 
-        const Controllers::DateTime& dateTimeController;
+        Controllers::DateTime& dateTimeController;
         const Controllers::Battery& batteryController;
         const Controllers::Ble& bleController;
         Controllers::NotificationManager& notificationManager;

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -410,8 +410,6 @@ void SystemTask::Work() {
     }
 
     monitor.Process();
-    uint32_t systick_counter = nrf_rtc_counter_get(portNRF_RTC_REG);
-    dateTimeController.UpdateTime(systick_counter);
     NoInit_BackUpTime = dateTimeController.CurrentDateTime();
     if (nrf_gpio_pin_read(PinMap::Button) == 0) {
       watchdog.Reload();


### PR DESCRIPTION
This changes CurrentDateTime() so every call it fetches the time fresh from the RTC. Mutual exclusion must now be used to protect access to the timekeeping data as many tasks may modify it.

This change has no power / performance impact (verified by testing in #1869)

One rationale of this is simply correctness - this removes the 0.1s jitter on the current time created by the system task. This jitter was causing problems for frame pacing with always on display. But it's also nice to have correctness when it costs no performance. This also paves the way to lengthening the system task period if we wanted to explore that further. For now, that still breaks motion wake (and probably more) so it's a no go.

There's also a few other misc fixes like correcting the tick overflow calculation and using the appropriate constants for readability.

PR split from #1869