### PR TITLE
navigation: fix greying out the app icon if not enabled

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -517,8 +517,8 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
   switch (app) {
     case Apps::Launcher: {
       std::array<Screens::Tile::Applications, UserAppTypes::Count> apps;
-      std::ranges::transform(userApps, apps.begin(), [](const auto& userApp) {
-        return Screens::Tile::Applications {userApp.icon, userApp.app, true};
+      std::ranges::transform(userApps, apps.begin(), [this](const auto& userApp) {
+        return Screens::Tile::Applications {userApp.icon, userApp.app, userApp.isAvailable(controllers.filesystem)};
       });
       currentScreen = std::make_unique<Screens::ApplicationList>(this,
                                                                  settingsController,

--- a/src/displayapp/UserApps.h
+++ b/src/displayapp/UserApps.h
@@ -26,6 +26,7 @@ namespace Pinetime {
       Apps app;
       const char* icon;
       Screens::Screen* (*create)(AppControllers& controllers);
+      bool (*isAvailable)(Controllers::FS& fileSystem);
     };
 
     struct WatchFaceDescription {
@@ -37,7 +38,7 @@ namespace Pinetime {
 
     template <Apps t>
     consteval AppDescription CreateAppDescription() {
-      return {AppTraits<t>::app, AppTraits<t>::icon, &AppTraits<t>::Create};
+      return {AppTraits<t>::app, AppTraits<t>::icon, &AppTraits<t>::Create, &AppTraits<t>::IsAvailable};
     }
 
     template <WatchFace t>

--- a/src/displayapp/screens/Alarm.h
+++ b/src/displayapp/screens/Alarm.h
@@ -78,6 +78,10 @@ namespace Pinetime {
                                   *controllers.systemTask,
                                   controllers.motorController);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/Calculator.h
+++ b/src/displayapp/screens/Calculator.h
@@ -78,6 +78,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& /* controllers */) {
         return new Screens::Calculator();
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/Dice.h
+++ b/src/displayapp/screens/Dice.h
@@ -56,6 +56,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& controllers) {
         return new Screens::Dice(controllers.motionController, controllers.motorController, controllers.settingsController);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/HeartRate.h
+++ b/src/displayapp/screens/HeartRate.h
@@ -48,6 +48,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& controllers) {
         return new Screens::HeartRate(controllers.heartRateController, *controllers.systemTask);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/InfiniPaint.h
+++ b/src/displayapp/screens/InfiniPaint.h
@@ -47,6 +47,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& controllers) {
         return new Screens::InfiniPaint(controllers.lvgl, controllers.motorController);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/Metronome.h
+++ b/src/displayapp/screens/Metronome.h
@@ -47,6 +47,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& controllers) {
         return new Screens::Metronome(controllers.motorController, *controllers.systemTask);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/Motion.h
+++ b/src/displayapp/screens/Motion.h
@@ -41,6 +41,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& controllers) {
         return new Screens::Motion(controllers.motionController);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/Music.h
+++ b/src/displayapp/screens/Music.h
@@ -94,6 +94,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& controllers) {
         return new Screens::Music(*controllers.musicService);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/Navigation.h
+++ b/src/displayapp/screens/Navigation.h
@@ -67,6 +67,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& controllers) {
         return new Screens::Navigation(*controllers.navigationService);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& filesystem) {
+        return Screens::Navigation::IsAvailable(filesystem);
+      };
     };
   }
 }

--- a/src/displayapp/screens/Paddle.h
+++ b/src/displayapp/screens/Paddle.h
@@ -57,6 +57,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& controllers) {
         return new Screens::Paddle(controllers.lvgl);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/Steps.h
+++ b/src/displayapp/screens/Steps.h
@@ -51,6 +51,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& controllers) {
         return new Screens::Steps(controllers.motionController, controllers.settingsController);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/StopWatch.h
+++ b/src/displayapp/screens/StopWatch.h
@@ -69,6 +69,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& controllers) {
         return new Screens::StopWatch(*controllers.systemTask);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -56,5 +56,9 @@ namespace Pinetime::Applications {
     static Screens::Screen* Create(AppControllers& controllers) {
       return new Screens::Timer(controllers.timer);
     };
+
+    static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+      return true;
+    };
   };
 }

--- a/src/displayapp/screens/Twos.h
+++ b/src/displayapp/screens/Twos.h
@@ -45,6 +45,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& /*controllers*/) {
         return new Screens::Twos();
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }

--- a/src/displayapp/screens/Weather.h
+++ b/src/displayapp/screens/Weather.h
@@ -51,6 +51,10 @@ namespace Pinetime {
       static Screens::Screen* Create(AppControllers& controllers) {
         return new Screens::Weather(controllers.settingsController, *controllers.weatherController);
       };
+
+      static bool IsAvailable(Pinetime::Controllers::FS& /*filesystem*/) {
+        return true;
+      };
     };
   }
 }


### PR DESCRIPTION
Commit 0aead42fdf51 ("navigation: Add is available (#1847)") added the ability to draw the app icon in grey and in a disabled state when some prerequisits were not met. Only the Navigation app was using this mechanism due to its icons being stored in the external memory and possibly missing.

Commit 63e0c4f4efb0 ("Application selection at build time") broke this by always setting the state as true:
      for (const auto& userApp : userApps) {
        apps[i++] = Screens::Tile::Applications {userApp.icon, userApp.app, true};
      }

Fix this by creating an isAvailable() strcuture in the app classes, similar
to how the Watchfaces handle the same problem of checking availability.