### PR TITLE
Improved StopWatch UI (iOS-inspired)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,171 @@
+# GitHub Actions Workflow to build FreeRTOS Firmware for PineTime Smart Watch
+# See https://lupyuen.github.io/pinetime-rust-mynewt/articles/cloud
+# Based on https://github.com/JF002/Pinetime/blob/master/doc/buildAndProgram.md
+# and https://github.com/JF002/Pinetime/blob/master/bootloader/README.md
+
+# Name of this Workflow
+name: Build PineTime Firmware
+
+# When to run this Workflow...
+on:
+
+  # Run this Workflow when files are updated (Pushed) in the "master" Branch
+  push:
+    branches: [ master ]
+    
+  # Also run this Workflow when a Pull Request is created or updated in the "master" Branch
+  pull_request:
+    branches: [ master ]
+
+# Steps to run for the Workflow
+jobs:
+  build:
+
+    # Run these steps on Ubuntu
+    runs-on: ubuntu-latest
+
+    steps:
+        
+    #########################################################################################
+    # Download and Cache Dependencies
+
+    - name: Install cmake
+      uses: lukka/get-cmake@v3.18.0
+
+    - name: Check cache for Embedded Arm Toolchain arm-none-eabi-gcc
+      id:   cache-toolchain
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-toolchain-9-2020-q2
+      with:
+        path: ${{ runner.temp }}/arm-none-eabi
+        key:  ${{ runner.os }}-build-${{ env.cache-name }}
+        restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}
+
+    - name: Install Embedded Arm Toolchain arm-none-eabi-gcc
+      if:   steps.cache-toolchain.outputs.cache-hit != 'true'  # Install toolchain if not found in cache
+      uses: fiam/arm-none-eabi-gcc@v1.0.2
+      with:
+        # GNU Embedded Toolchain for Arm release name, in the V-YYYY-qZ format (e.g. "9-2019-q4")
+        release: 9-2020-q2
+        # Directory to unpack GCC to. Defaults to a temporary directory.
+        directory: ${{ runner.temp }}/arm-none-eabi
+
+    - name: Check cache for nRF5 SDK
+      id:   cache-nrf5sdk
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-nrf5sdk
+      with:
+        path: ${{ runner.temp }}/nrf5_sdk
+        key:  ${{ runner.os }}-build-${{ env.cache-name }}
+        restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}
+          
+    - name: Install nRF5 SDK
+      if:   steps.cache-nrf5sdk.outputs.cache-hit != 'true'  # Install SDK if not found in cache
+      run:  |
+        cd ${{ runner.temp }}
+        curl https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip -o nrf5_sdk.zip
+        unzip nrf5_sdk.zip
+        mv nRF5_SDK_15.3.0_59ac345 nrf5_sdk
+
+    - name: Check cache for MCUBoot
+      id:   cache-mcuboot
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-mcuboot
+      with:
+        path: ${{ runner.temp }}/mcuboot
+        key:  ${{ runner.os }}-build-${{ env.cache-name }}
+        restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}
+
+    - name: Install MCUBoot
+      if:   steps.cache-mcuboot.outputs.cache-hit != 'true'  # Install MCUBoot if not found in cache
+      run:  |
+        cd ${{ runner.temp }}
+        git clone --branch v1.5.0 https://github.com/JuulLabs-OSS/mcuboot
+
+    - name: Install imgtool dependencies
+      run:  pip3 install --user -r ${{ runner.temp }}/mcuboot/scripts/requirements.txt
+
+    - name: Install adafruit-nrfutil
+      run:  |
+        pip3 install --user wheel
+        pip3 install --user setuptools
+        pip3 install --user adafruit-nrfutil
+        
+    #########################################################################################
+    # Checkout
+      
+    - name: Checkout source files
+      uses: actions/checkout@v2
+
+    - name: Show files
+      run:  set ; pwd ; ls -l
+
+    #########################################################################################
+    # CMake
+
+    - name: CMake
+      run:  |
+        mkdir -p build
+        cd build
+        cmake -DARM_NONE_EABI_TOOLCHAIN_PATH=${{ runner.temp }}/arm-none-eabi -DNRF5_SDK_PATH=${{ runner.temp }}/nrf5_sdk -DUSE_OPENOCD=1 ../
+      
+    #########################################################################################
+    # Make and Upload DFU Package
+    # pinetime-mcuboot-app.img must be flashed at address 0x8000 in the internal flash memory with OpenOCD:
+    # program image.bin 0x8000
+      
+    # For Debugging Builds: Remove "make" option "-j" for clearer output. Add "--trace" to see details.
+    # For Faster Builds: Add "make" option "-j"
+      
+    - name: Make pinetime-mcuboot-app
+      run:  |
+        cd build
+        make pinetime-mcuboot-app
+
+    - name: Create firmware image
+      run:  |
+        # The generated firmware binary looks like "pinetime-mcuboot-app-0.8.2.bin"
+        ls -l build/src/pinetime-mcuboot-app*.bin
+        ${{ runner.temp }}/mcuboot/scripts/imgtool.py create --align 4 --version 1.0.0 --header-size 32 --slot-size 475136 --pad-header build/src/pinetime-mcuboot-app*.bin build/src/pinetime-mcuboot-app-img.bin
+        ${{ runner.temp }}/mcuboot/scripts/imgtool.py verify build/src/pinetime-mcuboot-app-img.bin
+
+    - name: Create DFU package
+      run:  |
+        ~/.local/bin/adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application build/src/pinetime-mcuboot-app-img.bin build/src/pinetime-mcuboot-app-dfu.zip
+        unzip -v build/src/pinetime-mcuboot-app-dfu.zip
+        # Unzip the package because Upload Artifact will zip up the files
+        unzip build/src/pinetime-mcuboot-app-dfu.zip -d build/src/pinetime-mcuboot-app-dfu
+
+    - name: Upload DFU package
+      uses: actions/upload-artifact@v2
+      with:
+        name: pinetime-mcuboot-app-dfu.zip
+        path: build/src/pinetime-mcuboot-app-dfu/*
+
+    #########################################################################################
+    # Make and Upload Standalone Firmware
+      
+    - name: Make pinetime-app
+      run:  |
+        cd build
+        make pinetime-app
+
+    - name: Upload standalone firmware
+      uses: actions/upload-artifact@v2
+      with:
+        name: pinetime-app.out
+        path: build/src/pinetime-app*.out
+
+    #########################################################################################
+    # Finish
+
+    - name: Find output
+      run:  |
+        find . -name "pinetime-app.*" -ls
+        find . -name "pinetime-mcuboot-app.*" -ls
+      
+# Embedded Arm Toolchain and nRF5 SDK will only be cached if the build succeeds.
+# So make sure that the first build always succeeds, e.g. comment out the "Make" step.

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -61,17 +61,23 @@ StopWatch::StopWatch(System::SystemTask& systemTask) : wakeLock(systemTask) {
   lv_obj_set_width(lapText, LV_HOR_RES_MAX);
   lv_obj_align(lapText, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, -btnHeight);
 
-  msecTime = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_text_static(msecTime, "00");
-  lv_obj_set_style_local_text_color(msecTime, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  // Position msecTime above the colon
-  lv_obj_align(msecTime, time, LV_ALIGN_CENTER, 0, -38);  // Adjust -38 based on actual font size
-
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
   lv_label_set_text_static(time, "00:00");
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  lv_obj_align(time, msecTime, LV_ALIGN_OUT_TOP_MID, 0, 0);
+  lv_obj_align(time, nullptr, LV_ALIGN_CENTER, 0, -20);
+
+  // Calculate position for msecTime
+  lv_coord_t fontHeight = lv_font_get_line_height(&jetbrains_mono_76);
+  // Position above the colon (which is after 2 digits)
+  int16_t horizontalOffset = lv_obj_get_width(time) / 4;  // Approximate position of colon
+  int16_t verticalOffset = -fontHeight;  // Position fully above the time
+
+  msecTime = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_text_static(msecTime, "00");
+  lv_obj_set_style_local_text_color(msecTime, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
+  // Align relative to time, but offset to colon position
+  lv_obj_align(msecTime, time, LV_ALIGN_CENTER, horizontalOffset, verticalOffset);
 
   SetInterfaceStopped();
 

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -37,7 +37,7 @@ namespace {
 StopWatch::StopWatch(System::SystemTask& systemTask) : wakeLock(systemTask) {
   static constexpr uint8_t btnWidth = 115;
   static constexpr uint8_t btnHeight = 80;
-  static constexpr uint8_t lapLineHeight = 27;
+  static constexpr uint8_t lapLineHeight = 30;
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
   btnPlayPause->user_data = this;
   lv_obj_set_event_cb(btnPlayPause, play_pause_event_handler);
@@ -66,12 +66,12 @@ StopWatch::StopWatch(System::SystemTask& systemTask) : wakeLock(systemTask) {
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
   lv_label_set_text_static(time, "00:00");
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 2);
+  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 5);
 
   msecTime = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_static(msecTime, "00");
   lv_obj_set_style_local_text_color(msecTime, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  lv_obj_align(msecTime, time, LV_ALIGN_IN_TOP_MID, 0, -1);
+  lv_obj_align(msecTime, time, LV_ALIGN_IN_TOP_MID, 0, -3);
 
   SetInterfaceStopped();
 

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -70,7 +70,7 @@ StopWatch::StopWatch(System::SystemTask& systemTask) : wakeLock(systemTask) {
   msecTime = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_static(msecTime, "00");
   lv_obj_set_style_local_text_color(msecTime, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  lv_obj_align(msecTime, time, LV_ALIGN_TOP_MID, 0, 0);
+  lv_obj_align(msecTime, time, LV_ALIGN_IN_TOP_MID, 0, 0);
 
   SetInterfaceStopped();
 

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -65,19 +65,12 @@ StopWatch::StopWatch(System::SystemTask& systemTask) : wakeLock(systemTask) {
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
   lv_label_set_text_static(time, "00:00");
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  lv_obj_align(time, nullptr, LV_ALIGN_CENTER, 0, -20);
-
-  // Calculate position for msecTime
-  lv_coord_t fontHeight = lv_font_get_line_height(&jetbrains_mono_76);
-  // Position above the colon (which is after 2 digits)
-  int16_t horizontalOffset = lv_obj_get_width(time) / 4;  // Approximate position of colon
-  int16_t verticalOffset = -fontHeight;  // Position fully above the time
+  lv_obj_align(time, lapText, LV_ALIGN_OUT_TOP_MID, 0, 0);
 
   msecTime = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_static(msecTime, "00");
   lv_obj_set_style_local_text_color(msecTime, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  // Align relative to time, but offset to colon position
-  lv_obj_align(msecTime, time, LV_ALIGN_CENTER, horizontalOffset, verticalOffset);
+  lv_obj_align(msecTime, time, LV_ALIGN_TOP_MID, 0, 0);
 
   SetInterfaceStopped();
 

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -37,7 +37,7 @@ namespace {
 StopWatch::StopWatch(System::SystemTask& systemTask) : wakeLock(systemTask) {
   static constexpr uint8_t btnWidth = 115;
   static constexpr uint8_t btnHeight = 80;
-  static constexpr uint8_t lapLineHeight = 25;
+  static constexpr uint8_t lapLineHeight = 27;
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
   btnPlayPause->user_data = this;
   lv_obj_set_event_cb(btnPlayPause, play_pause_event_handler);
@@ -66,7 +66,7 @@ StopWatch::StopWatch(System::SystemTask& systemTask) : wakeLock(systemTask) {
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
   lv_label_set_text_static(time, "00:00");
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 0);
+  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 2);
 
   msecTime = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_static(msecTime, "00");

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -191,12 +191,15 @@ void StopWatch::stopLapBtnEventHandler() {
   if (currentState == States::Running) {
     lv_label_set_text(lapText, "");
     lapsDone = std::min(lapsDone + 1, maxLapCount);
+    TickType_t lastLapTime = 0;
     for (int i = lapsDone - displayedLaps; i < lapsDone; i++) {
       if (i < 0) {
         lv_label_ins_text(lapText, LV_LABEL_POS_LAST, "\n");
         continue;
       }
-      TimeSeparated_t times = convertTicksToTimeSegments(laps[i]);
+      TickType_t lapDuration = laps[i] - lastLapTime;
+      lastLapTime = laps[i];
+      TimeSeparated_t times = convertTicksToTimeSegments(lapDuration);
       char buffer[17];
       if (times.hours == 0) {
         snprintf(buffer, sizeof(buffer), "#%2d    %2d:%02d.%02d\n", i + 1, times.mins, times.secs, times.hundredths);

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -147,7 +147,7 @@ void StopWatch::Start() {
 
 void StopWatch::updateLapDisplay() {
   std::string displayText;
-  displayText.reserve(maxLapCount * charactersPerLapEntry);
+  displayText.reserve(maxLapCount * 20);
 
   std::array<char, 32> buffer{};
 

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -66,7 +66,7 @@ StopWatch::StopWatch(System::SystemTask& systemTask) : wakeLock(systemTask) {
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
   lv_label_set_text_static(time, "00:00");
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 5);
+  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 10);
 
   msecTime = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_static(msecTime, "00");

--- a/src/displayapp/screens/StopWatch.cpp
+++ b/src/displayapp/screens/StopWatch.cpp
@@ -37,6 +37,7 @@ namespace {
 StopWatch::StopWatch(System::SystemTask& systemTask) : wakeLock(systemTask) {
   static constexpr uint8_t btnWidth = 115;
   static constexpr uint8_t btnHeight = 80;
+  static constexpr uint8_t lapLineHeight = 25;
   btnPlayPause = lv_btn_create(lv_scr_act(), nullptr);
   btnPlayPause->user_data = this;
   lv_obj_set_event_cb(btnPlayPause, play_pause_event_handler);
@@ -59,18 +60,18 @@ StopWatch::StopWatch(System::SystemTask& systemTask) : wakeLock(systemTask) {
   lv_label_set_long_mode(lapText, LV_LABEL_LONG_BREAK);
   lv_label_set_align(lapText, LV_LABEL_ALIGN_CENTER);
   lv_obj_set_width(lapText, LV_HOR_RES_MAX);
-  lv_obj_align(lapText, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, -btnHeight);
+  lv_obj_align(lapText, lv_scr_act(), LV_ALIGN_IN_BOTTOM_MID, 0, -(btnHeight + lapLineHeight));
 
   time = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(time, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
   lv_label_set_text_static(time, "00:00");
   lv_obj_set_style_local_text_color(time, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  lv_obj_align(time, lapText, LV_ALIGN_OUT_TOP_MID, 0, 0);
+  lv_obj_align(time, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 0);
 
   msecTime = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_text_static(msecTime, "00");
   lv_obj_set_style_local_text_color(msecTime, LV_LABEL_PART_MAIN, LV_STATE_DISABLED, Colors::lightGray);
-  lv_obj_align(msecTime, time, LV_ALIGN_IN_TOP_MID, 0, 0);
+  lv_obj_align(msecTime, time, LV_ALIGN_IN_TOP_MID, 0, -1);
 
   SetInterfaceStopped();
 

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -36,6 +36,7 @@ namespace Pinetime {
         bool OnButtonPushed() override;
 
       private:
+        void updateLapDisplay();
         void SetInterfacePaused();
         void SetInterfaceRunning();
         void SetInterfaceStopped();

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -52,7 +52,7 @@ namespace Pinetime {
         TickType_t blinkTime = 0;
         static constexpr int maxLapCount = 20;
         TickType_t laps[maxLapCount + 1];
-        static constexpr int displayedLaps = 2;
+        static constexpr int displayedLaps = 3;
         int lapsDone = 0;
         lv_obj_t *time, *msecTime, *btnPlayPause, *btnStopLap, *txtPlayPause, *txtStopLap;
         lv_obj_t* lapText;


### PR DESCRIPTION
Lap times used to be cumulative, instead of starting at 0 for each lap (which is more useful imo). I changed lap time behaviour so that 1) lap 1 starts counting as the stopwatch is started 2) final lap times are now the duration of the lap instead of the end point in "absolute time". I also changed the UI to be more clear: "#1" became "Lap 1". I moved the millisecond indicator to the top of the colon to make space for a third lap. This way the UI provides more information than before (2 laps only) without feeling crowded. 

![IMG_6977](https://github.com/user-attachments/assets/0da85bae-e956-4b11-b2bb-81d01f0582b7)