### PR TITLE
Fix nrf sdk download links

### DIFF
--- a/doc/buildAndProgram.md
+++ b/doc/buildAndProgram.md
@@ -5,7 +5,7 @@
 To build this project, you'll need:
 
 - A cross-compiler : [ARM-GCC (10.3-2021.10)](https://developer.arm.com/downloads/-/gnu-rm)
-- The NRF52 SDK 15.3.0 : [nRF-SDK v15.3.0](https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip)
+- The NRF52 SDK 15.3.0 : [nRF-SDK v15.3.0](https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/sdks/nrf5/binaries/nrf5sdk153059ac345.zip)
 - The Python 3 modules `cbor`, `intelhex`, `click` and `cryptography` modules for the `mcuboot` tool (see [requirements.txt](../tools/mcuboot/requirements.txt))
   - To keep the system clean, you can install python modules into a python virtual environment (`venv`)
     ```sh

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -17,7 +17,7 @@ export npm_config_cache="${NPM_DIR}"
 
 export BUILD_TYPE=${BUILD_TYPE:=Release}
 export GCC_ARM_VER=${GCC_ARM_VER:="10.3-2021.10"}
-export NRF_SDK_VER=${NRF_SDK_VER:="nRF5_SDK_15.3.0_59ac345"}
+export NRF_SDK_VER=${NRF_SDK_VER:="nrf5sdk153059ac345"}
 
 MACHINE="$(uname -m)"
 [ "$MACHINE" = "arm64" ] && MACHINE="aarch64"
@@ -55,7 +55,7 @@ GetMcuBoot() {
 }
 
 GetNrfSdk() {
-  wget -q "https://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/$NRF_SDK_VER.zip" -O /tmp/$NRF_SDK_VER
+  wget -q "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/sdks/nrf5/binaries/$NRF_SDK_VER.zip" -O /tmp/$NRF_SDK_VER
   unzip -q /tmp/$NRF_SDK_VER -d "$TOOLS_DIR/"
   rm /tmp/$NRF_SDK_VER
 }


### PR DESCRIPTION
It appears that NRF has moved the download to a new location. The old URL is now a 404. 
Update the build script and README to use the same URL the download website currently provides.

Fixes #2267 
