### PR TITLE
Fixes the short ref not being set in Github builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,9 @@ jobs:
           apt-get -y install --no-install-recommends python3-pil
       - name: Build
         shell: bash
-        run: /opt/build.sh all
+        run: |
+          git config --global --add safe.directory /__w/InfiniTime/InfiniTime
+          /opt/build.sh all
       - name: Output build size
         id: output-sizes
         run: |


### PR DESCRIPTION
Fixes the `PROJECT_GIT_COMMIT_HASH` not getting set in Github builds.

Previously, the step that should get the short ref using git failed:

```
fatal: detected dubious ownership in repository at '/__w/InfiniTime/InfiniTime'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/InfiniTime/InfiniTime
```

The checkout action is supposed to do that already, but for some reason it's not working:

```
Adding repository directory to the temporary git global config as a safe directory
/usr/bin/git config --global --add safe.directory /__w/InfiniTime/InfiniTime
```

It looks like this is an issue more people are facing, but for some reason the issue is closed: https://github.com/actions/checkout/issues/1048

The proposed fix of setting the user wasn't working, so I'm just manually adding the cloned repository as safe. 