### PR TITLE
navigation: Unset the narrative text when the icon changes

### DIFF
--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -245,6 +245,11 @@ void Navigation::Refresh() {
     lv_obj_set_style_local_image_recolor_opa(imgFlag, LV_IMG_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_COVER);
     lv_obj_set_style_local_image_recolor(imgFlag, LV_IMG_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_CYAN);
     lv_img_set_offset_y(imgFlag, image.offset);
+
+    // Unset the narrative when the flag changes
+    // OSMand updates the flag way before the next narrative announcement
+    // so often, the old narrative accompanies a now mismatched new flag
+    lv_label_set_text(txtNarrative, "");
   }
 
   if (narrative != navService.getNarrative()) {


### PR DESCRIPTION
Navigation narrative commonly comes only at specific intervals and at least OSMand does update the direction icon and countdown-distance way earlier.

This can lead to situations when the old narrative is displayed to a mismatched direction icon.

So after the icon changes, assume the narrative is not applicable anymore.

The flag-update in the code also happens before possibly updating the narrative, so if a new narrative text is send within the same update, this will happen just normally.