### PR TITLE
Ignore old GoToRunning messages

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -292,7 +292,13 @@ void DisplayApp::Refresh() {
     switch (msg) {
       case Messages::GoToSleep:
       case Messages::GoToAOD:
-        if (state != States::Running) {
+        // Checking if SystemTask is sleeping is purely an optimisation.
+        // If it's no longer sleeping since it sent GoToSleep, it has
+        // cancelled the sleep and transitioned directly from
+        // GoingToSleep->Running, so we are about to receive GoToRunning
+        // and can ignore this message. If it wasn't ignored, DisplayApp
+        // would go to sleep and then immediately re-wake
+        if (state != States::Running || !systemTask->IsSleeping()) {
           break;
         }
         while (brightnessController.Level() != Controllers::BrightnessController::Levels::Low) {
@@ -334,7 +340,10 @@ void DisplayApp::Refresh() {
         lv_disp_trig_activity(nullptr);
         break;
       case Messages::GoToRunning:
-        if (state == States::Running) {
+        // If SystemTask is sleeping, the GoToRunning message is old
+        // and must be ignored. Otherwise DisplayApp will use SPI
+        // that is powered down and cause bad behaviour
+        if (state == States::Running || systemTask->IsSleeping()) {
           break;
         }
         if (state == States::AOD) {


### PR DESCRIPTION
Fixes the recent display inversion issue (#2160)

In short DisplayApp could process a stale GoToRunning message with a GoToSleep also queued up after it, and do one LVGL iteration when the SPI is off

Verified locally by adding guards around SpiMaster that reset the device immediately if SPI is used while asleep (easiest way without a devkit)

I'm pretty confident DisplayApp state handling is sound after this change. But it's also quite overcomplicated now and I'd like to simplify it, but right before a release probably isn't a good time so I'll propose that later 