### PR TITLE
Add an optional help text to CheckboxList to explain that resources are missing

### DIFF
--- a/src/displayapp/screens/CheckboxList.cpp
+++ b/src/displayapp/screens/CheckboxList.cpp
@@ -1,6 +1,7 @@
 #include "displayapp/DisplayApp.h"
 #include "displayapp/screens/CheckboxList.h"
 #include "displayapp/screens/Styles.h"
+#include "displayapp/InfiniTimeTheme.h"
 
 using namespace Pinetime::Applications::Screens;
 
@@ -17,7 +18,8 @@ CheckboxList::CheckboxList(const uint8_t screenID,
                            const char* optionsSymbol,
                            uint32_t originalValue,
                            std::function<void(uint32_t)> OnValueChanged,
-                           std::array<Item, MaxItems> options)
+                           std::array<Item, MaxItems> options,
+                           const char* optionsHelptext)
   : screenID {screenID},
     OnValueChanged {std::move(OnValueChanged)},
     options {options},
@@ -52,6 +54,17 @@ CheckboxList::CheckboxList(const uint8_t screenID,
   lv_label_set_text_static(icon, optionsSymbol);
   lv_label_set_align(icon, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(icon, title, LV_ALIGN_OUT_LEFT_MID, -10, 0);
+
+  lv_obj_t* helptext;
+  if (optionsHelptext != nullptr) {
+    helptext = lv_label_create(lv_scr_act(), nullptr);
+    lv_label_set_align(helptext, LV_LABEL_ALIGN_CENTER);
+    lv_label_set_long_mode(helptext, LV_LABEL_LONG_SROLL_CIRC);
+    lv_obj_set_width(helptext, LV_HOR_RES);
+    lv_obj_set_style_local_text_color(helptext, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::lightGray);
+    lv_label_set_text_static(helptext, optionsHelptext);
+    lv_obj_align(helptext, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, 0);
+  }
 
   for (unsigned int i = 0; i < options.size(); i++) {
     if (strcmp(options[i].name, "")) {

--- a/src/displayapp/screens/CheckboxList.h
+++ b/src/displayapp/screens/CheckboxList.h
@@ -27,7 +27,8 @@ namespace Pinetime {
                      const char* optionsSymbol,
                      uint32_t originalValue,
                      std::function<void(uint32_t)> OnValueChanged,
-                     std::array<Item, MaxItems> options);
+                     std::array<Item, MaxItems> options,
+                     const char* optionsHelptext = nullptr);
         ~CheckboxList() override;
         void UpdateSelected(lv_obj_t* object, lv_event_t event);
 

--- a/src/displayapp/screens/settings/SettingWatchFace.cpp
+++ b/src/displayapp/screens/settings/SettingWatchFace.cpp
@@ -8,6 +8,7 @@ using namespace Pinetime::Applications::Screens;
 
 constexpr const char* SettingWatchFace::title;
 constexpr const char* SettingWatchFace::symbol;
+constexpr const char* SettingWatchFace::helptext;
 
 namespace {
   uint32_t IndexOf(const std::array<Pinetime::Applications::Screens::SettingWatchFace::Item,
@@ -70,12 +71,14 @@ bool SettingWatchFace::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
 
 std::unique_ptr<Screen> SettingWatchFace::CreateScreen(unsigned int screenNum) const {
   std::array<Screens::CheckboxList::Item, settingsPerScreen> watchfacesOnThisScreen;
+  bool needsHelptext = false;
   for (int i = 0; i < settingsPerScreen; i++) {
     if (i + (screenNum * settingsPerScreen) >= watchfaceItems.size()) {
       watchfacesOnThisScreen[i] = {"", false};
     } else {
       auto& item = watchfaceItems[i + (screenNum * settingsPerScreen)];
       watchfacesOnThisScreen[i] = Screens::CheckboxList::Item {item.name, item.enabled};
+      needsHelptext |= !item.enabled;
     }
   }
 
@@ -89,5 +92,6 @@ std::unique_ptr<Screen> SettingWatchFace::CreateScreen(unsigned int screenNum) c
       settings.SetWatchFace(IndexToWatchFace(watchfaceItems, index));
       settings.SaveSettings();
     },
-    watchfacesOnThisScreen);
+    watchfacesOnThisScreen,
+    needsHelptext ? helptext : nullptr);
 }

--- a/src/displayapp/screens/settings/SettingWatchFace.h
+++ b/src/displayapp/screens/settings/SettingWatchFace.h
@@ -46,6 +46,7 @@ namespace Pinetime {
 
         static constexpr const char* title = "Watch face";
         static constexpr const char* symbol = Symbols::home;
+        static constexpr const char* helptext = "  Resources missing! Install resource pack to use greyed out watch faces.";
 
         ScreenList<nScreens> screens;
       };


### PR DESCRIPTION
Fixes #2196 

This adds an optional help text to the `CheckboxList`. It is done as an additional argument in the constructor that is `nullptr` by default. This way, no changes to other code are needed. If a help text is supplied it scrolls along the very bottom of the screen.

If any watch face signals it is not available, the message "Resources missing! Install resource pack to use greyed out watch faces." Is displayed on the corresponding selection screen.

![InfiniSim_2024-12-31_143511](https://github.com/user-attachments/assets/437e5659-0747-4d9d-839d-348bc859f386)

