### PR TITLE
Refactor doNotGoToSleep to a wakelock counter

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -478,6 +478,7 @@ list(APPEND SOURCE_FILES
 
         systemtask/SystemTask.cpp
         systemtask/SystemMonitor.cpp
+        systemtask/WakeLock.cpp
         drivers/TwiMaster.cpp
 
         heartratetask/HeartRateTask.cpp
@@ -542,6 +543,7 @@ list(APPEND RECOVERY_SOURCE_FILES
 
         systemtask/SystemTask.cpp
         systemtask/SystemMonitor.cpp
+        systemtask/WakeLock.cpp
         drivers/TwiMaster.cpp
         components/rle/RleDecoder.cpp
         components/heartrate/HeartRateController.cpp
@@ -660,6 +662,7 @@ set(INCLUDE_FILES
         displayapp/InfiniTimeTheme.h
         systemtask/SystemTask.h
         systemtask/SystemMonitor.h
+        systemtask/WakeLock.h
         displayapp/screens/Symbols.h
         drivers/TwiMaster.h
         heartratetask/HeartRateTask.h

--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -48,7 +48,7 @@ Alarm::Alarm(Controllers::AlarmController& alarmController,
              Controllers::Settings::ClockType clockType,
              System::SystemTask& systemTask,
              Controllers::MotorController& motorController)
-  : alarmController {alarmController}, systemTask {systemTask}, motorController {motorController} {
+  : alarmController {alarmController}, wakeLock(systemTask), motorController {motorController} {
 
   hourCounter.Create();
   lv_obj_align(hourCounter.GetObject(), nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 0);
@@ -205,7 +205,7 @@ void Alarm::SetAlerting() {
   lv_obj_set_hidden(btnStop, false);
   taskStopAlarm = lv_task_create(StopAlarmTaskCallback, pdMS_TO_TICKS(60 * 1000), LV_TASK_PRIO_MID, this);
   motorController.StartRinging();
-  systemTask.PushMessage(System::Messages::DisableSleeping);
+  wakeLock.Lock();
 }
 
 void Alarm::StopAlerting() {
@@ -216,7 +216,7 @@ void Alarm::StopAlerting() {
     lv_task_del(taskStopAlarm);
     taskStopAlarm = nullptr;
   }
-  systemTask.PushMessage(System::Messages::EnableSleeping);
+  wakeLock.Release();
   lv_obj_set_hidden(enableSwitch, false);
   lv_obj_set_hidden(btnStop, true);
 }

--- a/src/displayapp/screens/Alarm.h
+++ b/src/displayapp/screens/Alarm.h
@@ -22,6 +22,7 @@
 #include "displayapp/screens/Screen.h"
 #include "displayapp/widgets/Counter.h"
 #include "displayapp/Controllers.h"
+#include "systemtask/WakeLock.h"
 #include "Symbols.h"
 
 namespace Pinetime {
@@ -43,7 +44,7 @@ namespace Pinetime {
 
       private:
         Controllers::AlarmController& alarmController;
-        System::SystemTask& systemTask;
+        System::WakeLock wakeLock;
         Controllers::MotorController& motorController;
 
         lv_obj_t *btnStop, *txtStop, *btnRecur, *txtRecur, *btnInfo, *enableSwitch;

--- a/src/displayapp/screens/FlashLight.cpp
+++ b/src/displayapp/screens/FlashLight.cpp
@@ -15,7 +15,7 @@ namespace {
 }
 
 FlashLight::FlashLight(System::SystemTask& systemTask, Controllers::BrightnessController& brightnessController)
-  : systemTask {systemTask}, brightnessController {brightnessController} {
+  : wakeLock(systemTask), brightnessController {brightnessController} {
 
   previousBrightnessLevel = brightnessController.Level();
   brightnessController.Set(Controllers::BrightnessController::Levels::Low);
@@ -47,14 +47,13 @@ FlashLight::FlashLight(System::SystemTask& systemTask, Controllers::BrightnessCo
   backgroundAction->user_data = this;
   lv_obj_set_event_cb(backgroundAction, EventHandler);
 
-  systemTask.PushMessage(Pinetime::System::Messages::DisableSleeping);
+  wakeLock.Lock();
 }
 
 FlashLight::~FlashLight() {
   lv_obj_clean(lv_scr_act());
   lv_obj_set_style_local_bg_color(lv_scr_act(), LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
   brightnessController.Set(previousBrightnessLevel);
-  systemTask.PushMessage(Pinetime::System::Messages::EnableSleeping);
 }
 
 void FlashLight::SetColors() {

--- a/src/displayapp/screens/FlashLight.h
+++ b/src/displayapp/screens/FlashLight.h
@@ -3,6 +3,7 @@
 #include "displayapp/screens/Screen.h"
 #include "components/brightness/BrightnessController.h"
 #include "systemtask/SystemTask.h"
+#include "systemtask/WakeLock.h"
 #include <cstdint>
 #include <lvgl/lvgl.h>
 
@@ -23,7 +24,7 @@ namespace Pinetime {
         void SetIndicators();
         void SetColors();
 
-        Pinetime::System::SystemTask& systemTask;
+        Pinetime::System::WakeLock wakeLock;
         Controllers::BrightnessController& brightnessController;
 
         Controllers::BrightnessController::Levels brightnessLevel = Controllers::BrightnessController::Levels::High;

--- a/src/displayapp/screens/HeartRate.h
+++ b/src/displayapp/screens/HeartRate.h
@@ -4,6 +4,7 @@
 #include <chrono>
 #include "displayapp/screens/Screen.h"
 #include "systemtask/SystemTask.h"
+#include "systemtask/WakeLock.h"
 #include "Symbols.h"
 #include <lvgl/src/lv_core/lv_style.h>
 #include <lvgl/src/lv_core/lv_obj.h>
@@ -27,7 +28,7 @@ namespace Pinetime {
 
       private:
         Controllers::HeartRateController& heartRateController;
-        Pinetime::System::SystemTask& systemTask;
+        Pinetime::System::WakeLock wakeLock;
         void UpdateStartStopButton(bool isRunning);
         lv_obj_t* label_hr;
         lv_obj_t* label_bpm;

--- a/src/displayapp/screens/Metronome.h
+++ b/src/displayapp/screens/Metronome.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "systemtask/SystemTask.h"
+#include "systemtask/WakeLock.h"
 #include "components/motor/MotorController.h"
 #include "displayapp/screens/Screen.h"
 #include "Symbols.h"
@@ -21,7 +22,7 @@ namespace Pinetime {
         TickType_t startTime = 0;
         TickType_t tappedTime = 0;
         Controllers::MotorController& motorController;
-        System::SystemTask& systemTask;
+        System::WakeLock wakeLock;
         int16_t bpm = 120;
         uint8_t bpb = 4;
         uint8_t counter = 1;

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -20,7 +20,7 @@ Notifications::Notifications(DisplayApp* app,
     notificationManager {notificationManager},
     alertNotificationService {alertNotificationService},
     motorController {motorController},
-    systemTask {systemTask},
+    wakeLock(systemTask),
     mode {mode} {
 
   notificationManager.ClearNewNotificationFlag();
@@ -40,7 +40,7 @@ Notifications::Notifications(DisplayApp* app,
     validDisplay = false;
   }
   if (mode == Modes::Preview) {
-    systemTask.PushMessage(System::Messages::DisableSleeping);
+    wakeLock.Lock();
     if (notification.category == Controllers::NotificationManager::Categories::IncomingCall) {
       motorController.StartRinging();
     } else {
@@ -65,7 +65,6 @@ Notifications::~Notifications() {
   lv_task_del(taskRefresh);
   // make sure we stop any vibrations before exiting
   motorController.StopRinging();
-  systemTask.PushMessage(System::Messages::EnableSleeping);
   lv_obj_clean(lv_scr_act());
 }
 
@@ -120,7 +119,7 @@ void Notifications::Refresh() {
 }
 
 void Notifications::OnPreviewInteraction() {
-  systemTask.PushMessage(System::Messages::EnableSleeping);
+  wakeLock.Release();
   motorController.StopRinging();
   if (timeoutLine != nullptr) {
     lv_obj_del(timeoutLine);

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -8,6 +8,7 @@
 #include "components/ble/NotificationManager.h"
 #include "components/motor/MotorController.h"
 #include "systemtask/SystemTask.h"
+#include "systemtask/WakeLock.h"
 
 namespace Pinetime {
   namespace Controllers {
@@ -73,7 +74,7 @@ namespace Pinetime {
         Pinetime::Controllers::NotificationManager& notificationManager;
         Pinetime::Controllers::AlertNotificationService& alertNotificationService;
         Pinetime::Controllers::MotorController& motorController;
-        System::SystemTask& systemTask;
+        System::WakeLock wakeLock;
         Modes mode = Modes::Normal;
         std::unique_ptr<NotificationItem> currentItem;
         Pinetime::Controllers::NotificationManager::Notification::Id currentId;

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -7,6 +7,7 @@
 #include "portmacro_cmsis.h"
 
 #include "systemtask/SystemTask.h"
+#include "systemtask/WakeLock.h"
 #include "displayapp/apps/Apps.h"
 #include "displayapp/Controllers.h"
 #include "Symbols.h"
@@ -43,7 +44,7 @@ namespace Pinetime {
         void Start();
         void Pause();
 
-        Pinetime::System::SystemTask& systemTask;
+        Pinetime::System::WakeLock wakeLock;
         States currentState = States::Init;
         TickType_t startTime;
         TickType_t oldTimeElapsed = 0;

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -80,7 +80,7 @@ namespace Pinetime {
       void OnTouchEvent();
 
       bool IsSleepDisabled() {
-        return doNotGoToSleep;
+        return wakeLocksHeld > 0;
       }
 
       Pinetime::Controllers::NimbleController& nimble() {
@@ -124,7 +124,7 @@ namespace Pinetime {
       bool isBleDiscoveryTimerRunning = false;
       uint8_t bleDiscoveryTimer = 0;
       TimerHandle_t measureBatteryTimer;
-      bool doNotGoToSleep = false;
+      uint8_t wakeLocksHeld = 0;
       SystemTaskState state = SystemTaskState::Running;
 
       void HandleButtonAction(Controllers::ButtonActions action);

--- a/src/systemtask/WakeLock.cpp
+++ b/src/systemtask/WakeLock.cpp
@@ -1,0 +1,27 @@
+#include "systemtask/WakeLock.h"
+
+using namespace Pinetime::System;
+
+WakeLock::WakeLock(SystemTask& systemTask) : systemTask {systemTask} {
+  lockHeld = false;
+}
+
+WakeLock::~WakeLock() {
+  Release();
+}
+
+void WakeLock::Lock() {
+  if (lockHeld) {
+    return;
+  }
+  systemTask.PushMessage(Messages::DisableSleeping);
+  lockHeld = true;
+}
+
+void WakeLock::Release() {
+  if (!lockHeld) {
+    return;
+  }
+  systemTask.PushMessage(Messages::EnableSleeping);
+  lockHeld = false;
+}

--- a/src/systemtask/WakeLock.h
+++ b/src/systemtask/WakeLock.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "systemtask/SystemTask.h"
+
+namespace Pinetime {
+  namespace System {
+    class WakeLock {
+    public:
+      WakeLock(SystemTask& systemTask);
+      ~WakeLock();
+      void Lock();
+      void Release();
+
+    private:
+      bool lockHeld;
+      SystemTask& systemTask;
+    };
+  }
+}


### PR DESCRIPTION
Rather than tracking whether sleeping is disabled with a boolean, this moves it to a counter which records the number of requests to keep the device awake. When this counter is zero, sleeping is possible. This prevents one task from enabling sleeping when another task still wants sleeping disabled.