### PR TITLE
Show shake calibration being disabled when in sleep mode

### DIFF
--- a/src/displayapp/screens/settings/SettingShakeThreshold.cpp
+++ b/src/displayapp/screens/settings/SettingShakeThreshold.cpp
@@ -24,6 +24,19 @@ SettingShakeThreshold::SettingShakeThreshold(Controllers::Settings& settingsCont
   lv_label_set_align(title, LV_LABEL_ALIGN_CENTER);
   lv_obj_align(title, lv_scr_act(), LV_ALIGN_IN_TOP_MID, 0, 0);
 
+  if (settingsController.GetNotificationStatus() == Controllers::Settings::Notification::Sleep) {
+    lv_obj_t* explanation = lv_label_create(lv_scr_act(), nullptr);
+    lv_label_set_long_mode(explanation, LV_LABEL_LONG_BREAK);
+    lv_label_set_align(explanation, LV_LABEL_ALIGN_AUTO);
+    lv_obj_set_width(explanation, LV_HOR_RES_MAX);
+    lv_label_set_text_static(
+      explanation,
+      "\nShake detector is disabled in sleep mode, and will neither wake up the watch nor calibrate.\nDisable sleep mode to calibrate.");
+    calibrating = 255;
+    lv_obj_align(explanation, title, LV_ALIGN_OUT_BOTTOM_MID, 0, 0);
+    return;
+  }
+
   positionArc = lv_arc_create(lv_scr_act(), nullptr);
   positionArc->user_data = this;
 
@@ -72,6 +85,9 @@ SettingShakeThreshold::SettingShakeThreshold(Controllers::Settings& settingsCont
 }
 
 SettingShakeThreshold::~SettingShakeThreshold() {
+  if (calibrating == 255)
+    return;
+
   settingsController.SetShakeThreshold(lv_arc_get_value(positionArc));
 
   if (EnableForCal) {

--- a/src/displayapp/screens/settings/SettingShakeThreshold.h
+++ b/src/displayapp/screens/settings/SettingShakeThreshold.h
@@ -2,10 +2,15 @@
 
 #include <cstdint>
 #include <lvgl/lvgl.h>
-#include "components/settings/Settings.h"
 #include "displayapp/screens/Screen.h"
-#include <components/motion/MotionController.h>
-#include "systemtask/SystemTask.h"
+
+namespace Pinetime::Controllers {
+  class Settings;
+  class MotionController;
+}
+namespace Pinetime::System {
+  class SystemTask;
+}
 
 namespace Pinetime {
 
@@ -26,11 +31,20 @@ namespace Pinetime {
         Controllers::Settings& settingsController;
         Controllers::MotionController& motionController;
         System::SystemTask& systemTask;
-        uint8_t calibrating;
-        bool EnableForCal;
-        uint32_t vDecay, vCalTime;
-        lv_obj_t *positionArc, *animArc, *calButton, *calLabel;
-        lv_task_t* refreshTask;
+
+        enum class CalibrationStep {
+          NotCalibrated = 0,
+          GettingReady = 1,
+          Calibrating = 2,
+          // Special case for disabled calibration due to sleep mode
+          Disabled = 255,
+        };
+
+        CalibrationStep currentCalibrationStep = CalibrationStep::NotCalibrated;
+        bool oldWakeupModeShake = false;
+        uint32_t vDecay = 0, vCalTime = 0;
+        lv_obj_t *positionArc = nullptr, *animArc = nullptr, *calButton = nullptr, *calLabel = nullptr;
+        lv_task_t* refreshTask = nullptr;
       };
     }
   }


### PR DESCRIPTION
I was confused by the issue with the shake calibration on my PineTime for which a partial fix exists in https://github.com/InfiniTimeOrg/InfiniTime/pull/2161 (thank you lmamane). I adopted those changes and made the demanded enum refactor as well as fix an issue with the text not disappearing when leaving the shake calibration screen.

Here is a screenshot of the new disabled message:
![InfiniSim_2025-03-12_203033](https://github.com/user-attachments/assets/bb926a57-d00e-4aec-969a-954d5dade90b)

All changes are:
- Switch from bool EnableForCal to always saving and restoring shake wake mode to avoid to many conditionals in the constructor and destructor
- Refactor calibrating into currentCalibrationStepEnum with descriptive names
- Initialize variables with default values in the class body
- Switch to forward declarations for references in the header and remove unused include
- Fix issue where text would stay on screen due to not calling lv_obj_clean() in the destructor