### PR TITLE
add date format setting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -408,6 +408,8 @@ list(APPEND SOURCE_FILES
         displayapp/screens/settings/Settings.cpp
         displayapp/screens/settings/SettingWatchFace.cpp
         displayapp/screens/settings/SettingTimeFormat.cpp
+        displayapp/screens/settings/SettingClockFormat.cpp
+        displayapp/screens/settings/SettingDateFormat.cpp
         displayapp/screens/settings/SettingWeatherFormat.cpp
         displayapp/screens/settings/SettingWakeUp.cpp
         displayapp/screens/settings/SettingDisplay.cpp

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -10,6 +10,7 @@ namespace Pinetime {
     class Settings {
     public:
       enum class ClockType : uint8_t { H24, H12 };
+      enum class DateFormat : uint8_t { YYYYMMDD, DDMMYYYY, MMDDYYYY, DayDDMonthYYYY };
       enum class WeatherFormat : uint8_t { Metric, Imperial };
       enum class Notification : uint8_t { On, Off, Sleep };
       enum class ChimesOption : uint8_t { None, Hours, HalfHours };
@@ -181,6 +182,17 @@ namespace Pinetime {
         return settings.clockType;
       };
 
+      void SetDateFormat(DateFormat dateFormat) {
+        if (dateFormat != settings.dateFormat) {
+          settingsChanged = true;
+        }
+        settings.dateFormat = dateFormat;
+      };
+
+      DateFormat GetDateFormat() const {
+        return settings.dateFormat;
+      };
+
       void SetWeatherFormat(WeatherFormat weatherFormat) {
         if (weatherFormat != settings.weatherFormat) {
           settingsChanged = true;
@@ -311,6 +323,7 @@ namespace Pinetime {
         bool alwaysOnDisplay = false;
 
         ClockType clockType = ClockType::H24;
+        DateFormat dateFormat = DateFormat::DayDDMonthYYYY;
         WeatherFormat weatherFormat = WeatherFormat::Metric;
         Notification notificationStatus = Notification::On;
 

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -597,7 +597,7 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
       currentScreen = std::make_unique<Screens::SettingWatchFace>(this, std::move(items), settingsController, filesystem);
     } break;
     case Apps::SettingTimeFormat:
-      currentScreen = std::make_unique<Screens::SettingTimeFormat>(settingsController);
+      currentScreen = std::make_unique<Screens::SettingTimeFormat>(this, settingsController);
       break;
     case Apps::SettingWeatherFormat:
       currentScreen = std::make_unique<Screens::SettingWeatherFormat>(settingsController);

--- a/src/displayapp/screens/settings/SettingClockFormat.cpp
+++ b/src/displayapp/screens/settings/SettingClockFormat.cpp
@@ -1,0 +1,61 @@
+#include "displayapp/screens/settings/SettingClockFormat.h"
+#include <lvgl/lvgl.h>
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Styles.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  struct ClockOption {
+    Pinetime::Controllers::Settings::ClockType clockType;
+    const char* name;
+  };
+
+  constexpr std::array<ClockOption, 2> clockOptions = {{
+    {Pinetime::Controllers::Settings::ClockType::H12, "12-hour"},
+    {Pinetime::Controllers::Settings::ClockType::H24, "24-hour"},
+  }};
+
+  std::array<CheckboxList::Item, CheckboxList::MaxItems> CreateClockOptionArray() {
+    std::array<Pinetime::Applications::Screens::CheckboxList::Item, CheckboxList::MaxItems> clockOptionArray;
+    for (size_t i = 0; i < CheckboxList::MaxItems; i++) {
+      if (i >= clockOptions.size()) {
+        clockOptionArray[i].name = "";
+        clockOptionArray[i].enabled = false;
+      } else {
+        clockOptionArray[i].name = clockOptions[i].name;
+        clockOptionArray[i].enabled = true;
+      }
+    }
+    return clockOptionArray;
+  }
+
+  uint32_t GetDefaultClockOption(Pinetime::Controllers::Settings::ClockType currentOption) {
+    for (size_t i = 0; i < clockOptions.size(); i++) {
+      if (clockOptions[i].clockType == currentOption) {
+        return i;
+      }
+    }
+    return 0;
+  }
+}
+
+SettingClockFormat::SettingClockFormat(Pinetime::Controllers::Settings& settingsController)
+  : clockCheckboxList(
+      0,
+      1,
+      "Time format",
+      Symbols::clock,
+      GetDefaultClockOption(settingsController.GetClockType()),
+      [&settings = settingsController](uint32_t index) {
+        settings.SetClockType(clockOptions[index].clockType);
+        settings.SaveSettings();
+      },
+      CreateClockOptionArray()) {
+}
+
+SettingClockFormat::~SettingClockFormat() {
+  lv_obj_clean(lv_scr_act());
+}

--- a/src/displayapp/screens/settings/SettingClockFormat.h
+++ b/src/displayapp/screens/settings/SettingClockFormat.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <lvgl/lvgl.h>
+
+#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/CheckboxList.h"
+
+namespace Pinetime {
+  namespace Applications {
+    namespace Screens {
+      class SettingClockFormat : public Screen {
+      public:
+        SettingClockFormat(Pinetime::Controllers::Settings& settingsController);
+        ~SettingClockFormat() override;
+
+      private:
+        CheckboxList clockCheckboxList;
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingDateFormat.cpp
+++ b/src/displayapp/screens/settings/SettingDateFormat.cpp
@@ -1,0 +1,63 @@
+#include "displayapp/screens/settings/SettingDateFormat.h"
+#include <lvgl/lvgl.h>
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Styles.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  struct DateOption {
+    Pinetime::Controllers::Settings::DateFormat dateFormat;
+    const char* name;
+  };
+
+  constexpr std::array<DateOption, 4> dateOptions = {{
+    {Pinetime::Controllers::Settings::DateFormat::YYYYMMDD, "yyyy-mm-dd"},
+    {Pinetime::Controllers::Settings::DateFormat::DDMMYYYY, "dd/mm/yyyy"},
+    {Pinetime::Controllers::Settings::DateFormat::MMDDYYYY, "mm/dd/yyyy"},
+    {Pinetime::Controllers::Settings::DateFormat::DayDDMonthYYYY, "Day DD Month YYYY"},
+  }};
+
+  std::array<CheckboxList::Item, CheckboxList::MaxItems> CreateDateOptionArray() {
+    std::array<Pinetime::Applications::Screens::CheckboxList::Item, CheckboxList::MaxItems> dateOptionArray;
+    for (size_t i = 0; i < CheckboxList::MaxItems; i++) {
+      if (i >= dateOptions.size()) {
+        dateOptionArray[i].name = "";
+        dateOptionArray[i].enabled = false;
+      } else {
+        dateOptionArray[i].name = dateOptions[i].name;
+        dateOptionArray[i].enabled = true;
+      }
+    }
+    return dateOptionArray;
+  }
+
+  uint32_t GetDefaultDateOption(Pinetime::Controllers::Settings::DateFormat currentOption) {
+    for (size_t i = 0; i < dateOptions.size(); i++) {
+      if (dateOptions[i].dateFormat == currentOption) {
+        return i;
+      }
+    }
+    return 0;
+  }
+}
+
+SettingDateFormat::SettingDateFormat(Pinetime::Controllers::Settings& settingsController)
+  : dateCheckboxList(
+      0,
+      1,
+      "Date format",
+      Symbols::clock,
+      GetDefaultDateOption(settingsController.GetDateFormat()),
+      [&settings = settingsController](uint32_t index) {
+        settings.SetDateFormat(dateOptions[index].dateFormat);
+        settings.SaveSettings();
+      },
+      CreateDateOptionArray()) {
+}
+
+SettingDateFormat::~SettingDateFormat() {
+  lv_obj_clean(lv_scr_act());
+}

--- a/src/displayapp/screens/settings/SettingDateFormat.h
+++ b/src/displayapp/screens/settings/SettingDateFormat.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <lvgl/lvgl.h>
+
+#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/CheckboxList.h"
+
+namespace Pinetime {
+  namespace Applications {
+    namespace Screens {
+      class SettingDateFormat : public Screen {
+      public:
+        SettingDateFormat(Pinetime::Controllers::Settings& settingsController);
+        ~SettingDateFormat() override;
+
+      private:
+        CheckboxList dateCheckboxList;
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/SettingTimeFormat.cpp
+++ b/src/displayapp/screens/settings/SettingTimeFormat.cpp
@@ -1,61 +1,44 @@
 #include "displayapp/screens/settings/SettingTimeFormat.h"
-#include <lvgl/lvgl.h>
+#include "displayapp/screens/settings/SettingClockFormat.h"
+#include "displayapp/screens/settings/SettingDateFormat.h"
 #include "displayapp/DisplayApp.h"
-#include "displayapp/screens/Styles.h"
-#include "displayapp/screens/Screen.h"
-#include "displayapp/screens/Symbols.h"
+#include "displayapp/screens/ScreenList.h"
+#include "components/settings/Settings.h"
+#include "displayapp/widgets/DotIndicator.h"
 
 using namespace Pinetime::Applications::Screens;
 
-namespace {
-  struct Option {
-    Pinetime::Controllers::Settings::ClockType clockType;
-    const char* name;
-  };
-
-  constexpr std::array<Option, 2> options = {{
-    {Pinetime::Controllers::Settings::ClockType::H12, "12-hour"},
-    {Pinetime::Controllers::Settings::ClockType::H24, "24-hour"},
-  }};
-
-  std::array<CheckboxList::Item, CheckboxList::MaxItems> CreateOptionArray() {
-    std::array<Pinetime::Applications::Screens::CheckboxList::Item, CheckboxList::MaxItems> optionArray;
-    for (size_t i = 0; i < CheckboxList::MaxItems; i++) {
-      if (i >= options.size()) {
-        optionArray[i].name = "";
-        optionArray[i].enabled = false;
-      } else {
-        optionArray[i].name = options[i].name;
-        optionArray[i].enabled = true;
-      }
-    }
-    return optionArray;
-  }
-
-  uint32_t GetDefaultOption(Pinetime::Controllers::Settings::ClockType currentOption) {
-    for (size_t i = 0; i < options.size(); i++) {
-      if (options[i].clockType == currentOption) {
-        return i;
-      }
-    }
-    return 0;
-  }
+bool SettingTimeFormat::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
+  return screens.OnTouchEvent(event);
 }
 
-SettingTimeFormat::SettingTimeFormat(Pinetime::Controllers::Settings& settingsController)
-  : checkboxList(
-      0,
-      1,
-      "Time format",
-      Symbols::clock,
-      GetDefaultOption(settingsController.GetClockType()),
-      [&settings = settingsController](uint32_t index) {
-        settings.SetClockType(options[index].clockType);
-        settings.SaveSettings();
-      },
-      CreateOptionArray()) {
+SettingTimeFormat::SettingTimeFormat(Pinetime::Applications::DisplayApp* app,
+                                     Pinetime::Controllers::Settings& settingsController)
+  : settingsController {settingsController},
+    screens {app,
+             0,
+             {[this]() -> std::unique_ptr<Screen> {
+                return screenClockFormat();
+              },
+              [this]() -> std::unique_ptr<Screen> {
+                return screenDateFormat();
+              }},
+             Screens::ScreenListModes::UpDown} {
+}
+
+std::unique_ptr<Screen> SettingTimeFormat::screenDateFormat() {
+  Widgets::DotIndicator dotIndicator(1, 2);
+  dotIndicator.Create();
+  return std::make_unique<Screens::SettingDateFormat>(settingsController);
+}
+
+std::unique_ptr<Screen> SettingTimeFormat::screenClockFormat() {
+  Widgets::DotIndicator dotIndicator(0, 2);
+  dotIndicator.Create();
+  return std::make_unique<Screens::SettingClockFormat>(settingsController);
 }
 
 SettingTimeFormat::~SettingTimeFormat() {
   lv_obj_clean(lv_scr_act());
 }
+

--- a/src/displayapp/screens/settings/SettingTimeFormat.h
+++ b/src/displayapp/screens/settings/SettingTimeFormat.h
@@ -1,25 +1,27 @@
 #pragma once
 
-#include <array>
 #include <cstdint>
 #include <lvgl/lvgl.h>
-
-#include "components/settings/Settings.h"
 #include "displayapp/screens/Screen.h"
-#include "displayapp/screens/CheckboxList.h"
+#include "displayapp/screens/ScreenList.h"
 
 namespace Pinetime {
-
   namespace Applications {
     namespace Screens {
-
       class SettingTimeFormat : public Screen {
       public:
-        SettingTimeFormat(Pinetime::Controllers::Settings& settingsController);
+        SettingTimeFormat(DisplayApp* app,
+                           Pinetime::Controllers::Settings& settingsController);
         ~SettingTimeFormat() override;
 
+        bool OnTouchEvent(TouchEvents event) override;
+
       private:
-        CheckboxList checkboxList;
+        Controllers::Settings& settingsController;
+
+        ScreenList<2> screens;
+        std::unique_ptr<Screen> screenDateFormat();
+        std::unique_ptr<Screen> screenClockFormat();
       };
     }
   }


### PR DESCRIPTION
Add an option for Date format user preference so the watchfaces could use it to display the date.
I put it as a second screen of the Time format setting.

A minor issue still present is that the option "Day DD Month YYYY" go off the screen. Unfortunately, the checkboxes don't have long mode like labels do. I'm open to suggestions to fix this issue.