### PR TITLE
Remove defunct .gitconfig file

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,5 +1,0 @@
-[core]
-    whitespace = blank-at-eol,blank-at-eof,space-before-tab
-    autocrlf = input
-[apply]
-    whitespace = fix


### PR DESCRIPTION
The `.gitconfig` is not actually used by git unless manually configured to do so. The repo-specific git config is located in `.git/config`. The only `.gitconfig` file read by git is the one in the user home directory. See [`git config` docs](https://git-scm.com/docs/git-config) and the answers to [this stackoverflow question](https://stackoverflow.com/q/18329621).

I believe it is misleading to have this file in the repo as it implies the config is automatically applied. I for one have wasted a lot of time trying to fix the `.gitconfig` file before I realized this and came up with #2077 instead.

If I am mistaken and the `.gitconfig` file represents recommendations for contributors or similar then I strongly recommend to have this reflected somewhere in the docs, or noted as a comment in the defunct `.gitconfig` file.