### PR TITLE
Add shorter/simpler weather condition options.

### DIFF
--- a/src/displayapp/screens/WeatherSymbols.cpp
+++ b/src/displayapp/screens/WeatherSymbols.cpp
@@ -59,3 +59,28 @@ const char* Pinetime::Applications::Screens::Symbols::GetCondition(const Pinetim
       return "";
   }
 }
+
+const char* Pinetime::Applications::Screens::Symbols::GetSimpleCondition(const Pinetime::Controllers::SimpleWeatherService::Icons icon) {
+  switch (icon) {
+    case Pinetime::Controllers::SimpleWeatherService::Icons::Sun:
+      return "Clear";
+    case Pinetime::Controllers::SimpleWeatherService::Icons::CloudsSun:
+      return "Clouds";
+    case Pinetime::Controllers::SimpleWeatherService::Icons::Clouds:
+      return "Clouds";
+    case Pinetime::Controllers::SimpleWeatherService::Icons::BrokenClouds:
+      return "Clouds";
+    case Pinetime::Controllers::SimpleWeatherService::Icons::CloudShowerHeavy:
+      return "Rain";
+    case Pinetime::Controllers::SimpleWeatherService::Icons::CloudSunRain:
+      return "Drizzle";
+    case Pinetime::Controllers::SimpleWeatherService::Icons::Thunderstorm:
+      return "Thunder";
+    case Pinetime::Controllers::SimpleWeatherService::Icons::Snow:
+      return "Snow";
+    case Pinetime::Controllers::SimpleWeatherService::Icons::Smog:
+      return "Mist";
+    default:
+      return "";
+  }
+}

--- a/src/displayapp/screens/WeatherSymbols.h
+++ b/src/displayapp/screens/WeatherSymbols.h
@@ -8,6 +8,7 @@ namespace Pinetime {
       namespace Symbols {
         const char* GetSymbol(const Pinetime::Controllers::SimpleWeatherService::Icons icon);
         const char* GetCondition(const Pinetime::Controllers::SimpleWeatherService::Icons icon);
+        const char* GetSimpleCondition(const Pinetime::Controllers::SimpleWeatherService::Icons icon);
       }
     }
   }


### PR DESCRIPTION
These changes were originally created in PR #2001, but it was suggested that it be split off into its own PR.

This change simply adds a `GetSimpleCondition` option as an alternative to `GetCondition` to return a shorter condition description. For example: returning 'Thunder' instead of 'Thunderstorm' as a way to save space in constrained areas without losing the original descriptions meaning. 

There's an example GIF [here](https://github.com/InfiniTimeOrg/InfiniTime/pull/2001#discussion_r1478482793) of where this would be useful.