### PR TITLE
Resolve paint corrupting screen scrolling

### DIFF
--- a/src/displayapp/LittleVgl.cpp
+++ b/src/displayapp/LittleVgl.cpp
@@ -149,6 +149,10 @@ void LittleVgl::SetFullRefresh(FullRefreshDirections direction) {
   fullRefresh = true;
 }
 
+bool LittleVgl::IsScrolling() {
+  return scrollDirection != LittleVgl::FullRefreshDirections::None;
+}
+
 void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
   uint16_t y1, y2, width, height = 0;
 

--- a/src/displayapp/LittleVgl.h
+++ b/src/displayapp/LittleVgl.h
@@ -27,6 +27,7 @@ namespace Pinetime {
       void SetNewTouchPoint(int16_t x, int16_t y, bool contact);
       void CancelTap();
       void ClearTouchState();
+      bool IsScrolling();
 
       bool GetFullRefresh() {
         bool returnValue = fullRefresh;

--- a/src/displayapp/screens/InfiniPaint.cpp
+++ b/src/displayapp/screens/InfiniPaint.cpp
@@ -61,12 +61,17 @@ bool InfiniPaint::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
 }
 
 bool InfiniPaint::OnTouchEvent(uint16_t x, uint16_t y) {
+  // If currently scrolling in or out of InfiniPaint, don't paint anything!
+  // Since InfiniPaint writes directly to the display bypassing LVGL, painting
+  // while scrolling is happening causes bad behaviour
+  if (lvgl.IsScrolling()) {
+    return false;
+  }
   lv_area_t area;
   area.x1 = x - (width / 2);
   area.y1 = y - (height / 2);
   area.x2 = x + (width / 2) - 1;
   area.y2 = y + (height / 2) - 1;
-  lvgl.SetFullRefresh(Components::LittleVgl::FullRefreshDirections::None);
   lvgl.FlushDisplay(&area, b);
   return true;
 }


### PR DESCRIPTION
Closes #2034

The main problem is calling FlushDisplay while scrolling causes bad behaviour