### PR TITLE
Notification -> Notifications

### DIFF
--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -246,8 +246,8 @@ namespace {
 
 Notifications::NotificationItem::NotificationItem(Pinetime::Controllers::AlertNotificationService& alertNotificationService,
                                                   Pinetime::Controllers::MotorController& motorController)
-  : NotificationItem("Notification",
-                     "No notification to display",
+  : NotificationItem("Notifications",
+                     "No notifications to display",
                      0,
                      Controllers::NotificationManager::Categories::Unknown,
                      0,


### PR DESCRIPTION
This PR is a small change and it might very well be up to preference.


In the little notifications screen above the watchface, the "Notification" as well as "No notifications to display" is now changed to "Notification**s**" and "No notification**s** to display".

In my opinion using the plural makes more sense here, since the screen can show more than just one notification.
Feel free to tell me what you think!


Here's a pic of how it looks like in InfiniEmu:
![Screenshot_2025-01-27_17-21-01](https://github.com/user-attachments/assets/ac7f8209-1395-47b4-8bfd-4b3fee329c10)
