### PR TITLE
Navigation style updates

### DIFF
--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -202,14 +202,6 @@ Navigation::Navigation(Pinetime::Controllers::NavigationService& nav) : navServi
   lv_obj_set_style_local_image_recolor(imgFlag, LV_IMG_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_CYAN);
   lv_obj_align(imgFlag, nullptr, LV_ALIGN_IN_TOP_MID, 0, 2);
 
-  txtNarrative = lv_label_create(lv_scr_act(), nullptr);
-  lv_label_set_long_mode(txtNarrative, LV_LABEL_LONG_DOT);
-  lv_obj_set_width(txtNarrative, LV_HOR_RES);
-  lv_obj_set_height(txtNarrative, 80);
-  lv_label_set_text_static(txtNarrative, "Navigation");
-  lv_label_set_align(txtNarrative, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(txtNarrative, nullptr, LV_ALIGN_CENTER, 0, 30);
-
   txtManDist = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtManDist, LV_LABEL_LONG_BREAK);
   lv_obj_set_style_local_text_color(txtManDist, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
@@ -217,7 +209,7 @@ Navigation::Navigation(Pinetime::Controllers::NavigationService& nav) : navServi
   lv_obj_set_width(txtManDist, LV_HOR_RES);
   lv_label_set_text_static(txtManDist, "--M");
   lv_label_set_align(txtManDist, LV_LABEL_ALIGN_CENTER);
-  lv_obj_align(txtManDist, nullptr, LV_ALIGN_CENTER, 0, 90);
+  lv_obj_align(txtManDist, imgFlag, LV_ALIGN_OUT_BOTTOM_MID, 0, 2);
 
   // Route Progress
   barProgress = lv_bar_create(lv_scr_act(), nullptr);
@@ -228,6 +220,16 @@ Navigation::Navigation(Pinetime::Controllers::NavigationService& nav) : navServi
   lv_bar_set_anim_time(barProgress, 500);
   lv_bar_set_range(barProgress, 0, 100);
   lv_bar_set_value(barProgress, 0, LV_ANIM_OFF);
+
+  txtNarrative = lv_label_create(lv_scr_act(), nullptr);
+  lv_label_set_long_mode(txtNarrative, LV_LABEL_LONG_DOT);
+  lv_obj_set_width(txtNarrative, LV_HOR_RES);
+  lv_label_set_text(txtNarrative, "Navigation");
+  lv_label_set_align(txtNarrative, LV_LABEL_ALIGN_CENTER);
+  lv_obj_align(txtNarrative, txtManDist, LV_ALIGN_OUT_BOTTOM_MID, 0, 2);
+
+  // Set Narrative-height dynamically by progress-bar-y with 2px distance added
+  lv_obj_set_height(txtNarrative, lv_obj_get_y(barProgress) - lv_obj_get_y(txtNarrative) - 2);
 
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
 }

--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -221,8 +221,8 @@ Navigation::Navigation(Pinetime::Controllers::NavigationService& nav) : navServi
 
   // Route Progress
   barProgress = lv_bar_create(lv_scr_act(), nullptr);
-  lv_obj_set_size(barProgress, 200, 20);
-  lv_obj_align(barProgress, nullptr, LV_ALIGN_IN_BOTTOM_MID, 0, -10);
+  lv_obj_set_size(barProgress, LV_HOR_RES - 4, 20);
+  lv_obj_align(barProgress, nullptr, LV_ALIGN_IN_BOTTOM_MID, 0, -2);
   lv_obj_set_style_local_bg_color(barProgress, LV_BAR_PART_BG, LV_STATE_DEFAULT, lv_color_hex(0x222222));
   lv_obj_set_style_local_bg_color(barProgress, LV_BAR_PART_INDIC, LV_STATE_DEFAULT, LV_COLOR_ORANGE);
   lv_bar_set_anim_time(barProgress, 500);

--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -200,7 +200,7 @@ Navigation::Navigation(Pinetime::Controllers::NavigationService& nav) : navServi
   lv_img_set_offset_y(imgFlag, image.offset);
   lv_obj_set_style_local_image_recolor_opa(imgFlag, LV_IMG_PART_MAIN, LV_STATE_DEFAULT, LV_OPA_COVER);
   lv_obj_set_style_local_image_recolor(imgFlag, LV_IMG_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_CYAN);
-  lv_obj_align(imgFlag, nullptr, LV_ALIGN_CENTER, 0, -60);
+  lv_obj_align(imgFlag, nullptr, LV_ALIGN_IN_TOP_MID, 0, 2);
 
   txtNarrative = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtNarrative, LV_LABEL_LONG_DOT);

--- a/src/displayapp/screens/Navigation.cpp
+++ b/src/displayapp/screens/Navigation.cpp
@@ -212,7 +212,7 @@ Navigation::Navigation(Pinetime::Controllers::NavigationService& nav) : navServi
 
   txtManDist = lv_label_create(lv_scr_act(), nullptr);
   lv_label_set_long_mode(txtManDist, LV_LABEL_LONG_BREAK);
-  lv_obj_set_style_local_text_color(txtManDist, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_GREEN);
+  lv_obj_set_style_local_text_color(txtManDist, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, LV_COLOR_YELLOW);
   lv_obj_set_style_local_text_font(txtManDist, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_42);
   lv_obj_set_width(txtManDist, LV_HOR_RES);
   lv_label_set_text_static(txtManDist, "--M");


### PR DESCRIPTION
Some updates for the navigation display coming from having a PineTime strapped to the handlebar off a motorbike and using it for navigation :-) .

* For one, dark green distance on black background is hard to read, so made it yellow
* Action-Icon and distance are the values needed at a glance and often, so having them on opposite ends of the screen makes it harder to just glance at them, so swapped distance and narrative element
* The current layout creates a lot of empty space around the elements, where the PineTime already has a black area in its frame around the display. So moved everything a bit more together, which in turn makes room for a 4th line of narrative, because sometimes the narrative OSMand provides can be a bit unwieldy :-)
* And lvgl actually provides nice layout alignment variants, so we don't need hardcode some pixel-values from the center, but can instead align elements to each other.

After the change, the display looks like:
![navigation-after-reorder](https://github.com/user-attachments/assets/889d12f4-a908-4d99-a248-c8a8ff106c6e)

Of course style is always perceived differently, so I'm of course open for suggestions.