### PR TITLE
Remove unused submodule QCBOR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "src/libs/littlefs"]
 	path = src/libs/littlefs
 	url = https://github.com/littlefs-project/littlefs.git
-[submodule "src/libs/QCBOR"]
-	path = src/libs/QCBOR
-	url = https://github.com/laurencelundblade/QCBOR.git
 [submodule "src/libs/arduinoFFT"]
 	path = src/libs/arduinoFFT
 	url = https://github.com/kosme/arduinoFFT.git


### PR DESCRIPTION
The submodule isn't used anymore. Remove the submodule reference completely.