### PR TITLE
Refactor Timer component to provide expiry information

### DIFF
--- a/src/components/timer/Timer.cpp
+++ b/src/components/timer/Timer.cpp
@@ -9,18 +9,33 @@ Timer::Timer(void* const timerData, TimerCallbackFunction_t timerCallbackFunctio
 void Timer::StartTimer(std::chrono::milliseconds duration) {
   xTimerChangePeriod(timer, pdMS_TO_TICKS(duration.count()), 0);
   xTimerStart(timer, 0);
+  expiry = xTimerGetExpiryTime(timer);
+  triggered = true;
 }
 
-std::chrono::milliseconds Timer::GetTimeRemaining() {
+// nullopt if timer stopped (StopTimer called / StartTimer not yet called)
+// otherwise TimerStatus with the ticks until/since expiry (depending on state of expired flag)
+std::optional<Timer::TimerStatus> Timer::GetTimerState() {
   if (IsRunning()) {
-    TickType_t remainingTime = xTimerGetExpiryTime(timer) - xTaskGetTickCount();
-    return std::chrono::milliseconds(remainingTime * 1000 / configTICK_RATE_HZ);
+    TickType_t remainingTime = expiry - xTaskGetTickCount();
+    return std::make_optional<Timer::TimerStatus>(
+      {.distanceToExpiry = std::chrono::seconds(remainingTime / configTICK_RATE_HZ) +
+                           std::chrono::milliseconds((remainingTime % configTICK_RATE_HZ) * 1000 / configTICK_RATE_HZ),
+       .expired = false});
   }
-  return std::chrono::milliseconds(0);
+  if (triggered) {
+    TickType_t timeSinceExpiry = xTaskGetTickCount() - expiry;
+    return std::make_optional<Timer::TimerStatus>(
+      {.distanceToExpiry = std::chrono::seconds(timeSinceExpiry / configTICK_RATE_HZ) +
+                           std::chrono::milliseconds((timeSinceExpiry % configTICK_RATE_HZ) * 1000 / configTICK_RATE_HZ),
+       .expired = true});
+  }
+  return std::nullopt;
 }
 
 void Timer::StopTimer() {
   xTimerStop(timer, 0);
+  triggered = false;
 }
 
 bool Timer::IsRunning() {

--- a/src/components/timer/Timer.h
+++ b/src/components/timer/Timer.h
@@ -4,23 +4,31 @@
 #include <timers.h>
 
 #include <chrono>
+#include <optional>
 
 namespace Pinetime {
   namespace Controllers {
     class Timer {
     public:
+      struct TimerStatus {
+        std::chrono::milliseconds distanceToExpiry;
+        bool expired;
+      };
+
       Timer(void* timerData, TimerCallbackFunction_t timerCallbackFunction);
 
       void StartTimer(std::chrono::milliseconds duration);
 
       void StopTimer();
 
-      std::chrono::milliseconds GetTimeRemaining();
+      std::optional<TimerStatus> GetTimerState();
 
       bool IsRunning();
 
     private:
       TimerHandle_t timer;
+      TickType_t expiry;
+      bool triggered = false;
     };
   }
 }

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -118,7 +118,8 @@ void Timer::Refresh() {
 }
 
 void Timer::DisplayTime() {
-  displaySeconds = std::chrono::duration_cast<std::chrono::seconds>(timer.GetTimeRemaining());
+  displaySeconds =
+    std::chrono::duration_cast<std::chrono::seconds>(timer.GetTimerState().value_or(Controllers::Timer::TimerStatus {}).distanceToExpiry);
   if (displaySeconds.IsUpdated()) {
     minuteCounter.SetValue(displaySeconds.Get().count() / 60);
     secondCounter.SetValue(displaySeconds.Get().count() % 60);


### PR DESCRIPTION
Also resolve the overflow in GetTimeRemaining for long timers

Prerequisite for #1971 (@vkareh any feedback please do chip in!)

It's a bit annoying to store a duplicate of the expiry time but I think it's the best way around xTimerGetExpiryTime being undefined after a timer expires

Should the API for timer remaining/since expired be two methods? I went with this as it allows getting the complete state with one function, but maybe this isn't a sensible API for a generic timer component

Untested! 