### PR TITLE
Advertise HR service

### DIFF
--- a/src/components/ble/DfuService.h
+++ b/src/components/ble/DfuService.h
@@ -77,6 +77,10 @@ namespace Pinetime {
         uint16_t ComputeCrc(uint8_t const* p_data, uint32_t size, uint16_t const* p_crc);
       };
 
+      static constexpr ble_uuid128_t serviceUuid {
+        .u {.type = BLE_UUID_TYPE_128},
+        .value = {0x23, 0xD1, 0xBC, 0xEA, 0x5F, 0x78, 0x23, 0x15, 0xDE, 0xEF, 0x12, 0x12, 0x30, 0x15, 0x00, 0x00}};
+
     private:
       Pinetime::System::SystemTask& systemTask;
       Pinetime::Controllers::Ble& bleController;
@@ -89,10 +93,6 @@ namespace Pinetime {
       static constexpr uint16_t revisionCharacteristicId {0x1534};
 
       uint16_t revision {0x0008};
-
-      static constexpr ble_uuid128_t serviceUuid {
-        .u {.type = BLE_UUID_TYPE_128},
-        .value = {0x23, 0xD1, 0xBC, 0xEA, 0x5F, 0x78, 0x23, 0x15, 0xDE, 0xEF, 0x12, 0x12, 0x30, 0x15, 0x00, 0x00}};
 
       static constexpr ble_uuid128_t packetCharacteristicUuid {
         .u {.type = BLE_UUID_TYPE_128},

--- a/src/components/ble/HeartRateService.h
+++ b/src/components/ble/HeartRateService.h
@@ -21,13 +21,13 @@ namespace Pinetime {
       void SubscribeNotification(uint16_t attributeHandle);
       void UnsubscribeNotification(uint16_t attributeHandle);
 
+      static constexpr uint16_t heartRateServiceId {0x180D};
+      static constexpr ble_uuid16_t heartRateServiceUuid {.u {.type = BLE_UUID_TYPE_16}, .value = heartRateServiceId};
+
     private:
       NimbleController& nimble;
       Controllers::HeartRateController& heartRateController;
-      static constexpr uint16_t heartRateServiceId {0x180D};
       static constexpr uint16_t heartRateMeasurementId {0x2A37};
-
-      static constexpr ble_uuid16_t heartRateServiceUuid {.u {.type = BLE_UUID_TYPE_16}, .value = heartRateServiceId};
 
       static constexpr ble_uuid16_t heartRateMeasurementUuid {.u {.type = BLE_UUID_TYPE_16}, .value = heartRateMeasurementId};
 

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -158,7 +158,10 @@ void NimbleController::StartAdvertising() {
   }
 
   fields.flags = BLE_HS_ADV_F_DISC_GEN | BLE_HS_ADV_F_BREDR_UNSUP;
-  fields.uuids128 = &dfuServiceUuid;
+  fields.uuids16 = &HeartRateService::heartRateServiceUuid;
+  fields.num_uuids16 = 1;
+  fields.uuids16_is_complete = 1;
+  fields.uuids128 = &DfuService::serviceUuid;
   fields.num_uuids128 = 1;
   fields.uuids128_is_complete = 1;
   fields.tx_pwr_lvl = BLE_HS_ADV_TX_PWR_LVL_AUTO;

--- a/src/components/ble/NimbleController.h
+++ b/src/components/ble/NimbleController.h
@@ -112,10 +112,6 @@ namespace Pinetime {
       uint16_t connectionHandle = BLE_HS_CONN_HANDLE_NONE;
       uint8_t fastAdvCount = 0;
       uint8_t bondId[16] = {0};
-
-      ble_uuid128_t dfuServiceUuid {
-        .u {.type = BLE_UUID_TYPE_128},
-        .value = {0x23, 0xD1, 0xBC, 0xEA, 0x5F, 0x78, 0x23, 0x15, 0xDE, 0xEF, 0x12, 0x12, 0x30, 0x15, 0x00, 0x00}};
     };
 
     static NimbleController* nptr;


### PR DESCRIPTION
Builds on top of #897
The original problem was that an extra 128bit uuid was too big for the advertising packet

Works with OpenTracks (shows with the advertising filter on), NRF Connect shows both the DFU and HR service

Closes #895