### PR TITLE
Provide callback for watch face to react to LCD state changes

### DIFF
--- a/src/displayapp/screens/Screen.h
+++ b/src/displayapp/screens/Screen.h
@@ -40,6 +40,12 @@ namespace Pinetime {
           return false;
         }
 
+        virtual void OnLCDWakeup([[maybe_unused]] bool aodMode) {
+        }
+
+        virtual void OnLCDSleep([[maybe_unused]] bool aodMode) {
+        }
+
       protected:
         bool running = true;
       };


### PR DESCRIPTION
This provides a callback for watch faces to get notified about changes to the LCD state, meaning when it turns on and off or switches to and from the reduced color range of the Always On Display.

This requires no changes to any watch face if the functionality is not used there, since it is a virtual void with an empty default implementation.

However, it adds an additional 100 tick delay on LCD sleep since `lv_task_handler` is not called in idle mode and we need time for one display refresh before entering idle. For AOD there is a similar thing with the display refresh rate decreasing, so updating before AOD is faster.