### PR TITLE
Stopwatch: allow sleep

### DIFF
--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -3,6 +3,8 @@
 #include "displayapp/screens/Symbols.h"
 #include "displayapp/InfiniTimeTheme.h"
 
+#include "systemtask/SystemTask.h"
+
 using namespace Pinetime::Applications::Screens;
 
 namespace {
@@ -34,7 +36,7 @@ namespace {
   constexpr TickType_t blinkInterval = pdMS_TO_TICKS(1000);
 }
 
-StopWatch::StopWatch(System::SystemTask& systemTask) : systemTask {systemTask} {
+StopWatch::StopWatch() {
   static constexpr uint8_t btnWidth = 115;
   static constexpr uint8_t btnHeight = 80;
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
@@ -79,7 +81,6 @@ StopWatch::StopWatch(System::SystemTask& systemTask) : systemTask {systemTask} {
 
 StopWatch::~StopWatch() {
   lv_task_del(taskRefresh);
-  systemTask.PushMessage(Pinetime::System::Messages::EnableSleeping);
   lv_obj_clean(lv_scr_act());
 }
 
@@ -135,7 +136,6 @@ void StopWatch::Start() {
   SetInterfaceRunning();
   startTime = xTaskGetTickCount();
   currentState = States::Running;
-  systemTask.PushMessage(Pinetime::System::Messages::DisableSleeping);
 }
 
 void StopWatch::Pause() {
@@ -145,7 +145,6 @@ void StopWatch::Pause() {
   oldTimeElapsed = laps[lapsDone];
   blinkTime = xTaskGetTickCount() + blinkInterval;
   currentState = States::Halted;
-  systemTask.PushMessage(Pinetime::System::Messages::EnableSleeping);
 }
 
 void StopWatch::Refresh() {

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -6,7 +6,6 @@
 #include <FreeRTOS.h>
 #include "portmacro_cmsis.h"
 
-#include "systemtask/SystemTask.h"
 #include "displayapp/apps/Apps.h"
 #include "displayapp/Controllers.h"
 #include "Symbols.h"
@@ -26,7 +25,7 @@ namespace Pinetime {
 
       class StopWatch : public Screen {
       public:
-        explicit StopWatch(System::SystemTask& systemTask);
+        explicit StopWatch();
         ~StopWatch() override;
         void Refresh() override;
 
@@ -43,7 +42,6 @@ namespace Pinetime {
         void Start();
         void Pause();
 
-        Pinetime::System::SystemTask& systemTask;
         States currentState = States::Init;
         TickType_t startTime;
         TickType_t oldTimeElapsed = 0;
@@ -66,7 +64,7 @@ namespace Pinetime {
       static constexpr const char* icon = Screens::Symbols::stopWatch;
 
       static Screens::Screen* Create(AppControllers& controllers) {
-        return new Screens::StopWatch(*controllers.systemTask);
+        return new Screens::StopWatch();
       };
     };
   }


### PR DESCRIPTION
I often use a stopwatch for things like running, and noticed that the watch won’t sleep when the stopwatch is running. 

This PR gives the stopwatch the ability to run while the display is off. 