### PR TITLE
Use DirtyValue for timer

### DIFF
--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -104,9 +104,7 @@ void Timer::UpdateMask() {
 
 void Timer::Refresh() {
   if (timer.IsRunning()) {
-    auto secondsRemaining = std::chrono::duration_cast<std::chrono::seconds>(timer.GetTimeRemaining());
-    minuteCounter.SetValue(secondsRemaining.count() / 60);
-    secondCounter.SetValue(secondsRemaining.count() % 60);
+    DisplayTime();
   } else if (buttonPressing && xTaskGetTickCount() > pressTime + pdMS_TO_TICKS(150)) {
     lv_label_set_text_static(txtPlayPause, "Reset");
     maskPosition += 15;
@@ -116,6 +114,14 @@ void Timer::Refresh() {
     } else {
       UpdateMask();
     }
+  }
+}
+
+void Timer::DisplayTime() {
+  displaySeconds = std::chrono::duration_cast<std::chrono::seconds>(timer.GetTimeRemaining());
+  if (displaySeconds.IsUpdated()) {
+    minuteCounter.SetValue(displaySeconds.Get().count() / 60);
+    secondCounter.SetValue(displaySeconds.Get().count() % 60);
   }
 }
 
@@ -133,9 +139,7 @@ void Timer::SetTimerStopped() {
 
 void Timer::ToggleRunning() {
   if (timer.IsRunning()) {
-    auto secondsRemaining = std::chrono::duration_cast<std::chrono::seconds>(timer.GetTimeRemaining());
-    minuteCounter.SetValue(secondsRemaining.count() / 60);
-    secondCounter.SetValue(secondsRemaining.count() % 60);
+    DisplayTime();
     timer.StopTimer();
     SetTimerStopped();
   } else if (secondCounter.GetValue() + minuteCounter.GetValue() > 0) {
@@ -147,7 +151,6 @@ void Timer::ToggleRunning() {
 }
 
 void Timer::Reset() {
-  minuteCounter.SetValue(0);
-  secondCounter.SetValue(0);
+  DisplayTime();
   SetTimerStopped();
 }

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -5,6 +5,7 @@
 #include "systemtask/SystemTask.h"
 #include "displayapp/LittleVgl.h"
 #include "displayapp/widgets/Counter.h"
+#include "utility/DirtyValue.h"
 #include <lvgl/lvgl.h>
 
 #include "components/timer/Timer.h"
@@ -26,6 +27,7 @@ namespace Pinetime::Applications {
       void SetTimerRunning();
       void SetTimerStopped();
       void UpdateMask();
+      void DisplayTime();
       Pinetime::Controllers::Timer& timer;
 
       lv_obj_t* btnPlayPause;
@@ -43,6 +45,7 @@ namespace Pinetime::Applications {
       bool buttonPressing = false;
       lv_coord_t maskPosition = 0;
       TickType_t pressTime = 0;
+      Utility::DirtyValue<std::chrono::seconds> displaySeconds;
     };
   }
 


### PR DESCRIPTION
Currently the timer re-renders the digits every Refresh() cycle. As the digits are large on the display, this causes 100% CPU usage from DisplayApp.
This PR changes the timer to use DirtyValue so it only re-renders the digits when they change.