### PR TITLE
docker: fix NRF_SDK download and subsequent build.sh

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -32,20 +32,8 @@ main() {
   mkdir -p "$TOOLS_DIR"
 
   [ ! -d "$TOOLS_DIR/$GCC_ARM_PATH" ] && GetGcc
-  if [ ! -d "$TOOLS_DIR/$GCC_ARM_PATH" ]; then
-    echo "missing GCC path: $TOOLS_DIR/$GCC_ARM_PATH"
-    return 1
-  fi
   [ ! -d "$TOOLS_DIR/$NRF_SDK_VER" ] && GetNrfSdk
-  if [ ! -d "$TOOLS_DIR/$NRF_SDK_VER" ]; then
-    echo "missing NRF_SDK path: $TOOLS_DIR/$NRF_SDK_VER"
-    return 1
-  fi
   [ ! -d "$TOOLS_DIR/mcuboot" ] && GetMcuBoot
-  if [ ! -d "$TOOLS_DIR/mcuboot" ]; then
-    echo "missing mcuboot path: $TOOLS_DIR/mcuboot"
-    return 1
-  fi
 
   mkdir -p "$BUILD_DIR"
 
@@ -61,17 +49,29 @@ main() {
 
 GetGcc() {
   wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/$GCC_ARM_VER/$GCC_ARM_PATH-$MACHINE-linux.tar.bz2 -O - | tar -xj -C $TOOLS_DIR/
+  if [ ! -d "$TOOLS_DIR/$GCC_ARM_PATH" ]; then
+    echo "missing GCC path: $TOOLS_DIR/$GCC_ARM_PATH"
+    return 1
+  fi
 }
 
 GetMcuBoot() {
   git clone https://github.com/mcu-tools/mcuboot.git "$TOOLS_DIR/mcuboot"
   pip3 install -r "$TOOLS_DIR/mcuboot/scripts/requirements.txt"
+  if [ ! -d "$TOOLS_DIR/mcuboot" ]; then
+    echo "missing mcuboot path: $TOOLS_DIR/mcuboot"
+    return 1
+  fi
 }
 
 GetNrfSdk() {
   wget -q "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/sdks/nrf5/binaries/$NRF_SDK_VER_SLUG.zip" -O /tmp/$NRF_SDK_VER
   unzip -q /tmp/$NRF_SDK_VER -d "$TOOLS_DIR/"
   rm /tmp/$NRF_SDK_VER
+  if [ ! -d "$TOOLS_DIR/$NRF_SDK_VER" ]; then
+    echo "missing NRF_SDK path: $TOOLS_DIR/$NRF_SDK_VER"
+    return 1
+  fi
 }
 
 CmakeGenerate() {

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -19,6 +19,8 @@ export BUILD_TYPE=${BUILD_TYPE:=Release}
 export GCC_ARM_VER=${GCC_ARM_VER:="10.3-2021.10"}
 export NRF_SDK_VER=${NRF_SDK_VER:="nRF5_SDK_15.3.0_59ac345"}
 # convert to lower case and remove _ and . character
+# convert to lower case and remove _ and . character
+# the download URL uses the SLUG, but the extracted folder is named like the original value
 NRF_SDK_VER_SLUG=${NRF_SDK_VER,,}
 export NRF_SDK_VER_SLUG=${NRF_SDK_VER_SLUG//[_.]/}
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -18,6 +18,7 @@ export npm_config_cache="${NPM_DIR}"
 export BUILD_TYPE=${BUILD_TYPE:=Release}
 export GCC_ARM_VER=${GCC_ARM_VER:="10.3-2021.10"}
 export NRF_SDK_VER=${NRF_SDK_VER:="nRF5_SDK_15.3.0_59ac345"}
+# convert to lower case and remove _ and . character
 NRF_SDK_VER_SLUG=${NRF_SDK_VER,,}
 export NRF_SDK_VER_SLUG=${NRF_SDK_VER_SLUG//[_.]/}
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -19,7 +19,6 @@ export BUILD_TYPE=${BUILD_TYPE:=Release}
 export GCC_ARM_VER=${GCC_ARM_VER:="10.3-2021.10"}
 export NRF_SDK_VER=${NRF_SDK_VER:="nRF5_SDK_15.3.0_59ac345"}
 # convert to lower case and remove _ and . character
-# convert to lower case and remove _ and . character
 # the download URL uses the SLUG, but the extracted folder is named like the original value
 NRF_SDK_VER_SLUG=${NRF_SDK_VER,,}
 export NRF_SDK_VER_SLUG=${NRF_SDK_VER_SLUG//[_.]/}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -17,7 +17,9 @@ export npm_config_cache="${NPM_DIR}"
 
 export BUILD_TYPE=${BUILD_TYPE:=Release}
 export GCC_ARM_VER=${GCC_ARM_VER:="10.3-2021.10"}
-export NRF_SDK_VER=${NRF_SDK_VER:="nrf5sdk153059ac345"}
+export NRF_SDK_VER=${NRF_SDK_VER:="nRF5_SDK_15.3.0_59ac345"}
+NRF_SDK_VER_SLUG=${NRF_SDK_VER,,}
+export NRF_SDK_VER_SLUG=${NRF_SDK_VER_SLUG//[_.]/}
 
 MACHINE="$(uname -m)"
 [ "$MACHINE" = "arm64" ] && MACHINE="aarch64"
@@ -30,8 +32,20 @@ main() {
   mkdir -p "$TOOLS_DIR"
 
   [ ! -d "$TOOLS_DIR/$GCC_ARM_PATH" ] && GetGcc
+  if [ ! -d "$TOOLS_DIR/$GCC_ARM_PATH" ]; then
+    echo "missing GCC path: $TOOLS_DIR/$GCC_ARM_PATH"
+    return 1
+  fi
   [ ! -d "$TOOLS_DIR/$NRF_SDK_VER" ] && GetNrfSdk
+  if [ ! -d "$TOOLS_DIR/$NRF_SDK_VER" ]; then
+    echo "missing NRF_SDK path: $TOOLS_DIR/$NRF_SDK_VER"
+    return 1
+  fi
   [ ! -d "$TOOLS_DIR/mcuboot" ] && GetMcuBoot
+  if [ ! -d "$TOOLS_DIR/mcuboot" ]; then
+    echo "missing mcuboot path: $TOOLS_DIR/mcuboot"
+    return 1
+  fi
 
   mkdir -p "$BUILD_DIR"
 
@@ -55,7 +69,7 @@ GetMcuBoot() {
 }
 
 GetNrfSdk() {
-  wget -q "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/sdks/nrf5/binaries/$NRF_SDK_VER.zip" -O /tmp/$NRF_SDK_VER
+  wget -q "https://nsscprodmedia.blob.core.windows.net/prod/software-and-other-downloads/sdks/nrf5/binaries/$NRF_SDK_VER_SLUG.zip" -O /tmp/$NRF_SDK_VER
   unzip -q /tmp/$NRF_SDK_VER -d "$TOOLS_DIR/"
   rm /tmp/$NRF_SDK_VER
 }


### PR DESCRIPTION
The upstream NRF-SDK download url and zip archive filename changed, which was fixed with https://github.com/InfiniTimeOrg/InfiniTime/pull/2270

But the archive contents stayed the same, with the "old" folder name.

After #2270 we have basically the same docker-container as before the PR, but the `GetNrfSdk` function of the `build.sh` script is called again during firmware build time as the expected foldername for the SDK isn't the same as the zip filename:

```sh
[ ! -d "$TOOLS_DIR/$NRF_SDK_VER" ] && GetNrfSdk
```

Then during the build the `buils.sh` script tries to execute `GetNrfSdk` again, which fails as the files already exist resulting in the following error:

```
replace /opt/nRF5_SDK_15.3.0_59ac345/components/802_15_4/api/HAL/hal_atomic.h? [y]es, [n]o, [A]ll, [N]one, [r]ename:  NULL
```

Fix this by reverting the `NRF_SDK_VER` to the folder name in the zip archive and by some character replacement generate the download URL from the above (the download is in lower-case without the `_` and `.` characters).

Furthermore add safeguards to check after the `GetNrfSdk` call if the expected folder is really created. Then we have an error early during container image creation if the contents of the zip-archive are unexpected.