### PR TITLE
LCD delay improvements

### DIFF
--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -1,6 +1,5 @@
 #include "drivers/St7789.h"
 #include <hal/nrf_gpio.h>
-#include <libraries/delay/nrf_delay.h>
 #include <nrfx_log.h>
 #include "drivers/Spi.h"
 
@@ -45,7 +44,7 @@ void St7789::WriteSpi(const uint8_t* data, size_t size) {
 
 void St7789::SoftwareReset() {
   WriteCommand(static_cast<uint8_t>(Commands::SoftwareReset));
-  nrf_delay_ms(150);
+  vTaskDelay(pdMS_TO_TICKS(150));
 }
 
 void St7789::SleepOut() {
@@ -59,7 +58,7 @@ void St7789::SleepIn() {
 void St7789::ColMod() {
   WriteCommand(static_cast<uint8_t>(Commands::ColMod));
   WriteData(0x55);
-  nrf_delay_ms(10);
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::MemoryDataAccessControl() {
@@ -96,12 +95,12 @@ void St7789::RowAddressSet() {
 
 void St7789::DisplayInversionOn() {
   WriteCommand(static_cast<uint8_t>(Commands::DisplayInversionOn));
-  nrf_delay_ms(10);
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::NormalModeOn() {
   WriteCommand(static_cast<uint8_t>(Commands::NormalModeOn));
-  nrf_delay_ms(10);
+  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::DisplayOn() {
@@ -137,7 +136,7 @@ void St7789::SetVdv() {
 
 void St7789::DisplayOff() {
   WriteCommand(static_cast<uint8_t>(Commands::DisplayOff));
-  nrf_delay_ms(500);
+  vTaskDelay(pdMS_TO_TICKS(500));
 }
 
 void St7789::VerticalScrollStartAddress(uint16_t line) {
@@ -158,7 +157,7 @@ void St7789::DrawBuffer(uint16_t x, uint16_t y, uint16_t width, uint16_t height,
 
 void St7789::HardwareReset() {
   nrf_gpio_pin_clear(pinReset);
-  nrf_delay_ms(10);
+  vTaskDelay(pdMS_TO_TICKS(10));
   nrf_gpio_pin_set(pinReset);
 }
 

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -1,7 +1,4 @@
 #include "drivers/St7789.h"
-#include <hal/nrf_gpio.h>
-#include <nrfx_log.h>
-#include "drivers/Spi.h"
 
 using namespace Pinetime::Drivers;
 
@@ -43,22 +40,52 @@ void St7789::WriteSpi(const uint8_t* data, size_t size) {
 }
 
 void St7789::SoftwareReset() {
+  EnsureSleepOutPostDelay();
   WriteCommand(static_cast<uint8_t>(Commands::SoftwareReset));
-  vTaskDelay(pdMS_TO_TICKS(150));
+  // If sleep in: must wait 120ms before sleep out can sent (see driver datasheet)
+  // Unconditionally wait as software reset doesn't need to be performant
+  sleepIn = true;
+  lastSleepExit = xTaskGetTickCount();
+  vTaskDelay(pdMS_TO_TICKS(125));
 }
 
 void St7789::SleepOut() {
+  if (!sleepIn) {
+    return;
+  }
   WriteCommand(static_cast<uint8_t>(Commands::SleepOut));
+  // Wait 5ms for clocks to stabilise
+  // pdMS rounds down => 6 used here
+  vTaskDelay(pdMS_TO_TICKS(6));
+  // Cannot send sleep in or software reset for 120ms
+  lastSleepExit = xTaskGetTickCount();
+  sleepIn = false;
+}
+
+void St7789::EnsureSleepOutPostDelay() {
+  TickType_t delta = xTaskGetTickCount() - lastSleepExit;
+  // Due to timer wraparound, there is a chance of delaying when not necessary
+  // It is very low (pdMS_TO_TICKS(125)/2^32) and waiting an extra 125ms isn't too bad
+  if (delta < pdMS_TO_TICKS(125)) {
+    vTaskDelay(pdMS_TO_TICKS(125) - delta);
+  }
 }
 
 void St7789::SleepIn() {
+  if (sleepIn) {
+    return;
+  }
+  EnsureSleepOutPostDelay();
   WriteCommand(static_cast<uint8_t>(Commands::SleepIn));
+  // Wait 5ms for clocks to stabilise
+  // pdMS rounds down => 6 used here
+  vTaskDelay(pdMS_TO_TICKS(6));
+  sleepIn = true;
 }
 
 void St7789::ColMod() {
   WriteCommand(static_cast<uint8_t>(Commands::ColMod));
   WriteData(0x55);
-  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::MemoryDataAccessControl() {
@@ -95,12 +122,10 @@ void St7789::RowAddressSet() {
 
 void St7789::DisplayInversionOn() {
   WriteCommand(static_cast<uint8_t>(Commands::DisplayInversionOn));
-  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::NormalModeOn() {
   WriteCommand(static_cast<uint8_t>(Commands::NormalModeOn));
-  vTaskDelay(pdMS_TO_TICKS(10));
 }
 
 void St7789::DisplayOn() {
@@ -136,7 +161,6 @@ void St7789::SetVdv() {
 
 void St7789::DisplayOff() {
   WriteCommand(static_cast<uint8_t>(Commands::DisplayOff));
-  vTaskDelay(pdMS_TO_TICKS(500));
 }
 
 void St7789::VerticalScrollStartAddress(uint16_t line) {
@@ -157,8 +181,13 @@ void St7789::DrawBuffer(uint16_t x, uint16_t y, uint16_t width, uint16_t height,
 
 void St7789::HardwareReset() {
   nrf_gpio_pin_clear(pinReset);
-  vTaskDelay(pdMS_TO_TICKS(10));
+  vTaskDelay(pdMS_TO_TICKS(1));
   nrf_gpio_pin_set(pinReset);
+  // If hardware reset started while sleep out, reset time may be up to 120ms
+  // Unconditionally wait as hardware reset doesn't need to be performant
+  sleepIn = true;
+  lastSleepExit = xTaskGetTickCount();
+  vTaskDelay(pdMS_TO_TICKS(125));
 }
 
 void St7789::Sleep() {

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -1,4 +1,7 @@
 #include "drivers/St7789.h"
+#include <hal/nrf_gpio.h>
+#include <nrfx_log.h>
+#include "drivers/Spi.h"
 
 using namespace Pinetime::Drivers;
 

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -2,6 +2,7 @@
 #include <hal/nrf_gpio.h>
 #include <nrfx_log.h>
 #include "drivers/Spi.h"
+#include "task.h"
 
 using namespace Pinetime::Drivers;
 

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -2,6 +2,10 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <hal/nrf_gpio.h>
+#include <nrfx_log.h>
+#include "drivers/Spi.h"
+
 namespace Pinetime {
   namespace Drivers {
     class Spi;
@@ -29,10 +33,13 @@ namespace Pinetime {
       uint8_t pinDataCommand;
       uint8_t pinReset;
       uint8_t verticalScrollingStartAddress = 0;
+      bool sleepIn;
+      TickType_t lastSleepExit;
 
       void HardwareReset();
       void SoftwareReset();
       void SleepOut();
+      void EnsureSleepOutPostDelay();
       void SleepIn();
       void ColMod();
       void MemoryDataAccessControl();

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -2,9 +2,7 @@
 #include <cstddef>
 #include <cstdint>
 
-#include <hal/nrf_gpio.h>
-#include <nrfx_log.h>
-#include "drivers/Spi.h"
+#include <FreeRTOS.h>
 
 namespace Pinetime {
   namespace Drivers {


### PR DESCRIPTION
- No longer spins the CPU when the display task is waiting
- Unnecessary waits removed
- Sleep in - sleep out minimum interval now respected

This all assumes the datasheet is correct :P It could definitely be inconsistent in places
I'd appreciate if it at least one reviewer could check that they interpret the datasheet the same way
https://wiki.pine64.org/images/5/54/ST7789V_v1.6.pdf
See pages 48, 49, 163, 182, 184

Split from #1869 