### PR TITLE
Fix about screen vertical centering.

### DIFF
--- a/src/displayapp/screens/SystemInfo.cpp
+++ b/src/displayapp/screens/SystemInfo.cpp
@@ -198,7 +198,7 @@ std::unique_ptr<Screen> SystemInfo::CreateScreen3() {
                         " #808080 Free# %d/%d\n"
                         " #808080 Min free# %d\n"
                         " #808080 Alloc err# %d\n"
-                        " #808080 Ovrfl err# %d\n",
+                        " #808080 Ovrfl err# %d",
                         bleAddr[5],
                         bleAddr[4],
                         bleAddr[3],


### PR DESCRIPTION
There was a newline at the end of the last line on the third screen, which was causing the label to not be centered vertically. Removing it fixes the centering.

Here are some before and after screenshots for clarity.

![InfiniSim_2025-03-23_055820](https://github.com/user-attachments/assets/eebf4cea-0013-4399-98d7-b9148239f78a)
![InfiniSim_2025-03-23_055918](https://github.com/user-attachments/assets/c1744567-d5c6-4686-b393-143341555cf5)

Thank You!