### PR TITLE
Add "Run on InfiniEmu" link to pull requests, update actions/upload-artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,7 +205,7 @@ jobs:
         | data    | ${{ needs.build-firmware.outputs.data_size }}B | ${{ steps.output-sizes-diff.outputs.data_diff }}B |
         | bss     | ${{ needs.build-firmware.outputs.bss_size }}B  | ${{ steps.output-sizes-diff.outputs.bss_diff }}B  |
 
-        [Run in InfiniEmu](https://infiniemu.pipe01.net/?firmware=https://corsproxy.io/?https://nightly.link/${{ github.repository }}/actions/artifacts/${{ needs.build-firmware.outputs.firmware_artifact }}.zip&resources=https://corsproxy.io/?https://nightly.link/${{ github.repository }}/actions/artifacts/${{ needs.build-firmware.outputs.resources_artifact }}.zip)
+        [Run in InfiniEmu](https://infiniemu.pipe01.net/?firmware=artifact://${{ github.repository }}/${{ needs.build-firmware.outputs.firmware_artifact }}&resources=artifact://${{ github.repository }}/${{ needs.build-firmware.outputs.resources_artifact }})
         EOF
 
     - name: Upload comment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,7 +205,7 @@ jobs:
         | data    | ${{ needs.build-firmware.outputs.data_size }}B | ${{ steps.output-sizes-diff.outputs.data_diff }}B |
         | bss     | ${{ needs.build-firmware.outputs.bss_size }}B  | ${{ steps.output-sizes-diff.outputs.bss_diff }}B  |
 
-        [Run on InfiniEmu](https://infiniemu.pipe01.net/?firmware=https://corsproxy.io/?https://nightly.link/${{ github.repository }}/actions/artifacts/${{ needs.build-firmware.outputs.firmware_artifact }}.zip&resources=https://corsproxy.io/?https://nightly.link/${{ github.repository }}/actions/artifacts/${{ needs.build-firmware.outputs.resources_artifact }}.zip)
+        [Run in InfiniEmu](https://infiniemu.pipe01.net/?firmware=https://corsproxy.io/?https://nightly.link/${{ github.repository }}/actions/artifacts/${{ needs.build-firmware.outputs.firmware_artifact }}.zip&resources=https://corsproxy.io/?https://nightly.link/${{ github.repository }}/actions/artifacts/${{ needs.build-firmware.outputs.resources_artifact }}.zip)
         EOF
 
     - name: Upload comment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,11 +65,13 @@ jobs:
           path: ./build/output/pinetime-mcuboot-app-image-*.bin
       - name: Upload standalone ELF artifacts
         uses: actions/upload-artifact@v4
+        id: upload-firmware
         with:
           name: InfiniTime image ${{ env.REF_NAME }}
           path: ./build/output/src/pinetime-app-*.out
       - name: Upload resources artifacts
         uses: actions/upload-artifact@v4
+        id: upload-resources
         with:
           name: InfiniTime resources ${{ env.REF_NAME }}
           path: ./build/output/infinitime-resources-*.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
       text_size: ${{ steps.output-sizes.outputs.text_size }}
       data_size: ${{ steps.output-sizes.outputs.data_size }}
       bss_size: ${{ steps.output-sizes.outputs.bss_size }}
+      firmware_artifact: ${{ steps.upload-firmware.outputs.artifact-id }}
+      resources_artifact: ${{ steps.upload-resources.outputs.artifact-id }}
     env:
       # InfiniTime sources are downloaded to the current directory.
       # Override SOURCES_DIR in build.sh
@@ -47,22 +49,24 @@ jobs:
       - name: Unzip DFU package
         run: unzip ./build/output/pinetime-mcuboot-app-dfu-*.zip -d ./build/output/pinetime-mcuboot-app-dfu
       - name: Upload DFU artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: InfiniTime DFU ${{ github.head_ref }}
           path: ./build/output/pinetime-mcuboot-app-dfu/*
       - name: Upload MCUBoot image artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: InfiniTime MCUBoot image ${{ github.head_ref }}
           path: ./build/output/pinetime-mcuboot-app-image-*.bin
       - name: Upload standalone ELF artifacts
-        uses: actions/upload-artifact@v3
+        id: upload-firmware
+        uses: actions/upload-artifact@v4
         with:
           name: InfiniTime image ${{ github.head_ref }}
           path: ./build/output/src/pinetime-app-*.out
       - name: Upload resources artifacts
-        uses: actions/upload-artifact@v3
+        id: upload-resources
+        uses: actions/upload-artifact@v4
         with:
           name: InfiniTime resources ${{ github.head_ref }}
           path: ./build/output/infinitime-resources-*.zip
@@ -103,7 +107,7 @@ jobs:
         cmake --build build_lv_sim
 
     - name: Upload simulator executable
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: infinisim-${{ github.head_ref }}
         path: build_lv_sim/infinisim
@@ -200,10 +204,12 @@ jobs:
         | text    | ${{ needs.build-firmware.outputs.text_size }}B | ${{ steps.output-sizes-diff.outputs.text_diff }}B |
         | data    | ${{ needs.build-firmware.outputs.data_size }}B | ${{ steps.output-sizes-diff.outputs.data_diff }}B |
         | bss     | ${{ needs.build-firmware.outputs.bss_size }}B  | ${{ steps.output-sizes-diff.outputs.bss_diff }}B  |
+
+        [Run on InfiniEmu](https://infiniemu.pipe01.net/?firmware=https://corsproxy.io/?https://nightly.link/${{ github.repository }}/actions/artifacts/${{ needs.build-firmware.outputs.firmware_artifact }}.zip&resources=https://corsproxy.io/?https://nightly.link/${{ github.repository }}/actions/artifacts/${{ needs.build-firmware.outputs.resources_artifact }}.zip)
         EOF
 
     - name: Upload comment
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: comment
         path: comment


### PR DESCRIPTION
Using nightly.link and corsproxy.io we can generate a link that, when clicked, will direct users to a build of the latest commit of a pull request running on InfiniEmu.

It's also worth noting that GitHub actions artifacts expire after 90 days.