### PR TITLE
BatteryIcon: fix set color when using color on low battery

### DIFF
--- a/src/displayapp/screens/BatteryIcon.cpp
+++ b/src/displayapp/screens/BatteryIcon.cpp
@@ -11,7 +11,7 @@ BatteryIcon::BatteryIcon(bool colorOnLowBattery) : colorOnLowBattery {colorOnLow
 void BatteryIcon::Create(lv_obj_t* parent) {
   batteryImg = lv_img_create(parent, nullptr);
   lv_img_set_src(batteryImg, &batteryicon);
-  lv_obj_set_style_local_image_recolor(batteryImg, LV_IMG_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_BLACK);
+  lv_obj_set_style_local_image_recolor(batteryImg, LV_IMG_PART_MAIN, LV_STATE_DEFAULT, baseColor);
 
   batteryJuice = lv_obj_create(batteryImg, nullptr);
   lv_obj_set_width(batteryJuice, 8);
@@ -30,19 +30,29 @@ void BatteryIcon::SetBatteryPercentage(uint8_t percentage) {
     static constexpr int lowBatteryThreshold = 15;
     static constexpr int criticalBatteryThreshold = 5;
     if (percentage > lowBatteryThreshold) {
-      SetColor(LV_COLOR_WHITE);
+      _SetColor(baseColor);
     } else if (percentage > criticalBatteryThreshold) {
-      SetColor(LV_COLOR_ORANGE);
+      _SetColor(LV_COLOR_ORANGE);
     } else {
-      SetColor(Colors::deepOrange);
+      _SetColor(Colors::deepOrange);
     }
   }
 }
 
 void BatteryIcon::SetColor(lv_color_t color) {
+  baseColor = color;
+  _SetColor(color);
+}
+
+void BatteryIcon::_SetColor(lv_color_t color) {
   lv_obj_set_style_local_image_recolor(batteryImg, LV_IMG_PART_MAIN, LV_STATE_DEFAULT, color);
   lv_obj_set_style_local_image_recolor_opa(batteryImg, LV_IMG_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_COVER);
   lv_obj_set_style_local_bg_color(batteryJuice, LV_OBJ_PART_MAIN, LV_STATE_DEFAULT, color);
+}
+
+void BatteryIcon::SetVisible(bool visible) {
+  lv_obj_set_hidden(batteryImg, !visible);
+  lv_obj_set_hidden(batteryJuice, !visible);
 }
 
 const char* BatteryIcon::GetPlugIcon(bool isCharging) {

--- a/src/displayapp/screens/BatteryIcon.h
+++ b/src/displayapp/screens/BatteryIcon.h
@@ -9,6 +9,7 @@ namespace Pinetime {
       public:
         explicit BatteryIcon(bool colorOnLowBattery);
         void Create(lv_obj_t* parent);
+        void SetVisible(bool visible);
 
         void SetColor(lv_color_t);
         void SetBatteryPercentage(uint8_t percentage);
@@ -21,6 +22,9 @@ namespace Pinetime {
         lv_obj_t* batteryImg;
         lv_obj_t* batteryJuice;
         bool colorOnLowBattery = false;
+
+        lv_color_t baseColor = LV_COLOR_WHITE;
+        void _SetColor(lv_color_t color);
       };
     }
   }


### PR DESCRIPTION
As it currently is, the BatteryIcon can change to orange for low battery (if selected at creation).
However, the code assumes the default color to be white. In my Star Trek watch face, the default Icon color is black.

This change makes it such that when recharging after getting orange (or even red) the icon returns to the color set by `SetColor`.

Also adds a convenience function to set the visibility of the icon.