### PR TITLE
Display the SPI flash JEDEC IDs in SystemInformation.

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -81,7 +81,8 @@ DisplayApp::DisplayApp(Drivers::St7789& lcd,
                        Pinetime::Controllers::AlarmController& alarmController,
                        Pinetime::Controllers::BrightnessController& brightnessController,
                        Pinetime::Controllers::TouchHandler& touchHandler,
-                       Pinetime::Controllers::FS& filesystem)
+                       Pinetime::Controllers::FS& filesystem,
+                       Pinetime::Drivers::SpiNorFlash& spiNorFlash)
   : lcd {lcd},
     touchPanel {touchPanel},
     batteryController {batteryController},
@@ -97,6 +98,7 @@ DisplayApp::DisplayApp(Drivers::St7789& lcd,
     brightnessController {brightnessController},
     touchHandler {touchHandler},
     filesystem {filesystem},
+    spiNorFlash {spiNorFlash},
     lvgl {lcd, filesystem},
     timer(this, TimerCallback),
     controllers {batteryController,
@@ -535,7 +537,8 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
                                                             bleController,
                                                             watchdog,
                                                             motionController,
-                                                            touchPanel);
+                                                            touchPanel,
+                                                            spiNorFlash);
       break;
     case Apps::FlashLight:
       currentScreen = std::make_unique<Screens::FlashLight>(*systemTask, brightnessController);

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -66,7 +66,8 @@ namespace Pinetime {
                  Pinetime::Controllers::AlarmController& alarmController,
                  Pinetime::Controllers::BrightnessController& brightnessController,
                  Pinetime::Controllers::TouchHandler& touchHandler,
-                 Pinetime::Controllers::FS& filesystem);
+                 Pinetime::Controllers::FS& filesystem,
+                 Pinetime::Drivers::SpiNorFlash& spiNorFlash);
       void Start(System::BootErrors error);
       void PushMessage(Display::Messages msg);
 
@@ -96,6 +97,7 @@ namespace Pinetime {
       Pinetime::Controllers::BrightnessController& brightnessController;
       Pinetime::Controllers::TouchHandler& touchHandler;
       Pinetime::Controllers::FS& filesystem;
+      Pinetime::Drivers::SpiNorFlash& spiNorFlash;
 
       Pinetime::Controllers::FirmwareValidator validator;
       Pinetime::Components::LittleVgl lvgl;

--- a/src/displayapp/DisplayAppRecovery.cpp
+++ b/src/displayapp/DisplayAppRecovery.cpp
@@ -24,7 +24,8 @@ DisplayApp::DisplayApp(Drivers::St7789& lcd,
                        Pinetime::Controllers::AlarmController& /*alarmController*/,
                        Pinetime::Controllers::BrightnessController& /*brightnessController*/,
                        Pinetime::Controllers::TouchHandler& /*touchHandler*/,
-                       Pinetime::Controllers::FS& /*filesystem*/)
+                       Pinetime::Controllers::FS& /*filesystem*/,
+                       Pinetime::Drivers::SpiNorFlash& /*spiNorFlash*/)
   : lcd {lcd}, bleController {bleController} {
 }
 

--- a/src/displayapp/DisplayAppRecovery.h
+++ b/src/displayapp/DisplayAppRecovery.h
@@ -18,6 +18,7 @@ namespace Pinetime {
     class St7789;
     class Cst816S;
     class Watchdog;
+    class SpiNorFlash;
   }
 
   namespace Controllers {
@@ -59,7 +60,8 @@ namespace Pinetime {
                  Pinetime::Controllers::AlarmController& alarmController,
                  Pinetime::Controllers::BrightnessController& brightnessController,
                  Pinetime::Controllers::TouchHandler& touchHandler,
-                 Pinetime::Controllers::FS& filesystem);
+                 Pinetime::Controllers::FS& filesystem,
+                 Pinetime::Drivers::SpiNorFlash& spiNorFlash);
       void Start();
 
       void Start(Pinetime::System::BootErrors) {

--- a/src/displayapp/screens/SystemInfo.cpp
+++ b/src/displayapp/screens/SystemInfo.cpp
@@ -38,7 +38,8 @@ SystemInfo::SystemInfo(Pinetime::Applications::DisplayApp* app,
                        const Pinetime::Controllers::Ble& bleController,
                        const Pinetime::Drivers::Watchdog& watchdog,
                        Pinetime::Controllers::MotionController& motionController,
-                       const Pinetime::Drivers::Cst816S& touchPanel)
+                       const Pinetime::Drivers::Cst816S& touchPanel,
+                       const Pinetime::Drivers::SpiNorFlash& spiNorFlash)
   : app {app},
     dateTimeController {dateTimeController},
     batteryController {batteryController},
@@ -47,6 +48,7 @@ SystemInfo::SystemInfo(Pinetime::Applications::DisplayApp* app,
     watchdog {watchdog},
     motionController {motionController},
     touchPanel {touchPanel},
+    spiNorFlash {spiNorFlash},
     screens {app,
              0,
              {[this]() -> std::unique_ptr<Screen> {
@@ -186,10 +188,12 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen3() {
   lv_obj_t* label = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_recolor(label, true);
   const auto& bleAddr = bleController.Address();
+  auto spiFlashId = spiNorFlash.GetIdentification();
   lv_label_set_text_fmt(label,
                         "#808080 BLE MAC#\n"
-                        " %02x:%02x:%02x:%02x:%02x:%02x"
+                        " %02x:%02x:%02x:%02x:%02x:%02x\n"
                         "\n"
+                        "#808080 SPI Flash# %02x-%02x-%02x\n"
                         "\n"
                         "#808080 Memory heap#\n"
                         " #808080 Free# %d\n"
@@ -202,6 +206,9 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen3() {
                         bleAddr[2],
                         bleAddr[1],
                         bleAddr[0],
+                        spiFlashId.manufacturer,
+                        spiFlashId.type,
+                        spiFlashId.density,
                         xPortGetFreeHeapSize(),
                         xPortGetMinimumEverFreeHeapSize(),
                         mallocFailedCount,

--- a/src/displayapp/screens/SystemInfo.h
+++ b/src/displayapp/screens/SystemInfo.h
@@ -29,7 +29,8 @@ namespace Pinetime {
                             const Pinetime::Controllers::Ble& bleController,
                             const Pinetime::Drivers::Watchdog& watchdog,
                             Pinetime::Controllers::MotionController& motionController,
-                            const Pinetime::Drivers::Cst816S& touchPanel);
+                            const Pinetime::Drivers::Cst816S& touchPanel,
+                            const Pinetime::Drivers::SpiNorFlash& spiNorFlash);
         ~SystemInfo() override;
         bool OnTouchEvent(TouchEvents event) override;
 
@@ -42,6 +43,7 @@ namespace Pinetime {
         const Pinetime::Drivers::Watchdog& watchdog;
         Pinetime::Controllers::MotionController& motionController;
         const Pinetime::Drivers::Cst816S& touchPanel;
+        const Pinetime::Drivers::SpiNorFlash& spiNorFlash;
 
         ScreenList<5> screens;
 

--- a/src/drivers/SpiNorFlash.cpp
+++ b/src/drivers/SpiNorFlash.cpp
@@ -10,7 +10,7 @@ SpiNorFlash::SpiNorFlash(Spi& spi) : spi {spi} {
 }
 
 void SpiNorFlash::Init() {
-  device_id = ReadIdentificaion();
+  device_id = ReadIdentification();
   NRF_LOG_INFO("[SpiNorFlash] Manufacturer : %d, Memory type : %d, memory density : %d",
                device_id.manufacturer,
                device_id.type,
@@ -32,7 +32,7 @@ void SpiNorFlash::Wakeup() {
   uint8_t cmd[cmdSize] = {static_cast<uint8_t>(Commands::ReleaseFromDeepPowerDown), 0x01, 0x02, 0x03};
   uint8_t id = 0;
   spi.Read(reinterpret_cast<uint8_t*>(&cmd), cmdSize, &id, 1);
-  auto devId = device_id = ReadIdentificaion();
+  auto devId = device_id = ReadIdentification();
   if (devId.type != device_id.type) {
     NRF_LOG_INFO("[SpiNorFlash] ID on Wakeup: Failed");
   } else {
@@ -41,7 +41,7 @@ void SpiNorFlash::Wakeup() {
   NRF_LOG_INFO("[SpiNorFlash] Wakeup")
 }
 
-SpiNorFlash::Identification SpiNorFlash::ReadIdentificaion() {
+SpiNorFlash::Identification SpiNorFlash::ReadIdentification() {
   auto cmd = static_cast<uint8_t>(Commands::ReadIdentification);
   Identification identification;
   spi.Read(&cmd, 1, reinterpret_cast<uint8_t*>(&identification), sizeof(Identification));
@@ -144,4 +144,8 @@ void SpiNorFlash::Write(uint32_t address, const uint8_t* buffer, size_t size) {
     b += toWrite;
     len -= toWrite;
   }
+}
+
+SpiNorFlash::Identification SpiNorFlash::GetIdentification() const {
+  return device_id;
 }

--- a/src/drivers/SpiNorFlash.h
+++ b/src/drivers/SpiNorFlash.h
@@ -20,7 +20,6 @@ namespace Pinetime {
         uint8_t density = 0;
       };
 
-      Identification ReadIdentificaion();
       uint8_t ReadStatusRegister();
       bool WriteInProgress();
       bool WriteEnabled();
@@ -33,6 +32,8 @@ namespace Pinetime {
       bool ProgramFailed();
       bool EraseFailed();
 
+      Identification GetIdentification() const;
+
       void Init();
       void Uninit();
 
@@ -40,6 +41,8 @@ namespace Pinetime {
       void Wakeup();
 
     private:
+      Identification ReadIdentification();
+
       enum class Commands : uint8_t {
         PageProgram = 0x02,
         Read = 0x03,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,8 @@ Pinetime::Applications::DisplayApp displayApp(lcd,
                                               alarmController,
                                               brightnessController,
                                               touchHandler,
-                                              fs);
+                                              fs,
+                                              spiNorFlash);
 
 Pinetime::System::SystemTask systemTask(spi,
                                         spiNorFlash,


### PR DESCRIPTION
This is needed since a new memory chip will be used in future batches of PineTimes.

Fixes #2096 