### PR TITLE
SimpleWeatherService #include <array>

### DIFF
--- a/src/components/ble/SimpleWeatherService.h
+++ b/src/components/ble/SimpleWeatherService.h
@@ -19,7 +19,7 @@
 
 #include <cstdint>
 #include <string>
-#include <vector>
+#include <array>
 #include <memory>
 
 #define min // workaround: nimble's min/max macros conflict with libstdc++


### PR DESCRIPTION
not <vector> as that is what is actually used.
Fixes build failure
InfiniTime/src/components/ble/SimpleWeatherService.h:86:18: error: field ‘location’ has incomplete type ‘Pinetime::Controllers::SimpleWeatherService::Location’ {aka ‘std::array<char, 33>’

with g++ on Debian 12.2.0-14 and libstdc++-12-dev 12.2.0-14