### PR TITLE
README: Change links from Pine wiki to new documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Fast open-source firmware for the [PineTime smartwatch](https://pine64.org/devic
 - [Getting started with InfiniTime](doc/gettingStarted/gettingStarted-1.0.md)
 - [Updating the software](doc/gettingStarted/updating-software.md)
 - [About the firmware and bootloader](doc/gettingStarted/about-software.md)
-- [PineTimeStyle Watch face](https://wiki.pine64.org/wiki/PineTimeStyle)
-  - [Weather integration](https://wiki.pine64.org/wiki/Infinitime-Weather)
+- [PineTimeStyle Watch face](https://pine64.org/documentation/PineTime/Watchfaces/PineTimeStyle)
+  - [Weather integration](https://pine64.org/documentation/PineTime/Software/InfiniTime_weather/)
 
 ### Companion apps
 


### PR DESCRIPTION
As the Wiki was replaced by a new documentation website and is read-only, we should update the links, to point to the most up-to-date documentation.