### PR TITLE
Fix MotorController::Init call order

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -125,6 +125,7 @@ void DisplayApp::Start(System::BootErrors error) {
   bootError = error;
 
   lvgl.Init();
+  motorController.Init();
 
   if (error == System::BootErrors::TouchController) {
     LoadNewScreen(Apps::Error, DisplayApp::FullRefreshDirections::None);
@@ -150,7 +151,6 @@ void DisplayApp::Process(void* instance) {
 void DisplayApp::InitHw() {
   brightnessController.Init();
   ApplyBrightness();
-  motorController.Init();
   lcd.Init();
 }
 


### PR DESCRIPTION
The call to `LoadNewScreen` [here](https://github.com/InfiniTimeOrg/InfiniTime/blob/0dcfb2edb7ac071aa0a22c01609122d577d4c05d/src/displayapp/DisplayApp.cpp#L130) (and the one below it) calls `MotorController::StopRinging()` [here](https://github.com/InfiniTimeOrg/InfiniTime/blob/0dcfb2edb7ac071aa0a22c01609122d577d4c05d/src/displayapp/DisplayApp.cpp#L416), which in turn calls `xTimerStop` to stop the ringing timer. However, this timer only gets created when [`DisplayApp::InitHw`](https://github.com/InfiniTimeOrg/InfiniTime/blob/0dcfb2edb7ac071aa0a22c01609122d577d4c05d/src/displayapp/DisplayApp.cpp#L150) is called, which currently happens in [`DisplayApp::Process`](https://github.com/InfiniTimeOrg/InfiniTime/blob/0dcfb2edb7ac071aa0a22c01609122d577d4c05d/src/displayapp/DisplayApp.cpp#L143) after the initial call to `LoadNewScreen`. This means that `xTimerStop` is called on uninitialized data, which has undefined behaviour.

This PR makes it so that the call to `MotorController::Init` happens before `LoadNewScreen`.