### PR TITLE
ble: advertise battery charging state

### DIFF
--- a/src/components/ble/BatteryInformationService.cpp
+++ b/src/components/ble/BatteryInformationService.cpp
@@ -6,7 +6,7 @@ using namespace Pinetime::Controllers;
 
 constexpr ble_uuid16_t BatteryInformationService::batteryInformationServiceUuid;
 constexpr ble_uuid16_t BatteryInformationService::batteryLevelUuid;
-constexpr ble_uuid16_t BatteryInformationService::batteryLevelStatusUuid; // Renamed
+constexpr ble_uuid16_t BatteryInformationService::batteryLevelStatusUuid;
 
 int BatteryInformationServiceCallback(uint16_t /*conn_handle*/, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
   auto* batteryInformationService = static_cast<BatteryInformationService*>(arg);
@@ -23,11 +23,11 @@ BatteryInformationService::BatteryInformationService(Controllers::Battery& batte
       .val_handle = &batteryLevelHandle
     },
     {
-      .uuid = &batteryLevelStatusUuid.u, // Updated UUID
+      .uuid = &batteryLevelStatusUuid.u,
       .access_cb = BatteryInformationServiceCallback,
       .arg = this,
       .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
-      .val_handle = &batteryLevelStatusHandle // Updated handle
+      .val_handle = &batteryLevelStatusHandle
     },
     {0}},
     serviceDefinition {{
@@ -95,5 +95,5 @@ void BatteryInformationService::NotifyBatteryLevelStatus(uint16_t connectionHand
   }
 
   auto* om = ble_hs_mbuf_from_flat(&powerState, 1);
-  ble_gattc_notify_custom(connectionHandle, batteryLevelStatusHandle, om); // Updated handle
+  ble_gattc_notify_custom(connectionHandle, batteryLevelStatusHandle, om);
 }

--- a/src/components/ble/BatteryInformationService.cpp
+++ b/src/components/ble/BatteryInformationService.cpp
@@ -20,7 +20,7 @@ BatteryInformationService::BatteryInformationService(Controllers::Battery& batte
                                .arg = this,
                                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
                                .val_handle = &batteryLevelHandle},
-                               {.uuid = &isChargingUuid.u,
+                              {.uuid = &isChargingUuid.u,
                                .access_cb = BatteryInformationServiceCallback,
                                .arg = this,
                                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
@@ -50,7 +50,7 @@ int BatteryInformationService::OnBatteryServiceRequested(uint16_t attributeHandl
     uint8_t batteryValue = batteryController.PercentRemaining();
     int res = os_mbuf_append(context->om, &batteryValue, 1);
     return (res == 0) ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
-    
+
   } else if (attributeHandle == isChargingHandle) {
     NRF_LOG_INFO("BATTERY : handle = %d (isCharging)", isChargingHandle);
     uint8_t isCharging = batteryController.IsCharging() ? 1 : 0;

--- a/src/components/ble/BatteryInformationService.cpp
+++ b/src/components/ble/BatteryInformationService.cpp
@@ -6,6 +6,7 @@ using namespace Pinetime::Controllers;
 
 constexpr ble_uuid16_t BatteryInformationService::batteryInformationServiceUuid;
 constexpr ble_uuid16_t BatteryInformationService::batteryLevelUuid;
+constexpr ble_uuid16_t BatteryInformationService::isChargingUuid;
 
 int BatteryInformationServiceCallback(uint16_t /*conn_handle*/, uint16_t attr_handle, struct ble_gatt_access_ctxt* ctxt, void* arg) {
   auto* batteryInformationService = static_cast<BatteryInformationService*>(arg);
@@ -19,6 +20,11 @@ BatteryInformationService::BatteryInformationService(Controllers::Battery& batte
                                .arg = this,
                                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
                                .val_handle = &batteryLevelHandle},
+                               {.uuid = &isChargingUuid.u,
+                               .access_cb = BatteryInformationServiceCallback,
+                               .arg = this,
+                               .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
+                               .val_handle = &isChargingHandle},
                               {0}},
     serviceDefinition {
       {/* Device Information Service */
@@ -44,11 +50,24 @@ int BatteryInformationService::OnBatteryServiceRequested(uint16_t attributeHandl
     uint8_t batteryValue = batteryController.PercentRemaining();
     int res = os_mbuf_append(context->om, &batteryValue, 1);
     return (res == 0) ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
+    
+  } else if (attributeHandle == isChargingHandle) {
+    NRF_LOG_INFO("BATTERY : handle = %d (isCharging)", isChargingHandle);
+    uint8_t isCharging = batteryController.IsCharging() ? 1 : 0;
+    int res = os_mbuf_append(context->om, &isCharging, 1);
+    return (res == 0) ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
   }
-  return 0;
+
+  return BLE_ATT_ERR_UNLIKELY;
 }
 
 void BatteryInformationService::NotifyBatteryLevel(uint16_t connectionHandle, uint8_t level) {
   auto* om = ble_hs_mbuf_from_flat(&level, 1);
   ble_gattc_notify_custom(connectionHandle, batteryLevelHandle, om);
+}
+
+void BatteryInformationService::NotifyBatteryCharging(uint16_t connectionHandle, bool isCharging) {
+  uint8_t chargingValue = isCharging ? 1 : 0;
+  auto* om = ble_hs_mbuf_from_flat(&chargingValue, 1);
+  ble_gattc_notify_custom(connectionHandle, isChargingHandle, om);
 }

--- a/src/components/ble/BatteryInformationService.cpp
+++ b/src/components/ble/BatteryInformationService.cpp
@@ -58,7 +58,7 @@ int BatteryInformationService::OnBatteryServiceRequested(uint16_t attributeHandl
     return (res == 0) ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;
   }
 
-  return BLE_ATT_ERR_UNLIKELY;
+  return 0;
 }
 
 void BatteryInformationService::NotifyBatteryLevel(uint16_t connectionHandle, uint8_t level) {

--- a/src/components/ble/BatteryInformationService.h
+++ b/src/components/ble/BatteryInformationService.h
@@ -30,7 +30,7 @@ namespace Pinetime {
 
       static constexpr ble_uuid16_t batteryInformationServiceUuid {.u {.type = BLE_UUID_TYPE_16}, .value = batteryInformationServiceId};
       static constexpr ble_uuid16_t batteryLevelUuid {.u {.type = BLE_UUID_TYPE_16}, .value = batteryLevelId};
-      static constexpr ble_uuid16_t batteryLevelStatusUuid {.u {.type = BLE_UUID_TYPE_16}, .value = batteryLevelStatusId}; // Renamed to batteryLevelStatusUuid
+      static constexpr ble_uuid16_t batteryLevelStatusUuid {.u {.type = BLE_UUID_TYPE_16}, .value = batteryLevelStatusId};
 
       struct ble_gatt_chr_def characteristicDefinition[3];
       struct ble_gatt_svc_def serviceDefinition[2];

--- a/src/components/ble/BatteryInformationService.h
+++ b/src/components/ble/BatteryInformationService.h
@@ -20,25 +20,23 @@ namespace Pinetime {
 
       int OnBatteryServiceRequested(uint16_t attributeHandle, ble_gatt_access_ctxt* context);
       void NotifyBatteryLevel(uint16_t connectionHandle, uint8_t level);
-      void NotifyBatteryCharging(uint16_t connectionHandle, bool isCharging);
+      void NotifyBatteryLevelStatus(uint16_t connectionHandle, bool isCharging);
 
     private:
       Controllers::Battery& batteryController;
       static constexpr uint16_t batteryInformationServiceId {0x180F};
       static constexpr uint16_t batteryLevelId {0x2A19};
-      static constexpr uint16_t isChargingId {0x2BED};
+      static constexpr uint16_t batteryLevelStatusId {0x2BED};
 
       static constexpr ble_uuid16_t batteryInformationServiceUuid {.u {.type = BLE_UUID_TYPE_16}, .value = batteryInformationServiceId};
-
       static constexpr ble_uuid16_t batteryLevelUuid {.u {.type = BLE_UUID_TYPE_16}, .value = batteryLevelId};
-
-      static constexpr ble_uuid16_t isChargingUuid {.u {.type = BLE_UUID_TYPE_16}, .value = isChargingId};
+      static constexpr ble_uuid16_t batteryLevelStatusUuid {.u {.type = BLE_UUID_TYPE_16}, .value = batteryLevelStatusId}; // Renamed to batteryLevelStatusUuid
 
       struct ble_gatt_chr_def characteristicDefinition[3];
       struct ble_gatt_svc_def serviceDefinition[2];
 
       uint16_t batteryLevelHandle;
-      uint16_t isChargingHandle;
+      uint16_t batteryLevelStatusHandle;
     };
   }
 }

--- a/src/components/ble/BatteryInformationService.h
+++ b/src/components/ble/BatteryInformationService.h
@@ -26,7 +26,7 @@ namespace Pinetime {
       Controllers::Battery& batteryController;
       static constexpr uint16_t batteryInformationServiceId {0x180F};
       static constexpr uint16_t batteryLevelId {0x2A19};
-      static constexpr uint16_t isChargingId {0x2A1B};
+      static constexpr uint16_t isChargingId {0x2BED};
 
       static constexpr ble_uuid16_t batteryInformationServiceUuid {.u {.type = BLE_UUID_TYPE_16}, .value = batteryInformationServiceId};
 

--- a/src/components/ble/BatteryInformationService.h
+++ b/src/components/ble/BatteryInformationService.h
@@ -20,20 +20,25 @@ namespace Pinetime {
 
       int OnBatteryServiceRequested(uint16_t attributeHandle, ble_gatt_access_ctxt* context);
       void NotifyBatteryLevel(uint16_t connectionHandle, uint8_t level);
+      void NotifyBatteryCharging(uint16_t connectionHandle, bool isCharging);
 
     private:
       Controllers::Battery& batteryController;
       static constexpr uint16_t batteryInformationServiceId {0x180F};
       static constexpr uint16_t batteryLevelId {0x2A19};
+      static constexpr uint16_t isChargingId {0x2A1B};
 
       static constexpr ble_uuid16_t batteryInformationServiceUuid {.u {.type = BLE_UUID_TYPE_16}, .value = batteryInformationServiceId};
 
       static constexpr ble_uuid16_t batteryLevelUuid {.u {.type = BLE_UUID_TYPE_16}, .value = batteryLevelId};
 
+      static constexpr ble_uuid16_t isChargingUuid {.u {.type = BLE_UUID_TYPE_16}, .value = isChargingId};
+
       struct ble_gatt_chr_def characteristicDefinition[3];
       struct ble_gatt_svc_def serviceDefinition[2];
 
       uint16_t batteryLevelHandle;
+      uint16_t isChargingHandle;
     };
   }
 }

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -403,9 +403,9 @@ void NimbleController::NotifyBatteryLevel(uint8_t level) {
   }
 }
 
-void NimbleController::NotifyBatteryCharging(bool isCharging) {
+void NimbleController::NotifyBatteryLevelStatus(bool isCharging) {
   if (connectionHandle != BLE_HS_CONN_HANDLE_NONE) {
-    batteryInformationService.NotifyBatteryCharging(connectionHandle, isCharging);
+    batteryInformationService.NotifyBatteryLevelStatus(connectionHandle, isCharging);
   }
 }
 

--- a/src/components/ble/NimbleController.cpp
+++ b/src/components/ble/NimbleController.cpp
@@ -403,6 +403,12 @@ void NimbleController::NotifyBatteryLevel(uint8_t level) {
   }
 }
 
+void NimbleController::NotifyBatteryCharging(bool isCharging) {
+  if (connectionHandle != BLE_HS_CONN_HANDLE_NONE) {
+    batteryInformationService.NotifyBatteryCharging(connectionHandle, isCharging);
+  }
+}
+
 void NimbleController::EnableRadio() {
   bleController.EnableRadio();
   bleController.Disconnect();

--- a/src/components/ble/NimbleController.h
+++ b/src/components/ble/NimbleController.h
@@ -73,7 +73,7 @@ namespace Pinetime {
 
       uint16_t connHandle();
       void NotifyBatteryLevel(uint8_t level);
-      void NotifyBatteryCharging(bool isCharging);
+      void NotifyBatteryLevelStatus(bool isCharging);
 
       void RestartFastAdv() {
         fastAdvCount = 0;

--- a/src/components/ble/NimbleController.h
+++ b/src/components/ble/NimbleController.h
@@ -73,6 +73,7 @@ namespace Pinetime {
 
       uint16_t connHandle();
       void NotifyBatteryLevel(uint8_t level);
+      void NotifyBatteryCharging(bool isCharging);
 
       void RestartFastAdv() {
         fastAdvCount = 0;

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -332,6 +332,7 @@ void SystemTask::Work() {
           break;
         case Messages::OnChargingEvent:
           batteryController.ReadPowerState();
+          nimbleController.NotifyBatteryCharging(batteryController.IsCharging());
           GoToRunning();
           displayApp.PushMessage(Applications::Display::Messages::OnChargingEvent);
           break;


### PR DESCRIPTION
This PR allows companion apps to check if the battery is charging.

I created this because I am working on an enhancement in InfiniLink that depends on knowing if the battery is charging or not.