### PR TITLE
Improve timer vibration

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -270,7 +270,7 @@ void DisplayApp::Refresh() {
         } else {
           LoadNewScreen(Apps::Timer, DisplayApp::FullRefreshDirections::Up);
         }
-        motorController.RunForDuration(35);
+        motorController.StartRinging();
         break;
       case Messages::AlarmTriggered:
         if (currentApp == Apps::Alarm) {


### PR DESCRIPTION
This is a super-simple fix for #391.
When timer ends the watch will vibrate until the side button is pressed or a sliding-down movement is made on the screen (maybe there are some more gestures).