### PR TITLE
LittleFS upgrade + fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -902,6 +902,7 @@ target_compile_options(lvgl PRIVATE
 
 # LITTLEFS_SRC
 add_definitions(-DLFS_THREADSAFE)
+add_definitions(-DLFS_NAME_MAX=50)
 add_library(littlefs STATIC ${LITTLEFS_SRC})
 target_include_directories(littlefs SYSTEM PUBLIC . ../)
 target_include_directories(littlefs SYSTEM PUBLIC ${INCLUDES_FROM_LIBS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -901,6 +901,7 @@ target_compile_options(lvgl PRIVATE
         )
 
 # LITTLEFS_SRC
+add_definitions(-DLFS_THREADSAFE)
 add_library(littlefs STATIC ${LITTLEFS_SRC})
 target_include_directories(littlefs SYSTEM PUBLIC . ../)
 target_include_directories(littlefs SYSTEM PUBLIC ${INCLUDES_FROM_LIBS})

--- a/src/components/fs/FS.cpp
+++ b/src/components/fs/FS.cpp
@@ -44,6 +44,8 @@ void FS::Init() {
       return;
     }
   }
+  // Clean filesystem on boot
+  lfs_fs_gc(&lfs);
 
 #ifndef PINETIME_IS_RECOVERY
   VerifyResource();

--- a/src/components/fs/FS.cpp
+++ b/src/components/fs/FS.cpp
@@ -13,6 +13,8 @@ FS::FS(Pinetime::Drivers::SpiNorFlash& driver)
       .prog = SectorProg,
       .erase = SectorErase,
       .sync = SectorSync,
+      .lock = LockFilesystem,
+      .unlock = UnlockFilesystem,
 
       .read_size = 16,
       .prog_size = 8,
@@ -107,6 +109,16 @@ int FS::Stat(const char* path, lfs_info* info) {
 
 lfs_ssize_t FS::GetFSSize() {
   return lfs_fs_size(&lfs);
+}
+
+int FS::LockFilesystem(const struct lfs_config* c) {
+  Pinetime::Controllers::FS& lfs = *(static_cast<Pinetime::Controllers::FS*>(c->context));
+  return xSemaphoreTake(lfs.fsMutex, portMAX_DELAY) == pdTRUE ? 0 : -1;
+}
+
+int FS::UnlockFilesystem(const struct lfs_config* c) {
+  Pinetime::Controllers::FS& lfs = *(static_cast<Pinetime::Controllers::FS*>(c->context));
+  return xSemaphoreGive(lfs.fsMutex) == pdTRUE ? 0 : -1;
 }
 
 /*

--- a/src/components/fs/FS.cpp
+++ b/src/components/fs/FS.cpp
@@ -25,8 +25,9 @@ FS::FS(Pinetime::Drivers::SpiNorFlash& driver)
       .cache_size = 16,
       .lookahead_size = 16,
 
-      .name_max = 50,
+      .name_max = LFS_NAME_MAX, // Note: LFS_NAME_MAX is defined in src/CMakeLists.txt
       .attr_max = 50,
+      .metadata_max = 256,
     } {
 }
 

--- a/src/components/fs/FS.h
+++ b/src/components/fs/FS.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include "drivers/SpiNorFlash.h"
 #include <littlefs/lfs.h>
+#include <FreeRTOS.h>
+#include <semphr.h>
 
 namespace Pinetime {
   namespace Controllers {
@@ -71,12 +73,15 @@ namespace Pinetime {
       bool resourcesValid = false;
       const struct lfs_config lfsConfig;
 
+      SemaphoreHandle_t fsMutex = xSemaphoreCreateMutex();
       lfs_t lfs;
 
       static int SectorSync(const struct lfs_config* c);
       static int SectorErase(const struct lfs_config* c, lfs_block_t block);
       static int SectorProg(const struct lfs_config* c, lfs_block_t block, lfs_off_t off, const void* buffer, lfs_size_t size);
       static int SectorRead(const struct lfs_config* c, lfs_block_t block, lfs_off_t off, void* buffer, lfs_size_t size);
+      static int LockFilesystem(const struct lfs_config* c);
+      static int UnlockFilesystem(const struct lfs_config* c);
     };
   }
 }


### PR DESCRIPTION
The optimised parameters result in slightly less efficient flash usage with many small files but much better access performance. External fonts should load slightly faster after this.

After this PR, the on disk format will be updated to a newer version so loading an older version of InfiniTime will cause the flash to be reformatted

The optimised parameters require formatting the filesystem fully. I haven't included this in the PR, but we probably should? I haven't thought about how to do this in a nice way yet

This might close some issues relating to FS thread safety, but I'm not convinced it's fully fixed yet. It's definitely an improvement though - currently there is no locking at all