### PR TITLE
DirtyValue: add possibility to mark DirtyValue updated

### DIFF
--- a/src/utility/DirtyValue.h
+++ b/src/utility/DirtyValue.h
@@ -18,6 +18,10 @@ namespace Pinetime {
         return false;
       }
 
+      void MarkUpdated() {
+        this->isUpdated = true;
+      }
+
       T const& Get() {
         this->isUpdated = false;
         return value;


### PR DESCRIPTION
Adds the ability to manually mark a DirtyValue as updated.

This simplifies situations where a the user (or any other condition) selects if a value should be updated.

Example: In my Star Trek watch face I give the possibility to show weather or not. Using this function, I do not have to duplicate the weather updating code to the button press handler or introduce another variable `weatherNeedsUpdate`. I can just make the corresponding element visible, mark the weather data as updated (although it really isn't), and the next  normal refresh loop will put the correct weather information.