### PR TITLE
Initialise DisplayApp components in DisplayApp context

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -129,15 +129,6 @@ void DisplayApp::Start(System::BootErrors error) {
 
   bootError = error;
 
-  lvgl.Init();
-  motorController.Init();
-
-  if (error == System::BootErrors::TouchController) {
-    LoadNewScreen(Apps::Error, DisplayApp::FullRefreshDirections::None);
-  } else {
-    LoadNewScreen(Apps::Clock, DisplayApp::FullRefreshDirections::None);
-  }
-
   if (pdPASS != xTaskCreate(DisplayApp::Process, "displayapp", 800, this, 0, &taskHandle)) {
     APP_ERROR_HANDLER(NRF_ERROR_NO_MEM);
   }
@@ -146,17 +137,25 @@ void DisplayApp::Start(System::BootErrors error) {
 void DisplayApp::Process(void* instance) {
   auto* app = static_cast<DisplayApp*>(instance);
   NRF_LOG_INFO("displayapp task started!");
-  app->InitHw();
+  app->Init();
+
+  if (app->bootError == System::BootErrors::TouchController) {
+    app->LoadNewScreen(Apps::Error, DisplayApp::FullRefreshDirections::None);
+  } else {
+    app->LoadNewScreen(Apps::Clock, DisplayApp::FullRefreshDirections::None);
+  }
 
   while (true) {
     app->Refresh();
   }
 }
 
-void DisplayApp::InitHw() {
+void DisplayApp::Init() {
+  lcd.Init();
+  motorController.Init();
   brightnessController.Init();
   ApplyBrightness();
-  lcd.Init();
+  lvgl.Init();
 }
 
 TickType_t DisplayApp::CalculateSleepTime() {

--- a/src/displayapp/DisplayApp.h
+++ b/src/displayapp/DisplayApp.h
@@ -121,7 +121,7 @@ namespace Pinetime {
 
       TouchEvents GetGesture();
       static void Process(void* instance);
-      void InitHw();
+      void Init();
       void Refresh();
       void LoadNewScreen(Apps app, DisplayApp::FullRefreshDirections direction);
       void LoadScreen(Apps app, DisplayApp::FullRefreshDirections direction);


### PR DESCRIPTION
Loading the watchface in the SystemTask context creates a lot of stack pressure as the SystemTask stack is much smaller

This might also fix other bad behaviour that occurs with watchfaces on first load e.g as reported by feksa in the pinetime-dev channel. Not sure though, haven't looked at the exact cause