### PR TITLE
Hrs3300: fix includes for std::begin/std::end

### DIFF
--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -6,6 +6,7 @@
 
 #include "drivers/Hrs3300.h"
 #include <algorithm>
+#include <iterator>
 #include <nrf_gpio.h>
 
 #include <FreeRTOS.h>


### PR DESCRIPTION
Fix for Hrs3300 PR about Atomic HRS reads:
https://github.com/InfiniTimeOrg/InfiniTime/pull/1845

We use `std::begin` and `std::end`, but we don't include one of the headers that define those functions.
See https://en.cppreference.com/w/cpp/iterator/begin for a list of headers that define `std::begin` and `std::end`.

Starting with GCC 14 this leads to a compilation error presumably because they cleaned up their headers.

Fix code by inlcuding `<iterator>`