### PR TITLE
MusicService: add missing includes for TickType_t and xTaskGetTickCount

### DIFF
--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -18,6 +18,7 @@
 #include "components/ble/MusicService.h"
 #include "components/ble/NimbleController.h"
 #include <cstring>
+#include <task.h>
 
 namespace {
   // 0000yyxx-78fc-48fe-8e23-433b3a1942d0

--- a/src/components/ble/MusicService.cpp
+++ b/src/components/ble/MusicService.cpp
@@ -18,6 +18,7 @@
 #include "components/ble/MusicService.h"
 #include "components/ble/NimbleController.h"
 #include <cstring>
+#include <FreeRTOS.h>
 #include <task.h>
 
 namespace {

--- a/src/components/ble/MusicService.h
+++ b/src/components/ble/MusicService.h
@@ -25,7 +25,7 @@
 #include <host/ble_uuid.h>
 #undef max
 #undef min
-#include "portmacro_cmsis.h"
+#include <FreeRTOS.h>
 
 namespace Pinetime {
   namespace Controllers {

--- a/src/components/ble/MusicService.h
+++ b/src/components/ble/MusicService.h
@@ -25,6 +25,7 @@
 #include <host/ble_uuid.h>
 #undef max
 #undef min
+#include "portmacro_cmsis.h"
 
 namespace Pinetime {
   namespace Controllers {


### PR DESCRIPTION
Add includes for the directly used data type `TickType_t` in the header and the function `xTaskGetTickCount` from FreeRTOS's `task.h`

I found out while slimming down InfiniSim and trying to use `MusicService.h` from InfiniTime directly