### PR TITLE
Add small bytecode language for watchfaces

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -397,6 +397,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/Alarm.cpp
         displayapp/screens/Styles.cpp
         displayapp/screens/WeatherSymbols.cpp
+        displayapp/screens/ASM.cpp
         displayapp/Colors.cpp
         displayapp/widgets/Counter.cpp
         displayapp/widgets/PageIndicator.cpp

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -125,6 +125,7 @@ void DisplayApp::Start(System::BootErrors error) {
   bootError = error;
 
   lvgl.Init();
+  motorController.Init();
 
   if (error == System::BootErrors::TouchController) {
     LoadNewScreen(Apps::Error, DisplayApp::FullRefreshDirections::None);
@@ -150,7 +151,6 @@ void DisplayApp::Process(void* instance) {
 void DisplayApp::InitHw() {
   brightnessController.Init();
   ApplyBrightness();
-  motorController.Init();
   lcd.Init();
 }
 

--- a/src/displayapp/UserApps.h
+++ b/src/displayapp/UserApps.h
@@ -2,6 +2,7 @@
 #include "displayapp/apps/Apps.h"
 #include "Controllers.h"
 
+#include "displayapp/screens/ASM.h"
 #include "displayapp/screens/Alarm.h"
 #include "displayapp/screens/Dice.h"
 #include "displayapp/screens/Timer.h"

--- a/src/displayapp/screens/ASM.cpp
+++ b/src/displayapp/screens/ASM.cpp
@@ -127,6 +127,19 @@ void ASM::run() {
           ptr = pop_uint32();
           break;
 
+        case StartPeriodicRefresh:
+          if (taskRefresh == nullptr) {
+            taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
+          }
+          break;
+
+        case StopPeriodicRefresh:
+          if (taskRefresh != nullptr) {
+            lv_task_del(taskRefresh);
+            taskRefresh = nullptr;
+          }
+          break;
+
         case SetLabelText: {
           Value str = pop(String);
           Value obj = pop(LvglObject);

--- a/src/displayapp/screens/ASM.cpp
+++ b/src/displayapp/screens/ASM.cpp
@@ -189,6 +189,22 @@ void ASM::run() {
           break;
         }
 
+        case Add:
+          push(Value(pop_uint32() + pop_uint32()));
+          break;
+
+        case Subtract:
+          push(Value(pop_uint32() - pop_uint32()));
+          break;
+
+        case Multiply:
+          push(Value(pop_uint32() * pop_uint32()));
+          break;
+
+        case Divide:
+          push(Value(pop_uint32() / pop_uint32()));
+          break;
+
         default:
           NRF_LOG_ERROR("Unknown opcode: 0x%02X", opcode);
           break;

--- a/src/displayapp/screens/ASM.cpp
+++ b/src/displayapp/screens/ASM.cpp
@@ -154,7 +154,7 @@ void ASM::run() {
           auto str = pop(String);
           auto obj = pop(LvglObject);
 
-          lv_label_set_text(obj->data.obj, str->data.s);
+          lv_label_set_text(obj->data.lvobj, str->data.s);
           break;
         }
 
@@ -167,7 +167,7 @@ void ASM::run() {
           int16_t x = pop_uint32();
           uint8_t align = pop_uint32();
           auto obj = pop(LvglObject);
-          lv_obj_align(obj->data.obj, lv_scr_act(), align, x, y);
+          lv_obj_align(obj->data.lvobj, lv_scr_act(), align, x, y);
           break;
         }
 
@@ -181,11 +181,11 @@ void ASM::run() {
 
           switch (opcode) {
             case SetStyleLocalInt:
-              _lv_obj_set_style_local_int(obj->data.obj, part, prop, value);
+              _lv_obj_set_style_local_int(obj->data.lvobj, part, prop, value);
               break;
 
             case SetStyleLocalColor:
-              _lv_obj_set_style_local_color(obj->data.obj, part, prop, lv_color_hex(value));
+              _lv_obj_set_style_local_color(obj->data.lvobj, part, prop, lv_color_hex(value));
               break;
 
             case SetStyleLocalFont: {
@@ -202,7 +202,7 @@ void ASM::run() {
               }
 
               if (font)
-                _lv_obj_set_style_local_ptr(obj->data.obj, part, prop, font);
+                _lv_obj_set_style_local_ptr(obj->data.lvobj, part, prop, font);
 
               break;
             }

--- a/src/displayapp/screens/ASM.cpp
+++ b/src/displayapp/screens/ASM.cpp
@@ -126,7 +126,7 @@ void ASM::run() {
         case SetLabelText: {
           Value str = pop();
           assert(str.type == String);
-          Value obj = pop(); // TODO: Check type
+          Value obj = pop(LvglObject);
 
           lv_label_set_text(obj.data.obj, str.data.s);
           break;
@@ -141,7 +141,7 @@ void ASM::run() {
           int16_t y = pop_uint32();
           int16_t x = pop_uint32();
           uint8_t align = pop_uint32();
-          Value obj = pop(); // TODO: Check type
+          Value obj = pop(LvglObject);
           lv_obj_align(obj.data.obj, lv_scr_act(), align, x, y);
           break;
         }
@@ -153,7 +153,7 @@ void ASM::run() {
           uint32_t value = pop_uint32();
           uint32_t prop = pop_uint32();
           uint32_t part = pop_uint32();
-          Value obj = pop(); // TODO: Check type
+          Value obj = pop(LvglObject);
 
           switch (opcode) {
             case SetStyleLocalInt:
@@ -199,4 +199,12 @@ void ASM::run() {
 
 void ASM::Refresh() {
   run();
+}
+
+void ASM::asm_assert(bool condition) {
+  if (!condition) {
+    // TODO: Handle better
+    for (;;) {
+    }
+  }
 }

--- a/src/displayapp/screens/ASM.cpp
+++ b/src/displayapp/screens/ASM.cpp
@@ -1,0 +1,185 @@
+#include "ASM.h"
+
+#include <libraries/log/nrf_log.h>
+#include <assert.h>
+
+#include "asm_data.h"
+
+using namespace Pinetime::Applications::Screens;
+
+#define u16(n) (n) >> 8, (n) & 0xFF
+
+ASM::ASM() {
+  this->code = out_bin;
+  this->code_len = out_bin_len;
+
+  run();
+}
+
+ASM::~ASM() {
+  lv_obj_clean(lv_scr_act());
+}
+
+uint8_t ASM::read_byte(size_t pos) {
+  return code[pos];
+}
+
+uint16_t ASM::read_u16(size_t pos) {
+  return static_cast<uint16_t>(code[pos + 1] << 8 | code[pos]);
+}
+
+uint32_t ASM::read_u24(size_t pos) {
+  return static_cast<uint32_t>(code[pos + 2] << 16 | code[pos + 1] << 8 | code[pos]);
+}
+
+uint32_t ASM::read_u32(size_t pos) {
+  return static_cast<uint32_t>(code[pos + 3] << 24 | code[pos + 2] << 16 | code[pos + 1] << 8 | code[pos]);
+}
+
+void ASM::run() {
+  for (;;) {
+    if (ptr >= code_len) {
+      break;
+    }
+
+    OpcodeShort opcode = static_cast<OpcodeShort>(code[ptr]);
+    if (opcode & (1 << 7)) {
+      // Long opcode
+      OpcodeLong opcode = static_cast<OpcodeLong>(code[ptr] << 8 | code[ptr + 1]);
+
+      NRF_LOG_INFO("Long opcode: %d", opcode);
+
+      ptr += 2;
+
+      switch (opcode) {
+        default:
+          NRF_LOG_ERROR("Unknown opcode: 0x%04X", opcode);
+          break;
+      }
+    } else {
+      ptr++;
+
+      NRF_LOG_INFO("Short opcode: %d", opcode);
+
+      if (opcode >= SelectSlot0 && opcode <= SelectSlotMax) {
+        current_slot = opcode - SelectSlot0;
+        continue;
+      }
+
+      switch (opcode) {
+        case WaitRefresh:
+          return;
+
+        case Push0:
+          stack[stack_pointer++] = 0;
+          break;
+
+        case PushU8:
+          stack[stack_pointer++] = read_byte(ptr);
+          ptr++;
+          break;
+
+        case PushU16:
+          stack[stack_pointer++] = read_u16(ptr);
+          ptr += 2;
+          break;
+
+        case PushU24:
+          stack[stack_pointer++] = read_u24(ptr);
+          ptr += 3;
+          break;
+
+        case PushU32:
+          stack[stack_pointer++] = read_u32(ptr);
+          ptr += 4;
+          break;
+
+        case Branch:
+          assert(stack_pointer >= 1);
+          ptr = stack[--stack_pointer];
+          break;
+
+        case SetLabelText: { // TODO: Remove double allocation here
+          assert(stack_pointer >= 1);
+          size_t ptr = stack[--stack_pointer];
+
+          int length = read_byte(ptr);
+          char* text = new char[length + 1];
+          text[length] = '\0';
+
+          for (int i = 0; i < length; i++) {
+            text[i] = read_byte(ptr + 1 + i);
+          }
+
+          lv_label_set_text(slots[current_slot], text);
+
+          delete[] text;
+          break;
+        }
+
+        case CreateLabel:
+          slots[current_slot] = lv_label_create(lv_scr_act(), NULL); //
+          break;
+
+        case SetObjectAlign: {
+          assert(stack_pointer >= 3); // TODO: Compactize this
+          int16_t y = stack[--stack_pointer];
+          int16_t x = stack[--stack_pointer];
+          uint8_t align = stack[--stack_pointer];
+          lv_obj_align(slots[current_slot], lv_scr_act(), align, x, y);
+          break;
+        }
+
+        case SetStyleLocalInt:
+        case SetStyleLocalFont:
+        case SetStyleLocalColor: {
+          assert(stack_pointer >= 3);
+          uint32_t value = stack[--stack_pointer];
+          uint32_t prop = stack[--stack_pointer];
+          uint32_t part = stack[--stack_pointer];
+
+          switch (opcode) {
+            case SetStyleLocalInt:
+              _lv_obj_set_style_local_int(slots[current_slot], part, prop, value);
+              break;
+
+            case SetStyleLocalColor:
+              _lv_obj_set_style_local_color(slots[current_slot], part, prop, lv_color_hex(value));
+              break;
+
+            case SetStyleLocalFont: {
+              lv_font_t* font = NULL;
+
+              switch (value) {
+                case 0:
+                  font = &jetbrains_mono_extrabold_compressed;
+                  break;
+
+                default:
+                  NRF_LOG_ERROR("Unknown font: %d", value);
+                  break;
+              }
+
+              if (font)
+                _lv_obj_set_style_local_ptr(slots[current_slot], part, prop, font);
+
+              break;
+            }
+
+            default:
+              break;
+          }
+          break;
+        }
+
+        default:
+          NRF_LOG_ERROR("Unknown opcode: 0x%02X", opcode);
+          break;
+      }
+    }
+  }
+}
+
+void ASM::Refresh() {
+  run();
+}

--- a/src/displayapp/screens/ASM.cpp
+++ b/src/displayapp/screens/ASM.cpp
@@ -127,6 +127,14 @@ void ASM::run() {
           ptr = pop_uint32();
           break;
 
+        case Call: {
+          assert(stack_pointer >= 1);
+          uint32_t next = ptr;
+          ptr = pop_uint32();
+          push(Value(next));
+          break;
+        }
+
         case StartPeriodicRefresh:
           if (taskRefresh == nullptr) {
             taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);

--- a/src/displayapp/screens/ASM.h
+++ b/src/displayapp/screens/ASM.h
@@ -54,6 +54,21 @@ namespace Pinetime {
             data.s = s;
             data.cap = cap;
           }
+
+          ~Value() {
+            switch (type) {
+              case String:
+                delete[] data.s;
+                break;
+
+              case LvglObject:
+                lv_obj_del(data.obj);
+                break;
+
+              default:
+                break;
+            }
+          }
         } __packed;
 
         enum OpcodeShort : uint8_t {
@@ -68,6 +83,9 @@ namespace Pinetime {
           PushEmptyString,
           Duplicate,
           LoadString,
+
+          StartPeriodicRefresh,
+          StopPeriodicRefresh,
 
           SetLabelText,
           SetObjectAlign,
@@ -102,6 +120,8 @@ namespace Pinetime {
 
         Value stack[stack_size];
         uint8_t stack_pointer = 0;
+
+        lv_task_t* taskRefresh = nullptr;
 
         void run();
         void asm_assert(bool condition);

--- a/src/displayapp/screens/ASM.h
+++ b/src/displayapp/screens/ASM.h
@@ -55,26 +55,27 @@ namespace Pinetime {
             data.cap = cap;
           }
 
-          ~Value() {
-            switch (type) {
-              case String:
-                delete[] data.s;
-                break;
+          // ~Value() {
+          //   switch (type) {
+          //     case String:
+          //       delete[] data.s;
+          //       break;
 
-              case LvglObject:
-                lv_obj_del(data.obj);
-                break;
+          //     case LvglObject:
+          //       lv_obj_del(data.obj);
+          //       break;
 
-              default:
-                break;
-            }
-          }
+          //     default:
+          //       break;
+          //   }
+          // }
         } __packed;
 
         enum OpcodeShort : uint8_t {
           StoreLocal,
           LoadLocal,
           Branch,
+          Call,
           Push0,
           PushU8,
           PushU16,

--- a/src/displayapp/screens/ASM.h
+++ b/src/displayapp/screens/ASM.h
@@ -65,8 +65,10 @@ namespace Pinetime {
           PushU16,
           PushU24,
           PushU32,
+          PushEmptyString,
           Duplicate,
           LoadString,
+
           SetLabelText,
           SetObjectAlign,
           CreateLabel,
@@ -79,7 +81,10 @@ namespace Pinetime {
           Add,
           Subtract,
           Multiply,
-          Divide
+          Divide,
+
+          GrowString,
+          Concat
         };
 
         enum OpcodeLong : uint16_t {};

--- a/src/displayapp/screens/ASM.h
+++ b/src/displayapp/screens/ASM.h
@@ -74,7 +74,12 @@ namespace Pinetime {
           SetStyleLocalColor,
           SetStyleLocalOpa,
           SetStyleLocalFont,
-          WaitRefresh
+          WaitRefresh,
+
+          Add,
+          Subtract,
+          Multiply,
+          Divide
         };
 
         enum OpcodeLong : uint16_t {};

--- a/src/displayapp/screens/ASM.h
+++ b/src/displayapp/screens/ASM.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "displayapp/screens/Screen.h"
+#include "displayapp/apps/Apps.h"
+#include "displayapp/Controllers.h"
+#include "Symbols.h"
+
+namespace Pinetime {
+  namespace Applications {
+    namespace Screens {
+      class ASM : public Screen {
+      public:
+        ASM();
+        ~ASM();
+
+        void Refresh() override;
+
+      private:
+        static constexpr int num_slots = 16;
+        static constexpr int stack_size = 32;
+
+        enum OpcodeShort : uint8_t {
+          Branch,
+          Push0,
+          PushU8,
+          PushU16,
+          PushU24,
+          PushU32,
+          SelectSlot0,
+          SelectSlotMax = SelectSlot0 + ASM::num_slots - 1,
+          SetLabelText,
+          SetObjectAlign,
+          CreateLabel,
+          SetStyleLocalInt,
+          SetStyleLocalColor,
+          SetStyleLocalOpa,
+          SetStyleLocalFont,
+          WaitRefresh,
+        };
+
+        enum OpcodeLong : uint16_t {};
+
+        uint8_t read_byte(size_t pos);
+        uint16_t read_u16(size_t pos);
+        uint32_t read_u24(size_t pos);
+        uint32_t read_u32(size_t pos);
+
+        uint8_t* code;
+        size_t code_len;
+        size_t ptr = 0;
+
+        lv_obj_t* slots[num_slots] = {0};
+
+        uint32_t stack[stack_size] = {0};
+        uint8_t stack_pointer = 0;
+
+        uint8_t current_slot = 0;
+
+        void run();
+      };
+    }
+
+    template <>
+    struct AppTraits<Apps::ASM> {
+      static constexpr Apps app = Apps::ASM;
+      static constexpr const char* icon = Screens::Symbols::eye;
+
+      static Screens::Screen* Create(AppControllers&) {
+        return new Screens::ASM();
+      };
+    };
+  };
+}

--- a/src/displayapp/screens/ASM.h
+++ b/src/displayapp/screens/ASM.h
@@ -30,7 +30,7 @@ namespace Pinetime {
 
           union {
             uint32_t i;
-            lv_obj_t* obj;
+            lv_obj_t* lvobj;
 
             struct {
               char* s;
@@ -49,7 +49,7 @@ namespace Pinetime {
           }
 
           Value(lv_obj_t* obj) : type(LvglObject) {
-            data.obj = obj;
+            data.lvobj = obj;
           }
 
           Value(char* s, uint16_t cap) : type(String) {
@@ -64,7 +64,7 @@ namespace Pinetime {
                 break;
 
               case LvglObject:
-                lv_obj_del(data.obj);
+                lv_obj_del(data.lvobj);
                 break;
 
               default:

--- a/src/displayapp/screens/ASM.h
+++ b/src/displayapp/screens/ASM.h
@@ -74,7 +74,7 @@ namespace Pinetime {
           SetStyleLocalColor,
           SetStyleLocalOpa,
           SetStyleLocalFont,
-          WaitRefresh,
+          WaitRefresh
         };
 
         enum OpcodeLong : uint16_t {};
@@ -94,20 +94,26 @@ namespace Pinetime {
         uint8_t stack_pointer = 0;
 
         void run();
+        void asm_assert(bool condition);
 
         Value pop() {
-          assert(stack_pointer > 0);
+          asm_assert(stack_pointer > 0);
           return stack[--stack_pointer];
         }
 
+        Value pop(DataType type) {
+          asm_assert(stack_pointer > 0);
+          Value v = stack[--stack_pointer];
+          asm_assert(v.type == type);
+          return v;
+        }
+
         uint32_t pop_uint32() {
-          Value v = pop();
-          assert(v.type == Integer);
-          return v.data.i;
+          return pop(Integer).data.i;
         }
 
         void push(Value v) {
-          assert(stack_pointer < stack_size);
+          asm_assert(stack_pointer < stack_size);
           stack[stack_pointer] = v;
           stack_pointer++;
         }


### PR DESCRIPTION
I've implemented a small bytecode assembly language intended for making watchfaces without recompiling InfiniTime. Right now it's only a proof of concept and I'm open to any ideas and improvements. Currently it's loading the bytecode from memory but later it'll be easy to make it load code from the external flash instead, allowing users to add and remove watchfaces at runtime. It's also not very optimized for memory, as it's only a proof of concept.

You can try a sample out in [InfiniEmu](https://infiniemu.pipe01.net/?firmware=https://share.pipe01.net/-QAGHPAPQKb), currently the ASM screen is the app with the eye icon. The firmware is running the following assembly code:

```
createLabel
dup
storeLocal 10

push #0
push %TEXT_FONT
push #0
setStyleLocalFont

startPeriodicRefresh

refresh:
    loadLocal 10
    dup
    pushCurrentTime
    push format
    loadString
    formatDateTime
    setLabelText

    push #0
    push #0
    push #0
    setObjectAlign

    waitRefresh
    push refresh
    jump

format: .str %H:%M
```