### PR TITLE
Add a fast mode to Counter where more than one is skipped on long press

### DIFF
--- a/src/displayapp/screens/Alarm.cpp
+++ b/src/displayapp/screens/Alarm.cpp
@@ -68,6 +68,7 @@ Alarm::Alarm(Controllers::AlarmController& alarmController,
   lv_obj_align(minuteCounter.GetObject(), nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
   minuteCounter.SetValue(alarmController.Minutes());
   minuteCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
+  minuteCounter.EnableFastMode(5);
 
   lv_obj_t* colonLabel = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(colonLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -26,7 +26,9 @@ Timer::Timer(Controllers::Timer& timerController) : timer {timerController} {
   lv_obj_align(colonLabel, lv_scr_act(), LV_ALIGN_CENTER, 0, -29);
 
   minuteCounter.Create();
+  minuteCounter.EnableFastMode(5);
   secondCounter.Create();
+  secondCounter.EnableFastMode(5);
   lv_obj_align(minuteCounter.GetObject(), nullptr, LV_ALIGN_IN_TOP_LEFT, 0, 0);
   lv_obj_align(secondCounter.GetObject(), nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 0);
 

--- a/src/displayapp/screens/settings/SettingSetDate.cpp
+++ b/src/displayapp/screens/settings/SettingSetDate.cpp
@@ -64,6 +64,7 @@ SettingSetDate::SettingSetDate(Pinetime::Controllers::DateTime& dateTimeControll
   dayCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
   dayCounter.Create();
   dayCounter.SetValue(dateTimeController.Day());
+  dayCounter.EnableFastMode(5);
   lv_obj_align(dayCounter.GetObject(), nullptr, LV_ALIGN_CENTER, POS_X_DAY, POS_Y_TEXT);
 
   monthCounter.EnableMonthMode();

--- a/src/displayapp/screens/settings/SettingSetTime.cpp
+++ b/src/displayapp/screens/settings/SettingSetTime.cpp
@@ -55,6 +55,7 @@ SettingSetTime::SettingSetTime(Pinetime::Controllers::DateTime& dateTimeControll
 
   minuteCounter.Create();
   minuteCounter.SetValue(dateTimeController.Minutes());
+  minuteCounter.EnableFastMode(5);
   lv_obj_align(minuteCounter.GetObject(), nullptr, LV_ALIGN_CENTER, 0, POS_Y_TEXT);
   minuteCounter.SetValueChangedEventCallback(this, ValueChangedHandler);
 

--- a/src/displayapp/widgets/Counter.cpp
+++ b/src/displayapp/widgets/Counter.cpp
@@ -59,6 +59,9 @@ void Counter::DownBtnPressed() {
 void Counter::SetValue(int newValue) {
   value = newValue;
   UpdateLabel();
+  if (ValueChangedHandler != nullptr) {
+    ValueChangedHandler(userData);
+  }
 }
 
 void Counter::HideControls() {

--- a/src/displayapp/widgets/Counter.h
+++ b/src/displayapp/widgets/Counter.h
@@ -9,13 +9,14 @@ namespace Pinetime {
         Counter(int min, int max, lv_font_t& font);
 
         void Create();
-        void UpBtnPressed();
-        void DownBtnPressed();
+        void UpBtnPressed(lv_event_t event);
+        void DownBtnPressed(lv_event_t event);
         void SetValue(int newValue);
         void HideControls();
         void ShowControls();
         void EnableTwelveHourMode();
         void EnableMonthMode();
+        void EnableFastMode(int fastSkip);
         void SetMax(int newMax);
         void SetValueChangedEventCallback(void* userData, void (*handler)(void* userData));
 
@@ -44,6 +45,8 @@ namespace Pinetime {
         const int leadingZeroCount;
         bool twelveHourMode = false;
         bool monthMode = false;
+        bool fastMode = false;
+        int fastSkip = 1;
         lv_font_t& font;
 
         void* userData = nullptr;


### PR DESCRIPTION
Oftentimes I cannot be bothered to hold the + button of the timer down until 30s is reached, because it takes so long. Instead, I just set 30s less and wait around a bit after the timer rings.
When setting an alarm, I have the same problem with the minutes. It just takes too long. 

This adds a 'fast mode' to the `Counter` widget that is used in these cases.
An application designer can enable this for a widget and is then able to specify how many steps should be skipped on each trigger of the `LV_EVENT_LONG_PRESSED_REPEAT` event.

This PR enables this with value 5 for `Timer`, `Alarm` (minutes only) and `SettingDateTime` (days and minutes only).

Also includes a small fix for `Counter` where the `ValueChangedHandler` was not called if `SetValue` was used. I don't think there were any bugs caused by this yet, I checked all uses of the function.