### PR TITLE
SystemTask state refactor

### DIFF
--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -124,9 +124,11 @@ int DfuService::WritePacketHandler(uint16_t connectionHandle, os_mbuf* om) {
                    bootloaderSize,
                    applicationSize);
 
-      // wait until SystemTask has finished waking up all devices
-      while (systemTask.IsSleeping()) {
-        vTaskDelay(50); // 50ms
+      // Wait until SystemTask has disabled sleeping
+      // This isn't quite correct, as we don't actually know
+      // if BleFirmwareUpdateStarted has been received yet
+      while (!systemTask.IsSleepDisabled()) {
+        vTaskDelay(pdMS_TO_TICKS(5));
       }
 
       dfuImage.Erase();

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -454,9 +454,15 @@ void NimbleController::PersistBond(struct ble_gap_conn_desc& desc) {
     /* Wakeup Spi and SpiNorFlash before accessing the file system
      * This should be fixed in the FS driver
      */
-    systemTask.PushMessage(Pinetime::System::Messages::GoToRunning);
     systemTask.PushMessage(Pinetime::System::Messages::DisableSleeping);
-    vTaskDelay(10);
+
+    // This isn't quite correct
+    // SystemTask could receive EnableSleeping right after passing this check
+    // We need some guarantee that the SystemTask has processed the above message
+    // before we can continue
+    while (!systemTask.IsSleepDisabled()) {
+      vTaskDelay(pdMS_TO_TICKS(5));
+    }
 
     lfs_file_t file_p;
 

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -269,9 +269,20 @@ void DisplayApp::Refresh() {
         if (!isDimmed) {
           DimScreen();
         }
-        if (IsPastSleepTime()) {
-          systemTask->PushMessage(System::Messages::GoToSleep);
-          state = States::Idle;
+        if (IsPastSleepTime() && uxQueueMessagesWaiting(msgQueue) == 0) {
+          PushMessageToSystemTask(System::Messages::GoToSleep);
+          // Can't set state to Idle here, something may send
+          // DisableSleeping before this GoToSleep arrives
+          // Instead we check we have no messages queued before sending GoToSleep
+          // This works as the SystemTask is higher priority than DisplayApp
+          // As soon as we send GoToSleep, SystemTask pre-empts DisplayApp
+          // Whenever DisplayApp is running again, it is guaranteed that
+          // SystemTask has handled the message
+          // If it responded, we will have a GoToSleep waiting in the queue
+          // By checking that there are no messages in the queue, we avoid
+          // resending GoToSleep when we already have a response
+          // SystemTask is resilient to duplicate messages, this is an
+          // optimisation to reduce pressure on the message queues
         }
       } else if (isDimmed) {
         RestoreBrightness();
@@ -289,6 +300,9 @@ void DisplayApp::Refresh() {
         DimScreen();
         break;
       case Messages::GoToSleep:
+        if (state != States::Running) {
+          break;
+        }
         while (brightnessController.Level() != Controllers::BrightnessController::Levels::Low) {
           brightnessController.Lower();
           vTaskDelay(100);
@@ -323,6 +337,9 @@ void DisplayApp::Refresh() {
         lv_disp_trig_activity(nullptr);
         break;
       case Messages::GoToRunning:
+        if (state == States::Running) {
+          break;
+        }
         if (settingsController.GetAlwaysOnDisplay()) {
           lcd.LowPowerOff();
         } else {

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -79,9 +79,6 @@ namespace Pinetime {
 
       void OnTouchEvent();
 
-      void OnIdle();
-      void OnDim();
-
       bool IsSleepDisabled() {
         return doNotGoToSleep;
       }

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -52,7 +52,7 @@ namespace Pinetime {
   namespace System {
     class SystemTask {
     public:
-      enum class SystemTaskState { Sleeping, Running, GoingToSleep, WakingUp };
+      enum class SystemTaskState { Sleeping, Running, GoingToSleep };
       SystemTask(Drivers::SpiMaster& spi,
                  Pinetime::Drivers::SpiNorFlash& spiNorFlash,
                  Drivers::TwiMaster& twiMaster,
@@ -88,7 +88,7 @@ namespace Pinetime {
       };
 
       bool IsSleeping() const {
-        return state == SystemTaskState::Sleeping || state == SystemTaskState::WakingUp;
+        return state != SystemTaskState::Running;
       }
 
     private:
@@ -131,6 +131,7 @@ namespace Pinetime {
       bool fastWakeUpDone = false;
 
       void GoToRunning();
+      void GoToSleep();
       void UpdateMotion();
       bool stepCounterMustBeReset = false;
       static constexpr TickType_t batteryMeasurementPeriod = pdMS_TO_TICKS(10 * 60 * 1000);


### PR DESCRIPTION
Currently SystemTask is somewhat fragile to duplicate state transitions and unusual state transition message orders. Most notably this can cause it to get stuck in `GoingToSleep` in some scenarios.

This PR introduces GoToSleep() and changes GoToRunning() as immediately executable functions. The guarantee that state transitions happen immediately reduces complexity when it comes to ensuring the device is awake for events such as Chimes 

Fixes part of #1790 #2012 (there may be other issues contributing to these, but this is probably part of it)