### PR TITLE
Allow resetting timer more than once without starting it

### DIFF
--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -151,6 +151,7 @@ void Timer::ToggleRunning() {
 }
 
 void Timer::Reset() {
-  DisplayTime();
+  minuteCounter.SetValue(0);
+  secondCounter.SetValue(0);
   SetTimerStopped();
 }


### PR DESCRIPTION
Previously the timer only allows resetting the hour and minute values right when the app opens, and after the timer has ran once.

![broken_reset_button](https://github.com/user-attachments/assets/ce30bace-83ff-402c-986a-b853bd607d62)

My fix just ignores whatever `DisplayTime()` would return, setting the minute and second value to 0 instead. There may be a better approach that someone could suggest below, otherwise this one works fine.

![reset_fixed](https://github.com/user-attachments/assets/d6f64890-75cf-48de-9c2d-56fcd74bb968)
