### PR TITLE
Adds vibration strength settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,12 @@ name: CI
 # Run this workflow whenever the build may be affected
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ghoelian ]
     paths-ignore:
       - 'doc/**'
       - '**.md'
   pull_request:
-    branches: [ main ]
+    branches: [ main, ghoelian ]
     paths-ignore:
       - 'doc/**'
       - '**.md'

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ src/arm-none-eabi
 
 # clangd
 .cache/
+
+node_modules/

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mkdir -p build
+cd build
+
+echo "Configuring build..."
+cmake -DARM_NONE_EABI_TOOLCHAIN_PATH="/workspaces/infinitime/gcc-arm" -DNRF5_SDK_PATH="/workspaces/infinitime/nRF5_SDK" -DCMAKE_BUILD_TYPE="Release" -DBUILD_DFU=1 -DBUILD_RESOURCES=1 -DTARGET_DEVICE="PINETIME" ..
+echo "Finished configuring build"
+
+echo "Building..."
+make -j4 pinetime-mcuboot-app
+echo "Finished building"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,119 @@
+{
+	"name": "InfiniTime",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"dependencies": {
+				"lv_font_conv": "^1.5.3"
+			}
+		},
+		"node_modules/lv_font_conv": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/lv_font_conv/-/lv_font_conv-1.5.3.tgz",
+			"integrity": "sha512-0xJQThBOw2iptFccSXrKDIUTQAwr/2zhKjCI1lATIRgZo8uvYRTmenKafW9yTw6G0y5AyW00tqGpUtYuTuBIbQ==",
+			"bundleDependencies": [
+				"argparse",
+				"bit-buffer",
+				"debug",
+				"make-error",
+				"mkdirp",
+				"opentype.js",
+				"pngjs"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.0",
+				"bit-buffer": "^0.2.5",
+				"debug": "^4.3.3",
+				"make-error": "^1.3.5",
+				"mkdirp": "^1.0.4",
+				"opentype.js": "^1.3.4",
+				"pngjs": "^6.0.0"
+			},
+			"bin": {
+				"lv_font_conv": "lv_font_conv.js"
+			}
+		},
+		"node_modules/lv_font_conv/node_modules/argparse": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "Python-2.0"
+		},
+		"node_modules/lv_font_conv/node_modules/bit-buffer": {
+			"version": "0.2.5",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/lv_font_conv/node_modules/debug": {
+			"version": "4.3.4",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/lv_font_conv/node_modules/make-error": {
+			"version": "1.3.6",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/lv_font_conv/node_modules/mkdirp": {
+			"version": "1.0.4",
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/lv_font_conv/node_modules/ms": {
+			"version": "2.1.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/lv_font_conv/node_modules/opentype.js": {
+			"version": "1.3.4",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"string.prototype.codepointat": "^0.2.1",
+				"tiny-inflate": "^1.0.3"
+			},
+			"bin": {
+				"ot": "bin/ot"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/lv_font_conv/node_modules/pngjs": {
+			"version": "6.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.13.0"
+			}
+		},
+		"node_modules/lv_font_conv/node_modules/string.prototype.codepointat": {
+			"version": "0.2.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/lv_font_conv/node_modules/tiny-inflate": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "MIT"
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+	"dependencies": {
+		"lv_font_conv": "^1.5.3"
+	}
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -418,6 +418,8 @@ list(APPEND SOURCE_FILES
         displayapp/screens/settings/SettingChimes.cpp
         displayapp/screens/settings/SettingShakeThreshold.cpp
         displayapp/screens/settings/SettingBluetooth.cpp
+        displayapp/screens/settings/SettingNotifVibration.cpp
+        displayapp/screens/settings/SettingChimeVibration.cpp
 
         ## Watch faces
         displayapp/screens/WatchFaceAnalog.cpp

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -46,6 +46,13 @@ namespace Pinetime {
         PTSWeather weatherEnable = PTSWeather::Off;
       };
 
+      enum class CasioWeatherSegment : uint8_t { WeekNumber, DayCounter, DayOfWeek };
+
+      struct CasioStyleG7710 {
+        PTSWeather weatherEnable = PTSWeather::Off;
+        CasioWeatherSegment weatherSegment = CasioWeatherSegment::DayCounter;
+      };
+
       struct WatchFaceInfineat {
         bool showSideCover = true;
         int colorIndex = 0;
@@ -154,6 +161,27 @@ namespace Pinetime {
       PTSWeather GetPTSWeather() const {
         return settings.PTS.weatherEnable;
       };
+
+      void SetCasioWeather(PTSWeather weatherEnable) {
+        if (weatherEnable != settings.casio.weatherEnable)
+          settingsChanged = true;
+        settings.casio.weatherEnable = weatherEnable;
+      }
+
+      PTSWeather GetCasioWeather() const {
+        return settings.casio.weatherEnable;
+      }
+
+      void SetCasioWeatherSegment(CasioWeatherSegment weatherSegment) {
+        if (weatherSegment != settings.casio.weatherSegment)
+          settingsChanged = true;
+
+        settings.casio.weatherSegment = weatherSegment;
+      }
+
+      CasioWeatherSegment GetCasioWeatherSegment() const {
+        return settings.casio.weatherSegment;
+      }
 
       void SetAppMenu(uint8_t menu) {
         appMenu = menu;
@@ -341,6 +369,8 @@ namespace Pinetime {
         ChimesOption chimesOption = ChimesOption::None;
 
         PineTimeStyle PTS;
+
+        CasioStyleG7710 casio;
 
         WatchFaceInfineat watchFaceInfineat;
 

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -34,6 +34,7 @@ namespace Pinetime {
         Orange,
         Pink
       };
+      enum class VibrationStrength : uint8_t { Weak = 15, Normal = 35, Strong = 75 };
       enum class PTSGaugeStyle : uint8_t { Full, Half, Numeric };
       enum class PTSWeather : uint8_t { On, Off };
 
@@ -298,6 +299,28 @@ namespace Pinetime {
         return bleRadioEnabled;
       };
 
+      void SetNotifVibration(VibrationStrength strength) {
+        if (strength != settings.notifVibration) {
+          settingsChanged = true;
+        }
+        settings.notifVibration = strength;
+      };
+
+      VibrationStrength GetNotifVibration() const {
+        return settings.notifVibration;
+      }
+
+      void SetChimeVibration(VibrationStrength strength) {
+        if (strength != settings.chimeVibration) {
+          settingsChanged = true;
+        }
+        settings.chimeVibration = strength;
+      };
+
+      VibrationStrength GetChimeVibration() const {
+        return settings.chimeVibration;
+      }
+
     private:
       Pinetime::Controllers::FS& fs;
 
@@ -325,6 +348,9 @@ namespace Pinetime {
         uint16_t shakeWakeThreshold = 150;
 
         Controllers::BrightnessController::Levels brightLevel = Controllers::BrightnessController::Levels::Medium;
+
+        VibrationStrength notifVibration = VibrationStrength::Normal;
+        VibrationStrength chimeVibration = VibrationStrength::Normal;
       };
 
       SettingsData settings;

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -49,6 +49,8 @@
 #include "displayapp/screens/settings/SettingChimes.h"
 #include "displayapp/screens/settings/SettingShakeThreshold.h"
 #include "displayapp/screens/settings/SettingBluetooth.h"
+#include "displayapp/screens/settings/SettingNotifVibration.h"
+#include "displayapp/screens/settings/SettingChimeVibration.h"
 
 #include "libs/lv_conf.h"
 #include "UserApps.h"
@@ -372,7 +374,7 @@ void DisplayApp::Refresh() {
         } else {
           LoadNewScreen(Apps::Timer, DisplayApp::FullRefreshDirections::Up);
         }
-        motorController.RunForDuration(35);
+        motorController.RunForDuration(static_cast<uint8_t>(settingsController.GetNotifVibration()));
         break;
       case Messages::AlarmTriggered:
         if (currentApp == Apps::Alarm) {
@@ -384,7 +386,7 @@ void DisplayApp::Refresh() {
         break;
       case Messages::ShowPairingKey:
         LoadNewScreen(Apps::PassKey, DisplayApp::FullRefreshDirections::Up);
-        motorController.RunForDuration(35);
+        motorController.RunForDuration(static_cast<uint8_t>(settingsController.GetNotifVibration()));
         break;
       case Messages::TouchEvent: {
         if (state != States::Running) {
@@ -473,7 +475,7 @@ void DisplayApp::Refresh() {
         break;
       case Messages::Chime:
         LoadNewScreen(Apps::Clock, DisplayApp::FullRefreshDirections::None);
-        motorController.RunForDuration(35);
+        motorController.RunForDuration(static_cast<uint8_t>(settingsController.GetChimeVibration()));
         break;
       case Messages::OnChargingEvent:
         motorController.RunForDuration(15);
@@ -563,6 +565,7 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
                                                                notificationManager,
                                                                systemTask->nimble().alertService(),
                                                                motorController,
+                                                               settingsController,
                                                                *systemTask,
                                                                Screens::Notifications::Modes::Normal);
       break;
@@ -571,6 +574,7 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
                                                                notificationManager,
                                                                systemTask->nimble().alertService(),
                                                                motorController,
+                                                               settingsController,
                                                                *systemTask,
                                                                Screens::Notifications::Modes::Preview);
       break;
@@ -622,6 +626,12 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
       break;
     case Apps::SettingBluetooth:
       currentScreen = std::make_unique<Screens::SettingBluetooth>(this, settingsController);
+      break;
+    case Apps::SettingNotifVibration:
+      currentScreen = std::make_unique<Screens::SettingNotifVibration>(settingsController, motorController);
+      break;
+    case Apps::SettingChimeVibration:
+      currentScreen = std::make_unique<Screens::SettingChimeVibration>(settingsController, motorController);
       break;
     case Apps::BatteryInfo:
       currentScreen = std::make_unique<Screens::BatteryInfo>(batteryController);

--- a/src/displayapp/apps/Apps.h.in
+++ b/src/displayapp/apps/Apps.h.in
@@ -52,8 +52,9 @@ namespace Pinetime {
       Analog,
       PineTimeStyle,
       Terminal,
+      Json,
       Infineat,
-      CasioStyleG7710,
+      CasioStyleG7710
     };
 
     template <Apps>

--- a/src/displayapp/apps/Apps.h.in
+++ b/src/displayapp/apps/Apps.h.in
@@ -42,6 +42,8 @@ namespace Pinetime {
       SettingChimes,
       SettingShakeThreshold,
       SettingBluetooth,
+      SettingNotifVibration,
+      SettingChimeVibration,
       Error
     };
 

--- a/src/displayapp/fonts/CMakeLists.txt
+++ b/src/displayapp/fonts/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(FONTS jetbrains_mono_42 jetbrains_mono_76 jetbrains_mono_bold_20
-   jetbrains_mono_extrabold_compressed lv_font_sys_48
+   jetbrains_mono_extrabold_compressed jetbrains_mono_16 lv_font_sys_48
    open_sans_light fontawesome_weathericons)
 find_program(LV_FONT_CONV "lv_font_conv" NO_CACHE REQUIRED
    HINTS "${CMAKE_SOURCE_DIR}/node_modules/.bin")

--- a/src/displayapp/fonts/fonts.json
+++ b/src/displayapp/fonts/fonts.json
@@ -14,6 +14,16 @@
       "size": 20,
       "patches": ["jetbrains_mono_bold_20.c_zero.patch", "jetbrains_mono_bold_20.c_M.patch"]
    },
+   "jetbrains_mono_16": {
+      "sources": [
+         {
+            "file": "JetBrainsMono-Regular.ttf",
+            "range": "0x20-0x7e, 0x410-0x44f, 0xB0"
+         }
+      ],
+      "bpp": 1,
+      "size": 16
+   },
    "jetbrains_mono_42": {
       "sources": [
          {

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -14,6 +14,7 @@ Notifications::Notifications(DisplayApp* app,
                              Pinetime::Controllers::NotificationManager& notificationManager,
                              Pinetime::Controllers::AlertNotificationService& alertNotificationService,
                              Pinetime::Controllers::MotorController& motorController,
+                             Pinetime::Controllers::Settings& settingsController,
                              System::SystemTask& systemTask,
                              Modes mode)
   : app {app},
@@ -44,7 +45,7 @@ Notifications::Notifications(DisplayApp* app,
     if (notification.category == Controllers::NotificationManager::Categories::IncomingCall) {
       motorController.StartRinging();
     } else {
-      motorController.RunForDuration(35);
+      motorController.RunForDuration(static_cast<uint8_t>(settingsController.GetNotifVibration()));
     }
 
     timeoutLine = lv_line_create(lv_scr_act(), nullptr);

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -25,6 +25,7 @@ namespace Pinetime {
                                Pinetime::Controllers::NotificationManager& notificationManager,
                                Pinetime::Controllers::AlertNotificationService& alertNotificationService,
                                Pinetime::Controllers::MotorController& motorController,
+                               Pinetime::Controllers::Settings& settingsController,
                                System::SystemTask& systemTask,
                                Modes mode);
         ~Notifications() override;

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.h
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.h
@@ -9,6 +9,7 @@
 #include "displayapp/screens/Screen.h"
 #include "components/datetime/DateTimeController.h"
 #include "components/ble/BleController.h"
+#include "components/ble/SimpleWeatherService.h"
 #include "utility/DirtyValue.h"
 #include "displayapp/apps/Apps.h"
 
@@ -34,10 +35,19 @@ namespace Pinetime {
                                  Controllers::Settings& settingsController,
                                  Controllers::HeartRateController& heartRateController,
                                  Controllers::MotionController& motionController,
-                                 Controllers::FS& filesystem);
+                                 Controllers::FS& filesystem,
+                                 Controllers::SimpleWeatherService& weather);
         ~WatchFaceCasioStyleG7710() override;
 
+        bool OnTouchEvent(TouchEvents event) override;
+        bool OnButtonPushed() override;
+
+        void UpdateSelected(lv_obj_t* object, lv_event_t event);
+
         void Refresh() override;
+
+        void UpdateWeatherPosition();
+        void DrawWeather();
 
         static bool IsAvailable(Pinetime::Controllers::FS& filesystem);
 
@@ -52,6 +62,9 @@ namespace Pinetime {
         Utility::DirtyValue<bool> heartbeatRunning {};
         Utility::DirtyValue<bool> notificationState {};
         Utility::DirtyValue<std::chrono::time_point<std::chrono::system_clock, std::chrono::days>> currentDate;
+        Utility::DirtyValue<std::optional<Pinetime::Controllers::SimpleWeatherService::CurrentWeather>> currentWeather {};
+
+        uint32_t savedTick = 0;
 
         lv_point_t line_icons_points[3] {{0, 5}, {117, 5}, {122, 0}};
         lv_point_t line_day_of_week_number_points[4] {{0, 0}, {100, 0}, {95, 95}, {0, 95}};
@@ -84,6 +97,12 @@ namespace Pinetime {
         lv_obj_t* stepValue;
         lv_obj_t* notificationIcon;
         lv_obj_t* line_icons;
+        lv_obj_t* btnWeather;
+        lv_obj_t* btnSegment;
+        lv_obj_t* btnClose;
+        lv_obj_t* weatherIcon;
+        lv_obj_t* label_temperature;
+        lv_obj_t* label_temperature_segment;
 
         BatteryIcon batteryIcon;
 
@@ -94,11 +113,17 @@ namespace Pinetime {
         Controllers::Settings& settingsController;
         Controllers::HeartRateController& heartRateController;
         Controllers::MotionController& motionController;
+        Controllers::SimpleWeatherService& weatherService;
 
         lv_task_t* taskRefresh;
         lv_font_t* font_dot40 = nullptr;
         lv_font_t* font_segment40 = nullptr;
         lv_font_t* font_segment115 = nullptr;
+        lv_font_t* font_teko_light = nullptr;
+
+        void CloseMenu();
+        void HandleWeatherButton();
+        void HandleSegmentButton();
       };
     }
 
@@ -115,7 +140,8 @@ namespace Pinetime {
                                                      controllers.settingsController,
                                                      controllers.heartRateController,
                                                      controllers.motionController,
-                                                     controllers.filesystem);
+                                                     controllers.filesystem,
+                                                     *controllers.weatherController);
       };
 
       static bool IsAvailable(Pinetime::Controllers::FS& filesystem) {

--- a/src/displayapp/screens/settings/SettingChimeVibration.cpp
+++ b/src/displayapp/screens/settings/SettingChimeVibration.cpp
@@ -45,10 +45,8 @@ namespace {
   }
 }
 
-SettingChimeVibration::SettingChimeVibration(
-  Pinetime::Controllers::Settings& settingsController,
-  Pinetime::Controllers::MotorController& motorController
-)
+SettingChimeVibration::SettingChimeVibration(Pinetime::Controllers::Settings& settingsController,
+                                             Pinetime::Controllers::MotorController& motorController)
   : checkboxList(
       0,
       1,

--- a/src/displayapp/screens/settings/SettingChimeVibration.cpp
+++ b/src/displayapp/screens/settings/SettingChimeVibration.cpp
@@ -1,0 +1,70 @@
+#include "displayapp/screens/settings/SettingChimeVibration.h"
+
+#include <lvgl/lvgl.h>
+
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Styles.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  struct Option {
+    Pinetime::Controllers::Settings::VibrationStrength vibrationStrength;
+    const char* name;
+  };
+
+  constexpr std::array<Option, 3> options = {{
+    {Pinetime::Controllers::Settings::VibrationStrength::Weak, "Weak"},
+    {Pinetime::Controllers::Settings::VibrationStrength::Normal, "Normal"},
+    {Pinetime::Controllers::Settings::VibrationStrength::Strong, "Strong"},
+  }};
+
+  std::array<CheckboxList::Item, CheckboxList::MaxItems> CreateOptionArray() {
+    std::array<Pinetime::Applications::Screens::CheckboxList::Item, CheckboxList::MaxItems> optionArray;
+    for (size_t i = 0; i < CheckboxList::MaxItems; i++) {
+      if (i >= options.size()) {
+        optionArray[i].name = "";
+        optionArray[i].enabled = false;
+      } else {
+        optionArray[i].name = options[i].name;
+        optionArray[i].enabled = true;
+      }
+    }
+    return optionArray;
+  }
+
+  uint32_t GetDefaultOption(Pinetime::Controllers::Settings::VibrationStrength currentOption) {
+    for (size_t i = 0; i < options.size(); i++) {
+      if (options[i].vibrationStrength == currentOption) {
+        return i;
+      }
+    }
+    return 0;
+  }
+}
+
+SettingChimeVibration::SettingChimeVibration(
+  Pinetime::Controllers::Settings& settingsController,
+  Pinetime::Controllers::MotorController& motorController
+)
+  : checkboxList(
+      0,
+      1,
+      "Chime strength",
+      Symbols::tachometer,
+      GetDefaultOption(settingsController.GetChimeVibration()),
+      [&settings = settingsController, &motor = motorController](uint32_t index) {
+        // Preview current setting
+        motor.RunForDuration(static_cast<uint8_t>(options[index].vibrationStrength));
+
+        settings.SetChimeVibration(options[index].vibrationStrength);
+        settings.SaveSettings();
+      },
+      CreateOptionArray()) {
+}
+
+SettingChimeVibration::~SettingChimeVibration() {
+  lv_obj_clean(lv_scr_act());
+}

--- a/src/displayapp/screens/settings/SettingChimeVibration.h
+++ b/src/displayapp/screens/settings/SettingChimeVibration.h
@@ -16,10 +16,8 @@ namespace Pinetime {
 
       class SettingChimeVibration : public Screen {
       public:
-        explicit SettingChimeVibration(
-          Pinetime::Controllers::Settings& settingsController,
-          Pinetime::Controllers::MotorController& motorController
-        );
+        explicit SettingChimeVibration(Pinetime::Controllers::Settings& settingsController,
+                                       Pinetime::Controllers::MotorController& motorController);
         ~SettingChimeVibration() override;
 
       private:

--- a/src/displayapp/screens/settings/SettingChimeVibration.h
+++ b/src/displayapp/screens/settings/SettingChimeVibration.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <lvgl/lvgl.h>
+
+#include "components/settings/Settings.h"
+#include "components/motor/MotorController.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/CheckboxList.h"
+
+namespace Pinetime {
+
+  namespace Applications {
+    namespace Screens {
+
+      class SettingChimeVibration : public Screen {
+      public:
+        explicit SettingChimeVibration(
+          Pinetime::Controllers::Settings& settingsController,
+          Pinetime::Controllers::MotorController& motorController
+        );
+        ~SettingChimeVibration() override;
+
+      private:
+        CheckboxList checkboxList;
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingNotifVibration.cpp
+++ b/src/displayapp/screens/settings/SettingNotifVibration.cpp
@@ -1,0 +1,69 @@
+#include "displayapp/screens/settings/SettingNotifVibration.h"
+
+#include <lvgl/lvgl.h>
+
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Styles.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  struct Option {
+    Pinetime::Controllers::Settings::VibrationStrength vibrationStrength;
+    const char* name;
+  };
+
+  constexpr std::array<Option, 3> options = {{
+    {Pinetime::Controllers::Settings::VibrationStrength::Weak, "Weak"},
+    {Pinetime::Controllers::Settings::VibrationStrength::Normal, "Normal"},
+    {Pinetime::Controllers::Settings::VibrationStrength::Strong, "Strong"},
+  }};
+
+  std::array<CheckboxList::Item, CheckboxList::MaxItems> CreateOptionArray() {
+    std::array<Pinetime::Applications::Screens::CheckboxList::Item, CheckboxList::MaxItems> optionArray;
+    for (size_t i = 0; i < CheckboxList::MaxItems; i++) {
+      if (i >= options.size()) {
+        optionArray[i].name = "";
+        optionArray[i].enabled = false;
+      } else {
+        optionArray[i].name = options[i].name;
+        optionArray[i].enabled = true;
+      }
+    }
+    return optionArray;
+  }
+
+  uint32_t GetDefaultOption(Pinetime::Controllers::Settings::VibrationStrength currentOption) {
+    for (size_t i = 0; i < options.size(); i++) {
+      if (options[i].vibrationStrength == currentOption) {
+        return i;
+      }
+    }
+    return 0;
+  }
+}
+
+SettingNotifVibration::SettingNotifVibration(
+  Pinetime::Controllers::Settings& settingsController,
+  Pinetime::Controllers::MotorController& motorController
+)
+  : checkboxList(
+      0,
+      1,
+      "Notif. strength",
+      Symbols::tachometer,
+      GetDefaultOption(settingsController.GetNotifVibration()),
+      [&settings = settingsController, &motor = motorController](uint32_t index) {
+        motor.RunForDuration(static_cast<uint8_t>(options[index].vibrationStrength));
+
+        settings.SetNotifVibration(options[index].vibrationStrength);
+        settings.SaveSettings();
+      },
+      CreateOptionArray()) {
+}
+
+SettingNotifVibration::~SettingNotifVibration() {
+  lv_obj_clean(lv_scr_act());
+}

--- a/src/displayapp/screens/settings/SettingNotifVibration.cpp
+++ b/src/displayapp/screens/settings/SettingNotifVibration.cpp
@@ -45,10 +45,8 @@ namespace {
   }
 }
 
-SettingNotifVibration::SettingNotifVibration(
-  Pinetime::Controllers::Settings& settingsController,
-  Pinetime::Controllers::MotorController& motorController
-)
+SettingNotifVibration::SettingNotifVibration(Pinetime::Controllers::Settings& settingsController,
+                                             Pinetime::Controllers::MotorController& motorController)
   : checkboxList(
       0,
       1,

--- a/src/displayapp/screens/settings/SettingNotifVibration.h
+++ b/src/displayapp/screens/settings/SettingNotifVibration.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <lvgl/lvgl.h>
+
+#include "components/settings/Settings.h"
+#include "components/motor/MotorController.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/CheckboxList.h"
+
+namespace Pinetime {
+
+  namespace Applications {
+    namespace Screens {
+
+      class SettingNotifVibration : public Screen {
+      public:
+        explicit SettingNotifVibration(
+          Pinetime::Controllers::Settings& settingsController,
+          Pinetime::Controllers::MotorController& motorController
+        );
+        ~SettingNotifVibration() override;
+
+      private:
+        CheckboxList checkboxList;
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingNotifVibration.h
+++ b/src/displayapp/screens/settings/SettingNotifVibration.h
@@ -16,10 +16,8 @@ namespace Pinetime {
 
       class SettingNotifVibration : public Screen {
       public:
-        explicit SettingNotifVibration(
-          Pinetime::Controllers::Settings& settingsController,
-          Pinetime::Controllers::MotorController& motorController
-        );
+        explicit SettingNotifVibration(Pinetime::Controllers::Settings& settingsController,
+                                       Pinetime::Controllers::MotorController& motorController);
         ~SettingNotifVibration() override;
 
       private:

--- a/src/displayapp/screens/settings/Settings.h
+++ b/src/displayapp/screens/settings/Settings.h
@@ -43,8 +43,8 @@ namespace Pinetime {
           {Symbols::batteryHalf, "Battery", Apps::BatteryInfo},
 
           {Symbols::clock, "Chimes", Apps::SettingChimes},
-          {Symbols::none, "Chime strength", Apps::SettingChimeVibration},
-          {Symbols::none, "Notif. str.", Apps::SettingNotifVibration},
+          {Symbols::tachometer, "Notif. str.", Apps::SettingNotifVibration},
+          {Symbols::tachometer, "Chime strength", Apps::SettingChimeVibration},
           {Symbols::tachometer, "Shake Calib.", Apps::SettingShakeThreshold},
 
           {Symbols::check, "Firmware", Apps::FirmwareValidation},

--- a/src/displayapp/screens/settings/Settings.h
+++ b/src/displayapp/screens/settings/Settings.h
@@ -43,10 +43,12 @@ namespace Pinetime {
           {Symbols::batteryHalf, "Battery", Apps::BatteryInfo},
 
           {Symbols::clock, "Chimes", Apps::SettingChimes},
+          {Symbols::none, "Chime strength", Apps::SettingChimeVibration},
+          {Symbols::none, "Notif. str.", Apps::SettingNotifVibration},
           {Symbols::tachometer, "Shake Calib.", Apps::SettingShakeThreshold},
+
           {Symbols::check, "Firmware", Apps::FirmwareValidation},
           {Symbols::bluetooth, "Bluetooth", Apps::SettingBluetooth},
-
           {Symbols::list, "About", Apps::SysInfo},
 
           // {Symbols::none, "None", Apps::None},

--- a/src/libs/lv_conf.h
+++ b/src/libs/lv_conf.h
@@ -415,6 +415,7 @@ typedef void* lv_indev_drv_user_data_t;            /*Type of user data in the in
 
 #define LV_FONT_CUSTOM_DECLARE LV_FONT_DECLARE(jetbrains_mono_bold_20) \
                                LV_FONT_DECLARE(jetbrains_mono_extrabold_compressed) \
+                               LV_FONT_DECLARE(jetbrains_mono_16) \
                                LV_FONT_DECLARE(jetbrains_mono_42) \
                                LV_FONT_DECLARE(jetbrains_mono_76) \
                                LV_FONT_DECLARE(open_sans_light) \
@@ -538,7 +539,7 @@ typedef void* lv_font_user_data_t;
 #define lv_snprintf     snprintf
 #define lv_vsnprintf    vsnprintf
 #else   /*!LV_SPRINTF_CUSTOM*/
-#define LV_SPRINTF_DISABLE_FLOAT 1
+#define LV_SPRINTF_DISABLE_FLOAT 0
 #endif  /*LV_SPRINTF_CUSTOM*/
 
 /*===================

--- a/src/resources/fonts.json
+++ b/src/resources/fonts.json
@@ -39,7 +39,7 @@
       "sources": [
          {
             "file": "fonts/7segment.woff",
-            "symbols": "0123456789: -"
+            "symbols": "0123456789: -°CF"
          }
       ],
       "bpp": 1,


### PR DESCRIPTION
This pr adds 2 new settings, one for notification and one for the hour/half hour chime vibration strengh.

Also previews the selected strength when you exit the menu. I'd prefer for this to happen when you select an option, but I couldn't figure out how to do that.

The only way I could think of how to get this to work was by changing the time the vibration motor is activated. With the values I gave them, there's a pretty pronounced difference between the lowest and highest setting, without it starting to feel like a long vibration.

Could use some suggestions on icons to use for the settings as I haven't added any yet.