### PR TITLE
SPI transaction hooks

### DIFF
--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -75,6 +75,7 @@
 #define configUSE_TIME_SLICING                  0
 #define configUSE_NEWLIB_REENTRANT              0
 #define configENABLE_BACKWARD_COMPATIBILITY     1
+#define configUSE_TASK_NOTIFICATIONS            0
 
 /* Hook function related definitions. */
 #define configUSE_IDLE_HOOK            0

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -142,9 +142,6 @@ void DisplayApp::Process(void* instance) {
   NRF_LOG_INFO("displayapp task started!");
   app->InitHw();
 
-  // Send a dummy notification to unlock the lvgl display driver for the first iteration
-  xTaskNotifyGive(xTaskGetCurrentTaskHandle());
-
   while (true) {
     app->Refresh();
   }

--- a/src/displayapp/DisplayAppRecovery.cpp
+++ b/src/displayapp/DisplayAppRecovery.cpp
@@ -38,9 +38,6 @@ void DisplayApp::Process(void* instance) {
   auto* app = static_cast<DisplayApp*>(instance);
   NRF_LOG_INFO("displayapp task started!");
 
-  // Send a dummy notification to unlock the lvgl display driver for the first iteration
-  xTaskNotifyGive(xTaskGetCurrentTaskHandle());
-
   app->InitHw();
   while (true) {
     app->Refresh();
@@ -94,7 +91,6 @@ void DisplayApp::DisplayLogo(uint16_t color) {
   Pinetime::Tools::RleDecoder rleDecoder(infinitime_nb, sizeof(infinitime_nb), color, colorBlack);
   for (int i = 0; i < displayWidth; i++) {
     rleDecoder.DecodeNext(displayBuffer, displayWidth * bytesPerPixel);
-    ulTaskNotifyTake(pdTRUE, 500);
     lcd.DrawBuffer(0, i, displayWidth, 1, reinterpret_cast<const uint8_t*>(displayBuffer), displayWidth * bytesPerPixel);
   }
 }
@@ -103,7 +99,6 @@ void DisplayApp::DisplayOtaProgress(uint8_t percent, uint16_t color) {
   const uint8_t barHeight = 20;
   std::fill(displayBuffer, displayBuffer + (displayWidth * bytesPerPixel), color);
   for (int i = 0; i < barHeight; i++) {
-    ulTaskNotifyTake(pdTRUE, 500);
     uint16_t barWidth = std::min(static_cast<float>(percent) * 2.4f, static_cast<float>(displayWidth));
     lcd.DrawBuffer(0, displayWidth - barHeight + i, barWidth, 1, reinterpret_cast<const uint8_t*>(displayBuffer), barWidth * bytesPerPixel);
   }

--- a/src/displayapp/LittleVgl.cpp
+++ b/src/displayapp/LittleVgl.cpp
@@ -152,10 +152,6 @@ void LittleVgl::SetFullRefresh(FullRefreshDirections direction) {
 void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
   uint16_t y1, y2, width, height = 0;
 
-  ulTaskNotifyTake(pdTRUE, 200);
-  // Notification is still needed (even if there is a mutex on SPI) because of the DataCommand pin
-  // which cannot be set/clear during a transfer.
-
   if ((scrollDirection == LittleVgl::FullRefreshDirections::Down) && (area->y2 == visibleNbLines - 1)) {
     writeOffset = ((writeOffset + totalNbLines) - visibleNbLines) % totalNbLines;
   } else if ((scrollDirection == FullRefreshDirections::Up) && (area->y1 == 0)) {
@@ -219,7 +215,6 @@ void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
 
     if (height > 0) {
       lcd.DrawBuffer(area->x1, y1, width, height, reinterpret_cast<const uint8_t*>(color_p), width * height * 2);
-      ulTaskNotifyTake(pdTRUE, 100);
     }
 
     uint16_t pixOffset = width * height;

--- a/src/drivers/Spi.cpp
+++ b/src/drivers/Spi.cpp
@@ -9,8 +9,8 @@ Spi::Spi(SpiMaster& spiMaster, uint8_t pinCsn) : spiMaster {spiMaster}, pinCsn {
   nrf_gpio_pin_set(pinCsn);
 }
 
-bool Spi::Write(const uint8_t* data, size_t size) {
-  return spiMaster.Write(pinCsn, data, size);
+bool Spi::Write(const uint8_t* data, size_t size, void (*TransactionHook)(bool)) {
+  return spiMaster.Write(pinCsn, data, size, TransactionHook);
 }
 
 bool Spi::Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize) {

--- a/src/drivers/Spi.cpp
+++ b/src/drivers/Spi.cpp
@@ -9,7 +9,7 @@ Spi::Spi(SpiMaster& spiMaster, uint8_t pinCsn) : spiMaster {spiMaster}, pinCsn {
   nrf_gpio_pin_set(pinCsn);
 }
 
-bool Spi::Write(const uint8_t* data, size_t size, void (*TransactionHook)(bool)) {
+bool Spi::Write(const uint8_t* data, size_t size, std::function<void(bool)> TransactionHook) {
   return spiMaster.Write(pinCsn, data, size, TransactionHook);
 }
 

--- a/src/drivers/Spi.cpp
+++ b/src/drivers/Spi.cpp
@@ -9,8 +9,8 @@ Spi::Spi(SpiMaster& spiMaster, uint8_t pinCsn) : spiMaster {spiMaster}, pinCsn {
   nrf_gpio_pin_set(pinCsn);
 }
 
-bool Spi::Write(const uint8_t* data, size_t size, std::function<void(bool)> TransactionHook) {
-  return spiMaster.Write(pinCsn, data, size, TransactionHook);
+bool Spi::Write(const uint8_t* data, size_t size, const std::function<void()>& transactionHook) {
+  return spiMaster.Write(pinCsn, data, size, transactionHook);
 }
 
 bool Spi::Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize) {

--- a/src/drivers/Spi.cpp
+++ b/src/drivers/Spi.cpp
@@ -9,8 +9,8 @@ Spi::Spi(SpiMaster& spiMaster, uint8_t pinCsn) : spiMaster {spiMaster}, pinCsn {
   nrf_gpio_pin_set(pinCsn);
 }
 
-bool Spi::Write(const uint8_t* data, size_t size, const std::function<void()>& transactionHook) {
-  return spiMaster.Write(pinCsn, data, size, transactionHook);
+bool Spi::Write(const uint8_t* data, size_t size, const std::function<void()>& preTransactionHook) {
+  return spiMaster.Write(pinCsn, data, size, preTransactionHook);
 }
 
 bool Spi::Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize) {

--- a/src/drivers/Spi.h
+++ b/src/drivers/Spi.h
@@ -14,7 +14,7 @@ namespace Pinetime {
       Spi& operator=(Spi&&) = delete;
 
       bool Init();
-      bool Write(const uint8_t* data, size_t size);
+      bool Write(const uint8_t* data, size_t size, void (*TransactionHook)(bool));
       bool Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize);
       bool WriteCmdAndBuffer(const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize);
       void Sleep();

--- a/src/drivers/Spi.h
+++ b/src/drivers/Spi.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include <cstddef>
+#include <functional>
 #include "drivers/SpiMaster.h"
 
 namespace Pinetime {
@@ -14,7 +15,7 @@ namespace Pinetime {
       Spi& operator=(Spi&&) = delete;
 
       bool Init();
-      bool Write(const uint8_t* data, size_t size, void (*TransactionHook)(bool));
+      bool Write(const uint8_t* data, size_t size, std::function<void(bool)> TransactionHook);
       bool Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize);
       bool WriteCmdAndBuffer(const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize);
       void Sleep();

--- a/src/drivers/Spi.h
+++ b/src/drivers/Spi.h
@@ -15,7 +15,7 @@ namespace Pinetime {
       Spi& operator=(Spi&&) = delete;
 
       bool Init();
-      bool Write(const uint8_t* data, size_t size, const std::function<void()>& transactionHook);
+      bool Write(const uint8_t* data, size_t size, const std::function<void()>& preTransactionHook);
       bool Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize);
       bool WriteCmdAndBuffer(const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize);
       void Sleep();

--- a/src/drivers/Spi.h
+++ b/src/drivers/Spi.h
@@ -15,7 +15,7 @@ namespace Pinetime {
       Spi& operator=(Spi&&) = delete;
 
       bool Init();
-      bool Write(const uint8_t* data, size_t size, std::function<void(bool)> TransactionHook);
+      bool Write(const uint8_t* data, size_t size, const std::function<void()>& transactionHook);
       bool Read(uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize);
       bool WriteCmdAndBuffer(const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize);
       void Sleep();

--- a/src/drivers/SpiMaster.cpp
+++ b/src/drivers/SpiMaster.cpp
@@ -167,7 +167,7 @@ void SpiMaster::PrepareRx(const uint32_t bufferAddress, const size_t size) {
   spiBaseAddress->EVENTS_END = 0;
 }
 
-bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size, const std::function<void()>& transactionHook) {
+bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size, const std::function<void()>& preTransactionHook) {
   if (data == nullptr)
     return false;
   auto ok = xSemaphoreTake(mutex, portMAX_DELAY);
@@ -181,8 +181,8 @@ bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size, const st
     DisableWorkaroundForFtpan58(spiBaseAddress, 0, 0);
   }
 
-  if (transactionHook != nullptr) {
-    transactionHook();
+  if (preTransactionHook != nullptr) {
+    preTransactionHook();
   }
   nrf_gpio_pin_clear(this->pinCsn);
 

--- a/src/drivers/SpiMaster.cpp
+++ b/src/drivers/SpiMaster.cpp
@@ -136,20 +136,14 @@ void SpiMaster::OnEndEvent() {
 
     spiBaseAddress->TASKS_START = 1;
   } else {
-    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-    if (taskToNotify != nullptr) {
-      vTaskNotifyGiveFromISR(taskToNotify, &xHigherPriorityTaskWoken);
-      portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
-    }
-
     nrf_gpio_pin_set(this->pinCsn);
     if (this->TransactionHook != nullptr) {
       this->TransactionHook(false);
     }
     currentBufferAddr = 0;
-    BaseType_t xHigherPriorityTaskWoken2 = pdFALSE;
-    xSemaphoreGiveFromISR(mutex, &xHigherPriorityTaskWoken2);
-    portYIELD_FROM_ISR(xHigherPriorityTaskWoken | xHigherPriorityTaskWoken2);
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    xSemaphoreGiveFromISR(mutex, &xHigherPriorityTaskWoken);
+    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
   }
 }
 
@@ -181,7 +175,6 @@ bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size, void (*T
     return false;
   auto ok = xSemaphoreTake(mutex, portMAX_DELAY);
   ASSERT(ok == true);
-  taskToNotify = xTaskGetCurrentTaskHandle();
 
   this->TransactionHook = TransactionHook;
   this->pinCsn = pinCsn;
@@ -226,7 +219,6 @@ bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size, void (*T
 bool SpiMaster::Read(uint8_t pinCsn, uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize) {
   xSemaphoreTake(mutex, portMAX_DELAY);
 
-  taskToNotify = nullptr;
   this->TransactionHook = nullptr;
   this->pinCsn = pinCsn;
   DisableWorkaroundForFtpan58(spiBaseAddress, 0, 0);
@@ -274,8 +266,6 @@ void SpiMaster::Wakeup() {
 
 bool SpiMaster::WriteCmdAndBuffer(uint8_t pinCsn, const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize) {
   xSemaphoreTake(mutex, portMAX_DELAY);
-
-  taskToNotify = nullptr;
 
   this->TransactionHook = nullptr;
 

--- a/src/drivers/SpiMaster.cpp
+++ b/src/drivers/SpiMaster.cpp
@@ -143,6 +143,9 @@ void SpiMaster::OnEndEvent() {
     }
 
     nrf_gpio_pin_set(this->pinCsn);
+    if (this->TransactionHook != nullptr) {
+      this->TransactionHook(false);
+    }
     currentBufferAddr = 0;
     BaseType_t xHigherPriorityTaskWoken2 = pdFALSE;
     xSemaphoreGiveFromISR(mutex, &xHigherPriorityTaskWoken2);
@@ -173,13 +176,14 @@ void SpiMaster::PrepareRx(const uint32_t bufferAddress, const size_t size) {
   spiBaseAddress->EVENTS_END = 0;
 }
 
-bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size) {
+bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size, void (*TransactionHook)(bool)) {
   if (data == nullptr)
     return false;
   auto ok = xSemaphoreTake(mutex, portMAX_DELAY);
   ASSERT(ok == true);
   taskToNotify = xTaskGetCurrentTaskHandle();
 
+  this->TransactionHook = TransactionHook;
   this->pinCsn = pinCsn;
 
   if (size == 1) {
@@ -188,6 +192,9 @@ bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size) {
     DisableWorkaroundForFtpan58(spiBaseAddress, 0, 0);
   }
 
+  if (this->TransactionHook != nullptr) {
+    this->TransactionHook(true);
+  }
   nrf_gpio_pin_clear(this->pinCsn);
 
   currentBufferAddr = (uint32_t) data;
@@ -203,6 +210,9 @@ bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size) {
     while (spiBaseAddress->EVENTS_END == 0)
       ;
     nrf_gpio_pin_set(this->pinCsn);
+    if (this->TransactionHook != nullptr) {
+      this->TransactionHook(false);
+    }
     currentBufferAddr = 0;
 
     DisableWorkaroundForFtpan58(spiBaseAddress, 0, 0);
@@ -217,7 +227,7 @@ bool SpiMaster::Read(uint8_t pinCsn, uint8_t* cmd, size_t cmdSize, uint8_t* data
   xSemaphoreTake(mutex, portMAX_DELAY);
 
   taskToNotify = nullptr;
-
+  this->TransactionHook = nullptr;
   this->pinCsn = pinCsn;
   DisableWorkaroundForFtpan58(spiBaseAddress, 0, 0);
   spiBaseAddress->INTENCLR = (1 << 6);
@@ -266,6 +276,8 @@ bool SpiMaster::WriteCmdAndBuffer(uint8_t pinCsn, const uint8_t* cmd, size_t cmd
   xSemaphoreTake(mutex, portMAX_DELAY);
 
   taskToNotify = nullptr;
+
+  this->TransactionHook = nullptr;
 
   this->pinCsn = pinCsn;
   DisableWorkaroundForFtpan58(spiBaseAddress, 0, 0);

--- a/src/drivers/SpiMaster.cpp
+++ b/src/drivers/SpiMaster.cpp
@@ -170,7 +170,7 @@ void SpiMaster::PrepareRx(const uint32_t bufferAddress, const size_t size) {
   spiBaseAddress->EVENTS_END = 0;
 }
 
-bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size, void (*TransactionHook)(bool)) {
+bool SpiMaster::Write(uint8_t pinCsn, const uint8_t* data, size_t size, std::function<void(bool)> TransactionHook) {
   if (data == nullptr)
     return false;
   auto ok = xSemaphoreTake(mutex, portMAX_DELAY);

--- a/src/drivers/SpiMaster.h
+++ b/src/drivers/SpiMaster.h
@@ -57,7 +57,6 @@ namespace Pinetime {
 
       volatile uint32_t currentBufferAddr = 0;
       volatile size_t currentBufferSize = 0;
-      volatile TaskHandle_t taskToNotify;
       SemaphoreHandle_t mutex = nullptr;
     };
   }

--- a/src/drivers/SpiMaster.h
+++ b/src/drivers/SpiMaster.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 
 #include <FreeRTOS.h>
 #include <semphr.h>
@@ -31,7 +32,7 @@ namespace Pinetime {
       SpiMaster& operator=(SpiMaster&&) = delete;
 
       bool Init();
-      bool Write(uint8_t pinCsn, const uint8_t* data, size_t size, void (*TransactionHook)(bool));
+      bool Write(uint8_t pinCsn, const uint8_t* data, size_t size, std::function<void(bool)> TransactionHook);
       bool Read(uint8_t pinCsn, uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize);
 
       bool WriteCmdAndBuffer(uint8_t pinCsn, const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize);
@@ -50,7 +51,7 @@ namespace Pinetime {
 
       NRF_SPIM_Type* spiBaseAddress;
       uint8_t pinCsn;
-      void (*TransactionHook)(bool);
+      std::function<void(bool)> TransactionHook;
 
       SpiMaster::SpiModule spi;
       SpiMaster::Parameters params;

--- a/src/drivers/SpiMaster.h
+++ b/src/drivers/SpiMaster.h
@@ -32,7 +32,7 @@ namespace Pinetime {
       SpiMaster& operator=(SpiMaster&&) = delete;
 
       bool Init();
-      bool Write(uint8_t pinCsn, const uint8_t* data, size_t size, const std::function<void()>& transactionHook);
+      bool Write(uint8_t pinCsn, const uint8_t* data, size_t size, const std::function<void()>& preTransactionHook);
       bool Read(uint8_t pinCsn, uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize);
 
       bool WriteCmdAndBuffer(uint8_t pinCsn, const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize);

--- a/src/drivers/SpiMaster.h
+++ b/src/drivers/SpiMaster.h
@@ -32,7 +32,7 @@ namespace Pinetime {
       SpiMaster& operator=(SpiMaster&&) = delete;
 
       bool Init();
-      bool Write(uint8_t pinCsn, const uint8_t* data, size_t size, std::function<void(bool)> TransactionHook);
+      bool Write(uint8_t pinCsn, const uint8_t* data, size_t size, const std::function<void()>& transactionHook);
       bool Read(uint8_t pinCsn, uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize);
 
       bool WriteCmdAndBuffer(uint8_t pinCsn, const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize);
@@ -51,7 +51,6 @@ namespace Pinetime {
 
       NRF_SPIM_Type* spiBaseAddress;
       uint8_t pinCsn;
-      std::function<void(bool)> TransactionHook;
 
       SpiMaster::SpiModule spi;
       SpiMaster::Parameters params;

--- a/src/drivers/SpiMaster.h
+++ b/src/drivers/SpiMaster.h
@@ -31,7 +31,7 @@ namespace Pinetime {
       SpiMaster& operator=(SpiMaster&&) = delete;
 
       bool Init();
-      bool Write(uint8_t pinCsn, const uint8_t* data, size_t size);
+      bool Write(uint8_t pinCsn, const uint8_t* data, size_t size, void (*TransactionHook)(bool));
       bool Read(uint8_t pinCsn, uint8_t* cmd, size_t cmdSize, uint8_t* data, size_t dataSize);
 
       bool WriteCmdAndBuffer(uint8_t pinCsn, const uint8_t* cmd, size_t cmdSize, const uint8_t* data, size_t dataSize);
@@ -50,6 +50,7 @@ namespace Pinetime {
 
       NRF_SPIM_Type* spiBaseAddress;
       uint8_t pinCsn;
+      void (*TransactionHook)(bool);
 
       SpiMaster::SpiModule spi;
       SpiMaster::Parameters params;

--- a/src/drivers/SpiNorFlash.cpp
+++ b/src/drivers/SpiNorFlash.cpp
@@ -22,7 +22,7 @@ void SpiNorFlash::Uninit() {
 
 void SpiNorFlash::Sleep() {
   auto cmd = static_cast<uint8_t>(Commands::DeepPowerDown);
-  spi.Write(&cmd, sizeof(uint8_t));
+  spi.Write(&cmd, sizeof(uint8_t), nullptr);
   NRF_LOG_INFO("[SpiNorFlash] Sleep")
 }
 

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -29,27 +29,27 @@ void St7789::Init() {
   DisplayOn();
 }
 
-void St7789::EnableDataMode(bool isStart) {
-  if (isStart) {
-    nrf_gpio_pin_set(pinDataCommand);
-  }
-}
-
-void St7789::EnableCommandMode(bool isStart) {
-  if (isStart) {
-    nrf_gpio_pin_clear(pinDataCommand);
-  }
-}
-
 void St7789::WriteData(uint8_t data) {
-  WriteSpi(&data, 1, [this](bool isStart) {
-    EnableDataMode(isStart);
+  WriteData(&data, 1);
+}
+
+void St7789::WriteData(const uint8_t* data, size_t size) {
+  WriteSpi(data, size, [pinDataCommand = pinDataCommand](bool isStart) {
+    if (isStart) {
+      nrf_gpio_pin_set(pinDataCommand);
+    }
   });
 }
 
-void St7789::WriteCommand(uint8_t cmd) {
-  WriteSpi(&cmd, 1, [this](bool isStart) {
-    EnableCommandMode(isStart);
+void St7789::WriteCommand(uint8_t data) {
+  WriteCommand(&data, 1);
+}
+
+void St7789::WriteCommand(const uint8_t* data, size_t size) {
+  WriteSpi(data, size, [pinDataCommand = pinDataCommand](bool isStart) {
+    if (isStart) {
+      nrf_gpio_pin_clear(pinDataCommand);
+    }
   });
 }
 
@@ -138,9 +138,7 @@ void St7789::SetAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1) {
 
 void St7789::WriteToRam(const uint8_t* data, size_t size) {
   WriteCommand(static_cast<uint8_t>(Commands::WriteToRam));
-  WriteSpi(data, size, [this](bool isStart) {
-    EnableDataMode(isStart);
-  });
+  WriteData(data, size);
 }
 
 void St7789::SetVdv() {

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -34,10 +34,8 @@ void St7789::WriteData(uint8_t data) {
 }
 
 void St7789::WriteData(const uint8_t* data, size_t size) {
-  WriteSpi(data, size, [pinDataCommand = pinDataCommand](bool isStart) {
-    if (isStart) {
-      nrf_gpio_pin_set(pinDataCommand);
-    }
+  WriteSpi(data, size, [pinDataCommand = pinDataCommand]() {
+    nrf_gpio_pin_set(pinDataCommand);
   });
 }
 
@@ -46,15 +44,13 @@ void St7789::WriteCommand(uint8_t data) {
 }
 
 void St7789::WriteCommand(const uint8_t* data, size_t size) {
-  WriteSpi(data, size, [pinDataCommand = pinDataCommand](bool isStart) {
-    if (isStart) {
-      nrf_gpio_pin_clear(pinDataCommand);
-    }
+  WriteSpi(data, size, [pinDataCommand = pinDataCommand]() {
+    nrf_gpio_pin_clear(pinDataCommand);
   });
 }
 
-void St7789::WriteSpi(const uint8_t* data, size_t size, std::function<void(bool)> TransactionHook) {
-  spi.Write(data, size, TransactionHook);
+void St7789::WriteSpi(const uint8_t* data, size_t size, const std::function<void()>& transactionHook) {
+  spi.Write(data, size, transactionHook);
 }
 
 void St7789::SoftwareReset() {

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -49,8 +49,8 @@ void St7789::WriteCommand(const uint8_t* data, size_t size) {
   });
 }
 
-void St7789::WriteSpi(const uint8_t* data, size_t size, const std::function<void()>& transactionHook) {
-  spi.Write(data, size, transactionHook);
+void St7789::WriteSpi(const uint8_t* data, size_t size, const std::function<void()>& preTransactionHook) {
+  spi.Write(data, size, preTransactionHook);
 }
 
 void St7789::SoftwareReset() {

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -131,12 +131,11 @@ void St7789::SetAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1) {
   WriteData(y0 & 0xff);
   WriteData(y1 >> 8);
   WriteData(y1 & 0xff);
-
-  WriteToRam();
 }
 
-void St7789::WriteToRam() {
+void St7789::WriteToRam(const uint8_t* data, size_t size) {
   WriteCommand(static_cast<uint8_t>(Commands::WriteToRam));
+  WriteSpi(data, size, EnableDataMode);
 }
 
 void St7789::SetVdv() {
@@ -163,7 +162,7 @@ void St7789::Uninit() {
 
 void St7789::DrawBuffer(uint16_t x, uint16_t y, uint16_t width, uint16_t height, const uint8_t* data, size_t size) {
   SetAddrWindow(x, y, x + width - 1, y + height - 1);
-  WriteSpi(data, size, EnableDataMode);
+  WriteToRam(data, size);
 }
 
 void St7789::HardwareReset() {

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -8,7 +8,7 @@ namespace Pinetime {
 
     class St7789 {
     public:
-      explicit St7789(Spi& spi, uint8_t pinDataCommand, uint8_t pinReset);
+      explicit St7789(Spi& spi);
       St7789(const St7789&) = delete;
       St7789& operator=(const St7789&) = delete;
       St7789(St7789&&) = delete;
@@ -26,8 +26,6 @@ namespace Pinetime {
 
     private:
       Spi& spi;
-      uint8_t pinDataCommand;
-      uint8_t pinReset;
       uint8_t verticalScrollingStartAddress = 0;
 
       void HardwareReset();
@@ -45,7 +43,9 @@ namespace Pinetime {
       void SetAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
       void SetVdv();
       void WriteCommand(uint8_t cmd);
-      void WriteSpi(const uint8_t* data, size_t size);
+      void WriteSpi(const uint8_t* data, size_t size, void (*TransactionHook)(bool));
+      static void EnableDataMode(bool isStart);
+      static void EnableCommandMode(bool isStart);
 
       enum class Commands : uint8_t {
         SoftwareReset = 0x01,

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 
 namespace Pinetime {
   namespace Drivers {
@@ -8,7 +9,7 @@ namespace Pinetime {
 
     class St7789 {
     public:
-      explicit St7789(Spi& spi);
+      explicit St7789(Spi& spi, uint8_t pinDataCommand, uint8_t pinReset);
       St7789(const St7789&) = delete;
       St7789& operator=(const St7789&) = delete;
       St7789(St7789&&) = delete;
@@ -26,6 +27,8 @@ namespace Pinetime {
 
     private:
       Spi& spi;
+      uint8_t pinDataCommand;
+      uint8_t pinReset;
       uint8_t verticalScrollingStartAddress = 0;
 
       void HardwareReset();
@@ -43,9 +46,9 @@ namespace Pinetime {
       void SetAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
       void SetVdv();
       void WriteCommand(uint8_t cmd);
-      void WriteSpi(const uint8_t* data, size_t size, void (*TransactionHook)(bool));
-      static void EnableDataMode(bool isStart);
-      static void EnableCommandMode(bool isStart);
+      void WriteSpi(const uint8_t* data, size_t size, std::function<void(bool)> TransactionHook);
+      void EnableDataMode(bool isStart);
+      void EnableCommandMode(bool isStart);
 
       enum class Commands : uint8_t {
         SoftwareReset = 0x01,

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -36,7 +36,7 @@ namespace Pinetime {
       void MemoryDataAccessControl();
       void DisplayInversionOn();
       void NormalModeOn();
-      void WriteToRam();
+      void WriteToRam(const uint8_t* data, size_t size);
       void DisplayOn();
       void DisplayOff();
 

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -47,7 +47,7 @@ namespace Pinetime {
       void SetVdv();
       void WriteCommand(uint8_t cmd);
       void WriteCommand(const uint8_t* data, size_t size);
-      void WriteSpi(const uint8_t* data, size_t size, std::function<void(bool)> TransactionHook);
+      void WriteSpi(const uint8_t* data, size_t size, const std::function<void()>& transactionHook);
 
       enum class Commands : uint8_t {
         SoftwareReset = 0x01,

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -46,9 +46,8 @@ namespace Pinetime {
       void SetAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
       void SetVdv();
       void WriteCommand(uint8_t cmd);
+      void WriteCommand(const uint8_t* data, size_t size);
       void WriteSpi(const uint8_t* data, size_t size, std::function<void(bool)> TransactionHook);
-      void EnableDataMode(bool isStart);
-      void EnableCommandMode(bool isStart);
 
       enum class Commands : uint8_t {
         SoftwareReset = 0x01,
@@ -68,6 +67,7 @@ namespace Pinetime {
         VdvSet = 0xc4,
       };
       void WriteData(uint8_t data);
+      void WriteData(const uint8_t* data, size_t size);
       void ColumnAddressSet();
 
       static constexpr uint16_t Width = 240;

--- a/src/drivers/St7789.h
+++ b/src/drivers/St7789.h
@@ -47,7 +47,7 @@ namespace Pinetime {
       void SetVdv();
       void WriteCommand(uint8_t cmd);
       void WriteCommand(const uint8_t* data, size_t size);
-      void WriteSpi(const uint8_t* data, size_t size, const std::function<void()>& transactionHook);
+      void WriteSpi(const uint8_t* data, size_t size, const std::function<void()>& preTransactionHook);
 
       enum class Commands : uint8_t {
         SoftwareReset = 0x01,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,7 @@ Pinetime::Drivers::SpiMaster spi {Pinetime::Drivers::SpiMaster::SpiModule::SPI0,
                                    Pinetime::PinMap::SpiMiso}};
 
 Pinetime::Drivers::Spi lcdSpi {spi, Pinetime::PinMap::SpiLcdCsn};
-Pinetime::Drivers::St7789 lcd {lcdSpi, Pinetime::PinMap::LcdDataCommand, Pinetime::PinMap::LcdReset};
+Pinetime::Drivers::St7789 lcd {lcdSpi};
 
 Pinetime::Drivers::Spi flashSpi {spi, Pinetime::PinMap::SpiFlashCsn};
 Pinetime::Drivers::SpiNorFlash spiNorFlash {flashSpi};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,7 @@ Pinetime::Drivers::SpiMaster spi {Pinetime::Drivers::SpiMaster::SpiModule::SPI0,
                                    Pinetime::PinMap::SpiMiso}};
 
 Pinetime::Drivers::Spi lcdSpi {spi, Pinetime::PinMap::SpiLcdCsn};
-Pinetime::Drivers::St7789 lcd {lcdSpi};
+Pinetime::Drivers::St7789 lcd {lcdSpi, Pinetime::PinMap::LcdDataCommand, Pinetime::PinMap::LcdReset};
 
 Pinetime::Drivers::Spi flashSpi {spi, Pinetime::PinMap::SpiFlashCsn};
 Pinetime::Drivers::SpiNorFlash spiNorFlash {flashSpi};

--- a/src/recoveryLoader.cpp
+++ b/src/recoveryLoader.cpp
@@ -121,7 +121,6 @@ void DisplayLogo() {
   Pinetime::Tools::RleDecoder rleDecoder(infinitime_nb, sizeof(infinitime_nb));
   for (int i = 0; i < displayWidth; i++) {
     rleDecoder.DecodeNext(displayBuffer, displayWidth * bytesPerPixel);
-    ulTaskNotifyTake(pdTRUE, 500);
     lcd.DrawBuffer(0, i, displayWidth, 1, reinterpret_cast<const uint8_t*>(displayBuffer), displayWidth * bytesPerPixel);
   }
 }
@@ -130,7 +129,6 @@ void DisplayProgressBar(uint8_t percent, uint16_t color) {
   static constexpr uint8_t barHeight = 20;
   std::fill(displayBuffer, displayBuffer + (displayWidth * bytesPerPixel), color);
   for (int i = 0; i < barHeight; i++) {
-    ulTaskNotifyTake(pdTRUE, 500);
     uint16_t barWidth = std::min(static_cast<float>(percent) * 2.4f, static_cast<float>(displayWidth));
     lcd.DrawBuffer(0, displayWidth - barHeight + i, barWidth, 1, reinterpret_cast<const uint8_t*>(displayBuffer), barWidth * bytesPerPixel);
   }

--- a/src/recoveryLoader.cpp
+++ b/src/recoveryLoader.cpp
@@ -45,7 +45,7 @@ Pinetime::Drivers::Spi flashSpi {spi, Pinetime::PinMap::SpiFlashCsn};
 Pinetime::Drivers::SpiNorFlash spiNorFlash {flashSpi};
 
 Pinetime::Drivers::Spi lcdSpi {spi, Pinetime::PinMap::SpiLcdCsn};
-Pinetime::Drivers::St7789 lcd {lcdSpi, Pinetime::PinMap::LcdDataCommand, Pinetime::PinMap::LcdReset};
+Pinetime::Drivers::St7789 lcd {lcdSpi};
 
 Pinetime::Controllers::BrightnessController brightnessController;
 

--- a/src/recoveryLoader.cpp
+++ b/src/recoveryLoader.cpp
@@ -45,7 +45,7 @@ Pinetime::Drivers::Spi flashSpi {spi, Pinetime::PinMap::SpiFlashCsn};
 Pinetime::Drivers::SpiNorFlash spiNorFlash {flashSpi};
 
 Pinetime::Drivers::Spi lcdSpi {spi, Pinetime::PinMap::SpiLcdCsn};
-Pinetime::Drivers::St7789 lcd {lcdSpi};
+Pinetime::Drivers::St7789 lcd {lcdSpi, Pinetime::PinMap::LcdDataCommand, Pinetime::PinMap::LcdReset};
 
 Pinetime::Controllers::BrightnessController brightnessController;
 


### PR DESCRIPTION
This replaces the original technique for protecting the LCD data command pin (task notifications), which didn't work super well.

This is replaced with SPI transaction hooks, where when an SPI write request (transaction) is started, you can specify a hook that runs before the write and after it finishes. It's not a super elegant solution as the hook function has to be static (if someone with C++ knowledge wants to go nuts on that be my guest!) but it's pretty straightforward and simple at least. So for the LCD, the hook just sets the data command pin to the correct setting before the transaction starts, and does nothing on transaction end. It also allows us to remove task notifications completely which saves a bit of memory on each task.

I didn't bother hooking this up for reading as nothing needing hooks reads at the moment. But the idea would be identical to writes. Also, this PR only uses the pre-transaction action, so it could also be simplified to only support that.

As the hook function has to be static, the LCD driver is changed to reference the hardware pinmap directly. Not as nice an abstraction but we are only ever going to have one LCD so it's not too bad IMO.

Performance also seems to be better than waiting for notifications.

Closes #1984 (probably also #1022). Also fixes occasional temporary garbling of small parts of the display.
Split from #1869