### PR TITLE
MotionService: Fix step notification on sleep

### DIFF
--- a/src/components/ble/MotionService.cpp
+++ b/src/components/ble/MotionService.cpp
@@ -121,6 +121,6 @@ void MotionService::UnsubscribeNotification(uint16_t attributeHandle) {
     motionValuesNoficationEnabled = false;
 }
 
-bool MotionService::IsMotionNotificationSubscribed() const {
-  return motionValuesNoficationEnabled;
+bool MotionService::IsAnyNotificationSubscribed() const {
+  return stepCountNoficationEnabled || motionValuesNoficationEnabled;
 }

--- a/src/components/ble/MotionService.h
+++ b/src/components/ble/MotionService.h
@@ -21,7 +21,7 @@ namespace Pinetime {
 
       void SubscribeNotification(uint16_t attributeHandle);
       void UnsubscribeNotification(uint16_t attributeHandle);
-      bool IsMotionNotificationSubscribed() const;
+      bool IsAnyNotificationSubscribed() const;
 
     private:
       NimbleController& nimble;

--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -434,7 +434,7 @@ void SystemTask::UpdateMotion() {
   // AOD needs motion on to show up to date step counts
   if (state == SystemTaskState::Sleeping && !(settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::RaiseWrist) ||
                                               settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::Shake) ||
-                                              motionController.GetService()->IsMotionNotificationSubscribed())) {
+                                              motionController.GetService()->IsAnyNotificationSubscribed())) {
     return;
   }
 


### PR DESCRIPTION
When using BLE notifications for motion it seams that the code enabels the sending of each motion even in sleep mode.

Using BLE notifications for steps should work the same.

I don't know how much this would use the battery, but i think it could not be more than with motion notification.