### PR TITLE
Add weather to the terminal watch face

### DIFF
--- a/src/displayapp/screens/WatchFaceTerminal.cpp
+++ b/src/displayapp/screens/WatchFaceTerminal.cpp
@@ -9,8 +9,24 @@
 #include "components/heartrate/HeartRateController.h"
 #include "components/motion/MotionController.h"
 #include "components/settings/Settings.h"
+#include "components/ble/SimpleWeatherService.h"
+#include "displayapp/screens/WeatherSymbols.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 using namespace Pinetime::Applications::Screens;
+
+namespace {
+  lv_color_t TemperatureColor(Pinetime::Controllers::SimpleWeatherService::Temperature temp) {
+    if (temp.Celsius() <= 0) { // freezing
+      return Colors::blue;
+    } else if (temp.Celsius() <= 4) { // ice
+      return LV_COLOR_CYAN;
+    } else if (temp.Celsius() >= 27) { // hot
+      return Colors::deepOrange;
+    }
+    return Colors::orange; // normal
+  }
+}
 
 WatchFaceTerminal::WatchFaceTerminal(Controllers::DateTime& dateTimeController,
                                      const Controllers::Battery& batteryController,
@@ -18,7 +34,8 @@ WatchFaceTerminal::WatchFaceTerminal(Controllers::DateTime& dateTimeController,
                                      Controllers::NotificationManager& notificationManager,
                                      Controllers::Settings& settingsController,
                                      Controllers::HeartRateController& heartRateController,
-                                     Controllers::MotionController& motionController)
+                                     Controllers::MotionController& motionController,
+                                     Controllers::SimpleWeatherService& weatherService)
   : currentDateTime {{}},
     dateTimeController {dateTimeController},
     batteryController {batteryController},
@@ -26,7 +43,8 @@ WatchFaceTerminal::WatchFaceTerminal(Controllers::DateTime& dateTimeController,
     notificationManager {notificationManager},
     settingsController {settingsController},
     heartRateController {heartRateController},
-    motionController {motionController} {
+    motionController {motionController},
+    weatherService {weatherService} {
   batteryValue = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_recolor(batteryValue, true);
   lv_obj_align(batteryValue, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, -20);
@@ -47,7 +65,7 @@ WatchFaceTerminal::WatchFaceTerminal(Controllers::DateTime& dateTimeController,
   lv_label_set_text_static(label_prompt_1, "user@watch:~ $ now");
 
   label_prompt_2 = lv_label_create(lv_scr_act(), nullptr);
-  lv_obj_align(label_prompt_2, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, 60);
+  lv_obj_align(label_prompt_2, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, 80);
   lv_label_set_text_static(label_prompt_2, "user@watch:~ $");
 
   label_time = lv_label_create(lv_scr_act(), nullptr);
@@ -61,6 +79,10 @@ WatchFaceTerminal::WatchFaceTerminal(Controllers::DateTime& dateTimeController,
   stepValue = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_recolor(stepValue, true);
   lv_obj_align(stepValue, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, 0);
+
+  weather = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_recolor(weather, true);
+  lv_obj_align(weather, lv_scr_act(), LV_ALIGN_IN_LEFT_MID, 0, 60);
 
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
   Refresh();
@@ -147,5 +169,27 @@ void WatchFaceTerminal::Refresh() {
   stepCount = motionController.NbSteps();
   if (stepCount.IsUpdated()) {
     lv_label_set_text_fmt(stepValue, "[STEP]#ee3377 %lu steps#", stepCount.Get());
+  }
+
+  currentWeather = weatherService.Current();
+  if (currentWeather.IsUpdated()) {
+    auto optCurrentWeather = currentWeather.Get();
+    if (optCurrentWeather) {
+      int16_t temp = optCurrentWeather->temperature.Celsius();
+      char tempUnit = 'C';
+      lv_obj_set_style_local_text_color(weather, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, TemperatureColor(optCurrentWeather->temperature));
+      if (settingsController.GetWeatherFormat() == Controllers::Settings::WeatherFormat::Imperial) {
+        temp = optCurrentWeather->temperature.Fahrenheit();
+        tempUnit = 'F';
+      }
+      lv_label_set_text_fmt(weather,
+                            "#ffffff [WTHR]#%d°%c %s",
+                            temp,
+                            tempUnit,
+                            // Change to GetSimpleCondition with pull request #2134 (Add shorter/simpler weather condition options)
+                            Symbols::GetCondition(optCurrentWeather->iconId));
+    } else {
+      lv_label_set_text(weather, "#ffffff [WTHR]---°");
+    }
   }
 }

--- a/src/displayapp/screens/WatchFaceTerminal.h
+++ b/src/displayapp/screens/WatchFaceTerminal.h
@@ -7,6 +7,7 @@
 #include <displayapp/Controllers.h>
 #include "displayapp/screens/Screen.h"
 #include "components/datetime/DateTimeController.h"
+#include "components/ble/SimpleWeatherService.h"
 #include "utility/DirtyValue.h"
 
 namespace Pinetime {
@@ -30,7 +31,8 @@ namespace Pinetime {
                           Controllers::NotificationManager& notificationManager,
                           Controllers::Settings& settingsController,
                           Controllers::HeartRateController& heartRateController,
-                          Controllers::MotionController& motionController);
+                          Controllers::MotionController& motionController,
+                          Controllers::SimpleWeatherService& weatherService);
         ~WatchFaceTerminal() override;
 
         void Refresh() override;
@@ -46,6 +48,7 @@ namespace Pinetime {
         Utility::DirtyValue<bool> heartbeatRunning {};
         Utility::DirtyValue<bool> notificationState {};
         Utility::DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::days>> currentDate;
+        Utility::DirtyValue<std::optional<Controllers::SimpleWeatherService::CurrentWeather>> currentWeather {};
 
         lv_obj_t* label_time;
         lv_obj_t* label_date;
@@ -56,6 +59,7 @@ namespace Pinetime {
         lv_obj_t* stepValue;
         lv_obj_t* notificationIcon;
         lv_obj_t* connectState;
+        lv_obj_t* weather;
 
         Controllers::DateTime& dateTimeController;
         const Controllers::Battery& batteryController;
@@ -64,6 +68,7 @@ namespace Pinetime {
         Controllers::Settings& settingsController;
         Controllers::HeartRateController& heartRateController;
         Controllers::MotionController& motionController;
+        Controllers::SimpleWeatherService& weatherService;
 
         lv_task_t* taskRefresh;
       };
@@ -81,7 +86,8 @@ namespace Pinetime {
                                               controllers.notificationManager,
                                               controllers.settingsController,
                                               controllers.heartRateController,
-                                              controllers.motionController);
+                                              controllers.motionController,
+                                              *controllers.weatherController);
       };
 
       static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {


### PR DESCRIPTION
This was originally part of #2001 but is being split into its own PR without the non-weather changes to give it the ability to be merged without those changes.

This PR adds the current temperature and condition to the terminal watch face with dynamic coloring. In it's current state many of the conditions will overflow off the right side of the screen, but this will be fixed in #2134 which has already been added to the 1.16.0 milestone.

![InfiniSim_2024-12-20_215457](https://github.com/user-attachments/assets/b755cd09-d749-407a-8c66-253d88933c1f)
![InfiniSim_2024-12-20_215500](https://github.com/user-attachments/assets/1235f358-4320-4b2a-9c66-f70643bb154e)
![InfiniSim_2024-12-20_215515](https://github.com/user-attachments/assets/75e1d22d-3ff6-401a-bdcf-a66f25aa5264)
![InfiniSim_2024-12-20_221501](https://github.com/user-attachments/assets/4149d3b8-d86f-447c-9284-de34269e2a4b)
