### PR TITLE
weather: Fix inverted imperial forecast temperatures

### DIFF
--- a/src/displayapp/screens/Weather.cpp
+++ b/src/displayapp/screens/Weather.cpp
@@ -154,11 +154,11 @@ void Weather::Refresh() {
       std::tm localTime = *std::localtime(reinterpret_cast<const time_t*>(&optCurrentForecast->timestamp));
 
       for (int i = 0; i < optCurrentForecast->nbDays; i++) {
-        int16_t minTemp = optCurrentForecast->days[i]->minTemperature.Celsius();
         int16_t maxTemp = optCurrentForecast->days[i]->maxTemperature.Celsius();
+        int16_t minTemp = optCurrentForecast->days[i]->minTemperature.Celsius();
         if (settingsController.GetWeatherFormat() == Controllers::Settings::WeatherFormat::Imperial) {
-          minTemp = optCurrentForecast->days[i]->maxTemperature.Fahrenheit();
-          maxTemp = optCurrentForecast->days[i]->minTemperature.Fahrenheit();
+          maxTemp = optCurrentForecast->days[i]->maxTemperature.Fahrenheit();
+          minTemp = optCurrentForecast->days[i]->minTemperature.Fahrenheit();
         }
         lv_table_set_cell_type(forecast, 2, i, TemperatureStyle(optCurrentForecast->days[i]->maxTemperature));
         lv_table_set_cell_type(forecast, 3, i, TemperatureStyle(optCurrentForecast->days[i]->minTemperature));


### PR DESCRIPTION
When converting to imperial units, the min and max temperatures were incorrectly inverted, causing confusion in the display.

Fixes https://github.com/InfiniTimeOrg/InfiniTime/issues/2183