### PR TITLE
Clear ongoing taps when going to sleep

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -313,6 +313,10 @@ void DisplayApp::Refresh() {
           while (!lv_task_handler()) {
           };
         }
+        // Clear any ongoing touch pressed events
+        // Without this LVGL gets stuck in the pressed state and will keep refreshing the
+        // display activity timer causing the screen to never sleep after timeout
+        lvgl.ClearTouchState();
         if (msg == Messages::GoToAOD) {
           lcd.LowPowerOn();
           // Record idle entry time

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -472,7 +472,7 @@ void DisplayApp::Refresh() {
     }
   }
 
-  if (touchHandler.IsTouching()) {
+  if (state == States::Running && touchHandler.IsTouching()) {
     currentScreen->OnTouchEvent(touchHandler.GetX(), touchHandler.GetY());
   }
 

--- a/src/displayapp/LittleVgl.cpp
+++ b/src/displayapp/LittleVgl.cpp
@@ -248,11 +248,20 @@ void LittleVgl::SetNewTouchPoint(int16_t x, int16_t y, bool contact) {
   }
 }
 
+// Cancel an ongoing tap
+// Signifies that LVGL should not handle the current tap
 void LittleVgl::CancelTap() {
   if (tapped) {
     isCancelled = true;
     touchPoint = {-1, -1};
   }
+}
+
+// Clear the current tapped state
+// Signifies that touch input processing is suspended
+void LittleVgl::ClearTouchState() {
+  touchPoint = {-1, -1};
+  tapped = false;
 }
 
 bool LittleVgl::GetTouchPadInfo(lv_indev_data_t* ptr) {

--- a/src/displayapp/LittleVgl.h
+++ b/src/displayapp/LittleVgl.h
@@ -26,6 +26,7 @@ namespace Pinetime {
       void SetFullRefresh(FullRefreshDirections direction);
       void SetNewTouchPoint(int16_t x, int16_t y, bool contact);
       void CancelTap();
+      void ClearTouchState();
 
       bool GetFullRefresh() {
         bool returnValue = fullRefresh;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -168,7 +168,7 @@ std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds> NoI
 
 void nrfx_gpiote_evt_handler(nrfx_gpiote_pin_t pin, nrf_gpiote_polarity_t action) {
   if (pin == Pinetime::PinMap::Cst816sIrq) {
-    systemTask.OnTouchEvent();
+    systemTask.PushMessage(Pinetime::System::Messages::OnTouchEvent);
     return;
   }
 

--- a/src/systemtask/Messages.h
+++ b/src/systemtask/Messages.h
@@ -6,7 +6,6 @@ namespace Pinetime {
     enum class Messages : uint8_t {
       GoToSleep,
       GoToRunning,
-      TouchWakeUp,
       OnNewTime,
       OnNewNotification,
       OnNewCall,

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -493,10 +493,6 @@ void SystemTask::HandleButtonAction(Controllers::ButtonActions action) {
   fastWakeUpDone = false;
 }
 
-void SystemTask::OnTouchEvent() {
-  PushMessage(Messages::OnTouchEvent);
-}
-
 void SystemTask::PushMessage(System::Messages msg) {
   if (in_isr()) {
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -77,8 +77,6 @@ namespace Pinetime {
       void Start();
       void PushMessage(Messages msg);
 
-      void OnTouchEvent();
-
       bool IsSleepDisabled() {
         return wakeLocksHeld > 0;
       }


### PR DESCRIPTION
Currently if the touch panel is pressed when DisplayApp goes to sleep, the finger up event gets dropped. This causes LVGL to think the finger is never released from the touch panel, so it prevents the device from sleeping. This PR clears the tapped state when going to sleep so the internal LVGL state remains consistent with the real touch panel state.

Fixes part of #1790 #2012 (there may be other issues contributing to these, but this is probably part of it)