### PR TITLE
Disable legacy FreeRTOS functions

### DIFF
--- a/src/FreeRTOSConfig.h
+++ b/src/FreeRTOSConfig.h
@@ -73,7 +73,7 @@
 #define configUSE_QUEUE_SETS                    0
 #define configUSE_TIME_SLICING                  0
 #define configUSE_NEWLIB_REENTRANT              0
-#define configENABLE_BACKWARD_COMPATIBILITY     1
+#define configENABLE_BACKWARD_COMPATIBILITY     0
 #define configUSE_TASK_NOTIFICATIONS            0
 
 /* Hook function related definitions. */


### PR DESCRIPTION
We don't use any of them, so may as well turn them off