### PR TITLE
CI: use bash for get-base-ref-size job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,6 +162,7 @@ jobs:
 
     - name: Output build size
       id: output-sizes
+      shell: bash
       run: |
         . /opt/build.sh
         .github/workflows/getSize.sh "$BUILD_DIR"/src/pinetime-app-*.out >> $GITHUB_OUTPUT


### PR DESCRIPTION
Same change as done in https://github.com/InfiniTimeOrg/InfiniTime/commit/c3295d6d2a325f9a7418b15b943342635026926e But for get-base-ref-size job

The variable substitution I introduced are bash features. So they don't work with sh.

Update the size job to use `bash` instead of `sh` as shell