### PR TITLE
CI: Use artifact v4 instead of v3

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
         run: tests/test-format.sh
 
       - name: Upload patches
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: Patches

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,22 +52,22 @@ jobs:
           ref_name: ${{ github.head_ref || github.ref_name }}
         run: echo "REF_NAME=${ref_name//\//-}" >> $GITHUB_ENV
       - name: Upload DFU artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: InfiniTime DFU ${{ env.REF_NAME }}
           path: ./build/output/pinetime-mcuboot-app-dfu/*
       - name: Upload MCUBoot image artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: InfiniTime MCUBoot image ${{ env.REF_NAME }}
           path: ./build/output/pinetime-mcuboot-app-image-*.bin
       - name: Upload standalone ELF artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: InfiniTime image ${{ env.REF_NAME }}
           path: ./build/output/src/pinetime-app-*.out
       - name: Upload resources artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: InfiniTime resources ${{ env.REF_NAME }}
           path: ./build/output/infinitime-resources-*.zip
@@ -108,7 +108,7 @@ jobs:
         cmake --build build_lv_sim
 
     - name: Upload simulator executable
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: infinisim-${{ env.REF_NAME }}
         path: build_lv_sim/infinisim
@@ -208,7 +208,7 @@ jobs:
         EOF
 
     - name: Upload comment
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: comment
         path: comment


### PR DESCRIPTION
It seems v3 can be directly replaced by v4.

I have seen just issue with naming infinitisim artifact, which is unrelated with migration to v4. See https://github.com/InfiniTimeOrg/InfiniTime/issues/2223