### PR TITLE
AOD fixup

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -157,15 +157,20 @@ void DisplayApp::InitHw() {
 }
 
 TickType_t DisplayApp::CalculateSleepTime() {
-  TickType_t ticksElapsed = xTaskGetTickCount() - alwaysOnStartTime;
-  // Divide both the numerator and denominator by 8 to increase the number of ticks (frames) before the overflow tick is reached
+  // Calculates how many system ticks DisplayApp should sleep before rendering the next AOD frame
+  // Next frame time is frame count * refresh period (ms) * tick rate
+
   auto RoundedDiv = [](uint32_t a, uint32_t b) {
     return ((a + (b / 2)) / b);
   };
-  TickType_t elapsedTarget = RoundedDiv((configTICK_RATE_HZ / 8) * alwaysOnTickCount * alwaysOnRefreshPeriod, 1000 / 8);
   // RoundedDiv overflows when numerator + (denominator floordiv 2) > uint32 max
-  // in this case around 9 hours
-  constexpr TickType_t overflowTick = (UINT32_MAX - (1000 / 16)) / ((configTICK_RATE_HZ / 8) * alwaysOnRefreshPeriod);
+  // in this case around 9 hours (=overflow frame count / always on refresh period)
+  constexpr TickType_t overflowFrameCount = (UINT32_MAX - (1000 / 16)) / ((configTICK_RATE_HZ / 8) * alwaysOnRefreshPeriod);
+
+  TickType_t ticksElapsed = xTaskGetTickCount() - alwaysOnStartTime;
+  // Divide both the numerator and denominator by 8 (=GCD(1000,1024))
+  // to increase the number of ticks (frames) before the overflow tick is reached
+  TickType_t targetRenderTick = RoundedDiv((configTICK_RATE_HZ / 8) * alwaysOnFrameCount * alwaysOnRefreshPeriod, 1000 / 8);
 
   // Assumptions
 
@@ -173,17 +178,17 @@ TickType_t DisplayApp::CalculateSleepTime() {
   // Needed for division trick above
   static_assert(configTICK_RATE_HZ % 8 == 0);
 
-  // Local tick count must always wraparound before the system tick count does
-  // As a static assert we can use 64 bit ints and therefore dodge overflows
+  // Frame count must always wraparound more often than the system tick count does
   // Always on overflow time (ms) < system tick overflow time (ms)
-  static_assert((uint64_t) overflowTick * (uint64_t) alwaysOnRefreshPeriod < (uint64_t) UINT32_MAX * 1000ULL / configTICK_RATE_HZ);
+  // Using 64bit ints here to avoid overflow
+  static_assert((uint64_t) overflowFrameCount * (uint64_t) alwaysOnRefreshPeriod < (uint64_t) UINT32_MAX * 1000ULL / configTICK_RATE_HZ);
 
-  if (alwaysOnTickCount == overflowTick) {
-    alwaysOnTickCount = 0;
+  if (alwaysOnFrameCount == overflowFrameCount) {
+    alwaysOnFrameCount = 0;
     alwaysOnStartTime = xTaskGetTickCount();
   }
-  if (elapsedTarget > ticksElapsed) {
-    return elapsedTarget - ticksElapsed;
+  if (targetRenderTick > ticksElapsed) {
+    return targetRenderTick - ticksElapsed;
   } else {
     return 0;
   }
@@ -240,7 +245,7 @@ void DisplayApp::Refresh() {
         if (lv_task_handler() > 0) {
           // Drop frames that we've missed if drawing/event handling took way longer than expected
           while (queueTimeout == 0) {
-            alwaysOnTickCount += 1;
+            alwaysOnFrameCount += 1;
             queueTimeout = CalculateSleepTime();
           }
         }
@@ -311,7 +316,7 @@ void DisplayApp::Refresh() {
         if (msg == Messages::GoToAOD) {
           lcd.LowPowerOn();
           // Record idle entry time
-          alwaysOnTickCount = 0;
+          alwaysOnFrameCount = 0;
           alwaysOnStartTime = xTaskGetTickCount();
           PushMessageToSystemTask(Pinetime::System::Messages::OnDisplayTaskAOD);
           state = States::AOD;

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -159,8 +159,11 @@ void DisplayApp::InitHw() {
 TickType_t DisplayApp::CalculateSleepTime() {
   TickType_t ticksElapsed = xTaskGetTickCount() - alwaysOnStartTime;
   // Divide both the numerator and denominator by 8 to increase the number of ticks (frames) before the overflow tick is reached
-  TickType_t elapsedTarget = ROUNDED_DIV((configTICK_RATE_HZ / 8) * alwaysOnTickCount * alwaysOnRefreshPeriod, 1000 / 8);
-  // ROUNDED_DIV overflows when numerator + (denominator floordiv 2) > uint32 max
+  auto RoundedDiv = [](uint32_t a, uint32_t b) {
+    return ((a + (b / 2)) / b);
+  };
+  TickType_t elapsedTarget = RoundedDiv((configTICK_RATE_HZ / 8) * alwaysOnTickCount * alwaysOnRefreshPeriod, 1000 / 8);
+  // RoundedDiv overflows when numerator + (denominator floordiv 2) > uint32 max
   // in this case around 9 hours
   constexpr TickType_t overflowTick = (UINT32_MAX - (1000 / 16)) / ((configTICK_RATE_HZ / 8) * alwaysOnRefreshPeriod);
 

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -139,7 +139,7 @@ namespace Pinetime {
       bool isDimmed = false;
 
       TickType_t CalculateSleepTime();
-      TickType_t alwaysOnTickCount;
+      TickType_t alwaysOnFrameCount;
       TickType_t alwaysOnStartTime;
       // If this is to be changed, make sure the actual always on refresh rate is changed
       // by configuring the LCD refresh timings

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -49,7 +49,7 @@ namespace Pinetime {
   namespace Applications {
     class DisplayApp {
     public:
-      enum class States { Idle, Running };
+      enum class States { Idle, Running, AOD };
       enum class FullRefreshDirections { None, Up, Down, Left, Right, LeftAnim, RightAnim };
 
       DisplayApp(Drivers::St7789& lcd,

--- a/src/displayapp/Messages.h
+++ b/src/displayapp/Messages.h
@@ -6,6 +6,7 @@ namespace Pinetime {
     namespace Display {
       enum class Messages : uint8_t {
         GoToSleep,
+        GoToAOD,
         GoToRunning,
         UpdateBleConnection,
         TouchEvent,

--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -175,9 +175,8 @@ void St7789::IdleFrameRateOn() {
   // According to the datasheet, these controls should apply only to partial/idle mode
   // However they appear to apply to normal mode, so we have to enable/disable
   // every time we enter/exit always on
-  // In testing this divider appears to actually be 16x?
   constexpr uint8_t args[] = {
-    0x13, // Enable frame rate control for partial/idle mode, 8x frame divider
+    0x12, // Enable frame rate control for partial/idle mode, 4x frame divider
     0x1e, // Idle mode frame rate
     0x1e, // Partial mode frame rate (unused)
   };

--- a/src/systemtask/Messages.h
+++ b/src/systemtask/Messages.h
@@ -17,6 +17,7 @@ namespace Pinetime {
       HandleButtonEvent,
       HandleButtonTimerEvent,
       OnDisplayTaskSleeping,
+      OnDisplayTaskAOD,
       EnableSleeping,
       DisableSleeping,
       OnNewDay,

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -388,17 +388,19 @@ void SystemTask::GoToRunning() {
   if (state == SystemTaskState::Running) {
     return;
   }
-  // SPI only switched off when entering Sleeping, not AOD or GoingToSleep
-  if (state == SystemTaskState::Sleeping) {
-    spi.Wakeup();
-  }
+  if (state == SystemTaskState::Sleeping || state == SystemTaskState::AODSleeping) {
+    // SPI only switched off when entering Sleeping, not AOD or GoingToSleep
+    if (state == SystemTaskState::Sleeping) {
+      spi.Wakeup();
+    }
 
-  // Double Tap needs the touch screen to be in normal mode
-  if (!settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::DoubleTap)) {
-    touchPanel.Wakeup();
-  }
+    // Double Tap needs the touch screen to be in normal mode
+    if (!settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::DoubleTap)) {
+      touchPanel.Wakeup();
+    }
 
-  spiNorFlash.Wakeup();
+    spiNorFlash.Wakeup();
+  }
 
   displayApp.PushMessage(Pinetime::Applications::Display::Messages::GoToRunning);
   heartRateApp.PushMessage(Pinetime::Applications::HeartRateTask::Messages::WakeUp);

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -284,9 +284,10 @@ void SystemTask::Work() {
           HandleButtonAction(action);
         } break;
         case Messages::OnDisplayTaskSleeping:
+        case Messages::OnDisplayTaskAOD:
           // The state was set to GoingToSleep when GoToSleep() was called
           // If the state is no longer GoingToSleep, we have since transitioned back to Running
-          // In this case absorb the OnDisplayTaskSleeping
+          // In this case absorb the OnDisplayTaskSleeping/AOD
           // as DisplayApp is about to receive GoToRunning
           if (state != SystemTaskState::GoingToSleep) {
             break;
@@ -298,7 +299,7 @@ void SystemTask::Work() {
           }
 
           // Must keep SPI awake when still updating the display for always on
-          if (!settingsController.GetAlwaysOnDisplay()) {
+          if (msg == Messages::OnDisplayTaskSleeping) {
             spi.Sleep();
           }
 
@@ -307,7 +308,11 @@ void SystemTask::Work() {
             touchPanel.Sleep();
           }
 
-          state = SystemTaskState::Sleeping;
+          if (msg == Messages::OnDisplayTaskSleeping) {
+            state = SystemTaskState::Sleeping;
+          } else {
+            state = SystemTaskState::AODSleeping;
+          }
           break;
         case Messages::OnNewDay:
           // We might be sleeping (with TWI device disabled.
@@ -383,8 +388,8 @@ void SystemTask::GoToRunning() {
   if (state == SystemTaskState::Running) {
     return;
   }
-  // SPI doesn't go to sleep for always on mode
-  if (!settingsController.GetAlwaysOnDisplay()) {
+  // SPI only switched off when entering Sleeping, not AOD or GoingToSleep
+  if (state == SystemTaskState::Sleeping) {
     spi.Wakeup();
   }
 
@@ -413,16 +418,22 @@ void SystemTask::GoToSleep() {
     return;
   }
   NRF_LOG_INFO("[systemtask] Going to sleep");
-  displayApp.PushMessage(Pinetime::Applications::Display::Messages::GoToSleep);
+  if (settingsController.GetAlwaysOnDisplay()) {
+    displayApp.PushMessage(Pinetime::Applications::Display::Messages::GoToAOD);
+  } else {
+    displayApp.PushMessage(Pinetime::Applications::Display::Messages::GoToSleep);
+  }
   heartRateApp.PushMessage(Pinetime::Applications::HeartRateTask::Messages::GoToSleep);
 
   state = SystemTaskState::GoingToSleep;
 };
 
 void SystemTask::UpdateMotion() {
-  if (IsSleeping() && !(settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist) ||
-                        settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::Shake) ||
-                        motionController.GetService()->IsMotionNotificationSubscribed())) {
+  // Only consider disabling motion updates specifically in the Sleeping state
+  // AOD needs motion on to show up to date step counts
+  if (state == SystemTaskState::Sleeping && !(settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist) ||
+                                              settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::Shake) ||
+                                              motionController.GetService()->IsMotionNotificationSubscribed())) {
     return;
   }
 

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -52,7 +52,7 @@ namespace Pinetime {
   namespace System {
     class SystemTask {
     public:
-      enum class SystemTaskState { Sleeping, Running, GoingToSleep };
+      enum class SystemTaskState { Sleeping, Running, GoingToSleep, AODSleeping };
       SystemTask(Drivers::SpiMaster& spi,
                  Pinetime::Drivers::SpiNorFlash& spiNorFlash,
                  Drivers::TwiMaster& twiMaster,


### PR DESCRIPTION
- Removed `ROUNDED_DIV` macro which doesn't make sense to rely on here (it's from the NRF SDK).
  - Would an namespace {} function be better than the inline one? Any ideas?
- Motion is now updated when in AOD (as watchfaces display steps and this should update if in AOD).
- Idle refresh rate increased from 2Hz to 8Hz. This reduces visible display strobing in AOD particularly on apps with a brighter background such as Twos

Before merging this the power impact of the 8Hz idle commit needs to be tested; if it uses a lot more energy then it might not be worth the improved visuals. I don't have a power profiler so I'd really appreciate if someone could compare AOD power usage with that commit applied directly to main compared to current main (other commits in this branch like motion updates could affect results)