### PR TITLE
documentation make cmake work out of the box

### DIFF
--- a/doc/buildAndProgram.md
+++ b/doc/buildAndProgram.md
@@ -66,7 +66,7 @@ DFU files are the files you'll need to install your build of InfiniTime using OT
 #### CMake command 
 
 ```
-cmake -DARM_NONE_EABI_TOOLCHAIN_PATH=... -DNRF5_SDK_PATH=...
+cmake -DARM_NONE_EABI_TOOLCHAIN_PATH=... -DNRF5_SDK_PATH=... -S ..
 ```
 
 ### Build the project


### PR DESCRIPTION
since the previous command done when one follows the documentation is "cd build", one needs to point cmake the root directory of the sources. Add "-S .." for that.