### PR TITLE
notifications: only show notification count if there's notifications

### DIFF
--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -282,7 +282,11 @@ Notifications::NotificationItem::NotificationItem(const char* title,
   lv_cont_set_fit(subject_container, LV_FIT_NONE);
 
   lv_obj_t* alert_count = lv_label_create(container, nullptr);
-  lv_label_set_text_fmt(alert_count, "%i/%i", notifNr, notifNb);
+  if (notifNr == 0) {
+    lv_label_set_text_fmt(alert_count, "", notifNr, notifNb);
+  } else {
+    lv_label_set_text_fmt(alert_count, "%i/%i", notifNr, notifNb);
+  }
   lv_obj_align(alert_count, nullptr, LV_ALIGN_IN_TOP_RIGHT, 0, 16);
 
   lv_obj_t* alert_type = lv_label_create(container, nullptr);


### PR DESCRIPTION
This is a small change, making the notification counter only show if there's 1 or more notification.
Screenshots:
![image](https://github.com/user-attachments/assets/bcf5c798-cd3f-49fb-a9ce-9f82b01b8aa6)
![image](https://github.com/user-attachments/assets/03e59ffc-6c57-4262-9731-589804e7153a)
