### PR TITLE
Size optimise NRF SDK build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -860,7 +860,6 @@ target_compile_options(nrf-sdk PRIVATE
         $<$<CONFIG:RELEASE>: ${RELEASE_FLAGS}>
         $<$<COMPILE_LANGUAGE:CXX>: ${CXX_FLAGS}>
         $<$<COMPILE_LANGUAGE:ASM>: ${ASM_FLAGS}>
-        -O3
         )
 
 # NimBLE


### PR DESCRIPTION
Currently the NRF SDK is built with -O3 rather than -Os like with everything else

This saves a bit of flash space and performance seems unchanged to me. Thoughts on this change? I could definitely see the performance improvement being justified if it exists, but I don't have a profiler or anything.