### PR TITLE
Restrict debugging monitor to debug builds

### DIFF
--- a/src/systemtask/SystemMonitor.cpp
+++ b/src/systemtask/SystemMonitor.cpp
@@ -1,5 +1,5 @@
 #include "systemtask/SystemTask.h"
-#if configUSE_TRACE_FACILITY == 1
+#if NRF_LOG_ENABLED
   // FreeRtosMonitor
   #include <FreeRTOS.h>
   #include <task.h>


### PR DESCRIPTION
The debugging monitor serves no purpose if a logger isn't available, so the preprocessor check now verifies exactly that. Since the about screen relies on `configUSE_TRACE_FACILITY` (and presumably won't compile without), I thought there is no point checking that too