### PR TITLE
Correct tick overflow handling for timer reset

### DIFF
--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -105,7 +105,7 @@ void Timer::UpdateMask() {
 void Timer::Refresh() {
   if (timer.IsRunning()) {
     DisplayTime();
-  } else if (buttonPressing && xTaskGetTickCount() > pressTime + pdMS_TO_TICKS(150)) {
+  } else if (buttonPressing && xTaskGetTickCount() - pressTime > pdMS_TO_TICKS(150)) {
     lv_label_set_text_static(txtPlayPause, "Reset");
     maskPosition += 15;
     if (maskPosition > 240) {


### PR DESCRIPTION
Imagine the tick count wraps around at 1000, the hold time is set to 150, and the current time is 900. With the current code the comparison becomes `900 > 900 + 150` which is `900 > 50` as (1050 % 1000 = 50) so the condition will immediately be true.

With the new code, the comparison becomes `0  > 150` so there is no problem. 