### PR TITLE
Upload standalone ELF build as artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,11 @@ jobs:
         with:
           name: InfiniTime MCUBoot image ${{ github.head_ref }}
           path: ./build/output/pinetime-mcuboot-app-image-*.bin
+      - name: Upload standalone ELF artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: InfiniTime image ${{ github.head_ref }}
+          path: ./build/output/src/pinetime-app-*.out
       - name: Upload resources artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
By uploading the standalone ELF build as an artifact we'll be able to use the web build of InfiniEmu to test any PRs without downloading any files.