### PR TITLE
Clean unused DisplayApp messages

### DIFF
--- a/src/displayapp/Messages.h
+++ b/src/displayapp/Messages.h
@@ -7,7 +7,6 @@ namespace Pinetime {
       enum class Messages : uint8_t {
         GoToSleep,
         GoToRunning,
-        UpdateDateTime,
         UpdateBleConnection,
         TouchEvent,
         ButtonPushed,
@@ -17,7 +16,8 @@ namespace Pinetime {
         NewNotification,
         TimerDone,
         BleFirmwareUpdateStarted,
-        DimScreen,
+        // Resets the screen timeout timer when awake
+        // Does nothing when asleep
         NotifyDeviceActivity,
         ShowPairingKey,
         AlarmTriggered,

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -194,7 +194,6 @@ void SystemTask::Work() {
           if (!bleController.IsFirmwareUpdating()) {
             doNotGoToSleep = false;
           }
-          displayApp.PushMessage(Pinetime::Applications::Display::Messages::NotifyDeviceActivity);
           break;
         case Messages::DisableSleeping:
           doNotGoToSleep = true;
@@ -245,8 +244,6 @@ void SystemTask::Work() {
           heartRateApp.PushMessage(Pinetime::Applications::HeartRateTask::Messages::GoToSleep);
           break;
         case Messages::OnNewTime:
-          displayApp.PushMessage(Pinetime::Applications::Display::Messages::NotifyDeviceActivity);
-          displayApp.PushMessage(Pinetime::Applications::Display::Messages::UpdateDateTime);
           if (alarmController.State() == Controllers::AlarmController::AlarmState::Set) {
             alarmController.ScheduleAlarm();
           }
@@ -255,8 +252,6 @@ void SystemTask::Work() {
           if (settingsController.GetNotificationStatus() == Pinetime::Controllers::Settings::Notification::On) {
             if (state == SystemTaskState::Sleeping) {
               GoToRunning();
-            } else {
-              displayApp.PushMessage(Pinetime::Applications::Display::Messages::NotifyDeviceActivity);
             }
             displayApp.PushMessage(Pinetime::Applications::Display::Messages::NewNotification);
           }


### PR DESCRIPTION
There are some old left over messages from before `RestoreBrightness` became `NotifyDeviceActivity`, and also some other ones that are well before my time. Since screens pull the time directly from the time controller, removing `UpdateDateTime` seems justified. And I can't think of anything that'd want to send `DimScreen` to DisplayApp, so I removed this too (the message is currently unused)