### PR TITLE
Fix EOL related build issues on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
+* text=auto eol=lf
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,9 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
+# Prevent build errors on non lf systems (like Windows), we need files with lf as newlines.
 * text=auto eol=lf
 
 # Explicitly declare text files you want to always be normalized and converted
-# to native line endings on checkout.
+# to lf line endings on checkout.
 *.c text
 *.cpp text
 *.h text


### PR DESCRIPTION
Proper fix for #1275 that does no longer require manual intervention. 

On Windows, git has `core.autocrlf=true` set at _system_ level, hence any Windows user who has not changed their _global_ git config will checkout all text files with CRLF line endings. For some files this seems to cause build issues.

With this change, I can build using docker on Windows 11 as follows:

```pwsh
git clone https://github.com/madmini/InfiniTime.git --branch fix/eol-on-windows
cd InfiniTime
git submodule update --init
docker run --rm -it -v ${PWD}:/sources infinitime/infinitime-build
```

Without the change, the build fails with an error that matches the one described in #1275:

```
...
[ 34%] Linking C static library libnimble.a
[ 34%] Built target nimble
gmake: *** [Makefile:91: all] Error 2
```

<hr />

Note: when changing between branches with varying `.gitattributes` with `checkout` instead of directly cloning with `--branch`, resetting the line endings is more complicated:

```pwsh
git clone https://github.com/madmini/InfiniTime.git
# CRLF line endings
git checkout fix/eol-on-windows
# still CRLF line endings
git rm --cached -r .
git reset --hard
# LF line endings
```