### PR TITLE
ImmediateAlertService: fix latent bug

### DIFF
--- a/src/components/ble/ImmediateAlertService.cpp
+++ b/src/components/ble/ImmediateAlertService.cpp
@@ -63,7 +63,8 @@ int ImmediateAlertService::OnAlertLevelChanged(uint16_t attributeHandle, ble_gat
       auto* alertString = ToString(alertLevel);
 
       NotificationManager::Notification notif;
-      std::memcpy(notif.message.data(), alertString, strlen(alertString));
+      std::memcpy(notif.message.data(), alertString, strlen(alertString) + 1);
+      notif.size = strlen(alertString) + 1;
       notif.category = Pinetime::Controllers::NotificationManager::Categories::SimpleAlert;
       notificationManager.Push(std::move(notif));
 


### PR DESCRIPTION
Include null terminator in the bytes copied.
Set `notif.size` like it is done in AlertNotificationService.cpp and AlertNotificationClient.cpp.