### PR TITLE
cmake: fix python path with use multi-version python

### DIFF
--- a/src/displayapp/fonts/CMakeLists.txt
+++ b/src/displayapp/fonts/CMakeLists.txt
@@ -11,6 +11,7 @@ configure_file(${CMAKE_CURRENT_LIST_DIR}/jetbrains_mono_bold_20.c_M.patch
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
    # FindPython3 module introduces with CMake 3.12
    # https://cmake.org/cmake/help/latest/module/FindPython3.html
+   set(Python3_FIND_STRATEGY LOCATION) # https://discourse.cmake.org/t/find-package-python3-is-not-finding-the-correct-python/10563
    find_package(Python3 REQUIRED)
 else()
    set(Python3_EXECUTABLE "python")

--- a/src/resources/CMakeLists.txt
+++ b/src/resources/CMakeLists.txt
@@ -10,6 +10,7 @@ message(STATUS "Using ${LV_IMG_CONV} to generate font files")
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
    # FindPython3 module introduces with CMake 3.12
    # https://cmake.org/cmake/help/latest/module/FindPython3.html
+   set(Python3_FIND_STRATEGY LOCATION) # https://discourse.cmake.org/t/find-package-python3-is-not-finding-the-correct-python/10563
    find_package(Python3 REQUIRED)
 else()
    set(Python3_EXECUTABLE "python")


### PR DESCRIPTION
If I use python3.13 as my system python version, but I use python3.12 to create venv, cmake will find /usr/bin/python3.13 but not venv

Because cmake will use the latest version.

From https://cmake.org/cmake/help/latest/module/FindPython3.html
> Note
> This hint has the lowest priority of all hints, so even if, for example, you specify IronPython first and CPython in second, a python product based on CPython can be selected because, for example with Python3_FIND_STRATEGY=LOCATION, each location will be search first for IronPython and second for CPython. 

Refer: https://discourse.cmake.org/t/find-package-python3-is-not-finding-the-correct-python/10563