### PR TITLE
PPGv2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "src/libs/littlefs"]
 	path = src/libs/littlefs
 	url = https://github.com/littlefs-project/littlefs.git
-[submodule "src/libs/arduinoFFT"]
-	path = src/libs/arduinoFFT
-	url = https://github.com/kosme/arduinoFFT.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -675,9 +675,9 @@ set(INCLUDE_FILES
         heartratetask/HeartRateTask.h
         components/heartrate/Ppg.h
         components/heartrate/HeartRateController.h
-        libs/arduinoFFT/src/arduinoFFT.h
-        libs/arduinoFFT/src/defs.h
-        libs/arduinoFFT/src/types.h
+        components/heartrate/FFT.h
+        components/heartrate/IIR.h
+        components/heartrate/RLS.h
         components/motor/MotorController.h
         buttonhandler/ButtonHandler.h
         touchhandler/TouchHandler.h

--- a/src/components/heartrate/FFT.h
+++ b/src/components/heartrate/FFT.h
@@ -1,0 +1,125 @@
+#include <complex>
+#include <array>
+#include <bit>
+#include <numbers>
+
+namespace Pinetime {
+  namespace Utility {
+    // Fast Fourier transform
+    // Implements in-place N to N point complex-to-complex FFT
+    // Implements in-place 2N to N point real-to-complex FFT
+    // Performing these transforms requires some "twiddling" constants to be known
+    // These constants depend only on the size of the transform
+    // Since they are expensive to compute, they can only be computed at compile time (consteval)
+    class FFT {
+    public:
+      static consteval std::size_t IntegerLog2(std::size_t n) {
+        return std::bit_width(n) - 1;
+      }
+
+      template <std::size_t N>
+      static consteval std::array<std::complex<float>, IntegerLog2(N)> GenComplexTwiddle() {
+        using namespace std::complex_literals;
+
+        std::array<std::complex<float>, IntegerLog2(N)> result;
+        for (std::size_t i = 0; i < IntegerLog2(N); i++) {
+          result[i] = exp_consteval(-2.i * std::numbers::pi / static_cast<double>(1 << (i + 1)));
+        }
+        return result;
+      }
+
+      template <std::size_t N>
+      static consteval std::array<std::complex<float>, (N / 4) - 1> GenRealTwiddle() {
+        using namespace std::complex_literals;
+
+        std::array<std::complex<float>, (N / 4) - 1> result;
+        for (std::size_t i = 0; i < (N / 4) - 1; i++) {
+          result[i] = exp_consteval(-2.i * std::numbers::pi * static_cast<double>(i + 1) / static_cast<double>(N));
+        }
+        return result;
+      }
+
+      template <std::size_t N>
+      static void ComplexFFT(std::array<std::complex<float>, N>& array, const std::array<std::complex<float>, IntegerLog2(N)>& twiddle) {
+        // In-place Cooley-Tukey
+        InplaceBitReverse(array);
+        for (std::size_t s = 1; s < IntegerLog2(N) + 1; s++) {
+          std::size_t m = 1 << s;
+          for (std::size_t k = 0; k < N; k += m) {
+            std::complex<float> omega = 1.f;
+            for (std::size_t j = 0; j < m / 2; j++) {
+              std::complex<float> t = omega * array[k + j + (m / 2)];
+              std::complex<float> u = array[k + j];
+              array[k + j] = u + t;
+              array[k + j + (m / 2)] = u - t;
+              omega *= twiddle[s - 1];
+            }
+          }
+        }
+      }
+
+      template <std::size_t N>
+      static void RealFFT(std::array<std::complex<float>, N>& array,
+                          const std::array<std::complex<float>, (N / 2) - 1>& realTwiddle,
+                          const std::array<std::complex<float>, IntegerLog2(N)>& complexTwiddle) {
+        using namespace std::complex_literals;
+
+        // See https://www.robinscheibler.org/2013/02/13/real-fft.html for how this works
+        FFT::ComplexFFT(array, complexTwiddle);
+        // Compute DC bin directly (xe/xo simplify)
+        // Nyquist bin ignored as unneeded
+        array[0] = array[0].real() + array[0].imag();
+        // Since computations depend on the inverse of the index (mirrored)
+        // compute two at once, outside to inside
+        for (std::size_t index = 1; index < N / 2; index++) {
+          std::size_t indexInv = N - index;
+          std::complex<float> xeLo = (array[index] + std::conj(array[indexInv])) / 2.f;
+          std::complex<float> xoLo = -1.if * ((array[index] - std::conj(array[indexInv])) / 2.f);
+          std::complex<float> xeHi = (array[indexInv] + std::conj(array[index])) / 2.f;
+          std::complex<float> xoHi = -1.if * ((array[indexInv] - std::conj(array[index])) / 2.f);
+          array[index] = xeLo + (xoLo * realTwiddle[index - 1]);
+          array[indexInv] = xeHi + (xoHi * -std::conj(realTwiddle[index - 1]));
+        }
+        // Middle element not computed by above loop
+        // Since index == indexInv
+        // the middle simplifies to the conjugate as the twiddle is always -i
+        std::size_t middle = N / 2;
+        array[middle] = std::conj(array[middle]);
+      }
+
+    private:
+      // consteval wrappers of builtins
+      template <typename _Tp>
+      static consteval std::complex<_Tp> exp_consteval(const std::complex<_Tp>& __z) {
+        return polar_consteval<_Tp>(__builtin_exp(__z.real()), __z.imag());
+      }
+
+      template <typename _Tp>
+      static consteval std::complex<_Tp> polar_consteval(const _Tp& __rho, const _Tp& __theta) {
+        return std::complex<_Tp>(__rho * __builtin_cos(__theta), __rho * __builtin_sin(__theta));
+      }
+
+      template <class T, std::size_t N>
+      static void InplaceBitReverse(std::array<T, N>& array) {
+        // Gold-Rader algorithm
+        // Faster algorithms exist, but this is sufficient
+        std::size_t swapTarget = 0;
+        for (std::size_t index = 0; index < N - 1; index++) {
+          // Only swap in one direction
+          // Otherwise entire array gets swapped twice
+          if (index < swapTarget) {
+            T temp = array[index];
+            array[index] = array[swapTarget];
+            array[swapTarget] = temp;
+          }
+          std::size_t kFactor = N / 2;
+          while (kFactor <= swapTarget) {
+            swapTarget -= kFactor;
+            kFactor /= 2;
+          }
+          swapTarget += kFactor;
+        }
+      }
+    };
+  }
+}

--- a/src/components/heartrate/HeartRateController.cpp
+++ b/src/components/heartrate/HeartRateController.cpp
@@ -1,11 +1,15 @@
 #include "components/heartrate/HeartRateController.h"
-#include <heartratetask/HeartRateTask.h>
-#include <systemtask/SystemTask.h>
+
+#include <cstdint>
+#include "heartratetask/HeartRateTask.h"
 
 using namespace Pinetime::Controllers;
 
-void HeartRateController::Update(HeartRateController::States newState, uint8_t heartRate) {
+void HeartRateController::UpdateState(HeartRateController::States newState) {
   this->state = newState;
+}
+
+void HeartRateController::UpdateHeartRate(uint8_t heartRate) {
   if (this->heartRate != heartRate) {
     this->heartRate = heartRate;
     service->OnNewHeartRateValue(heartRate);
@@ -14,14 +18,14 @@ void HeartRateController::Update(HeartRateController::States newState, uint8_t h
 
 void HeartRateController::Enable() {
   if (task != nullptr) {
-    state = States::NotEnoughData;
+    state = States::Stopped;
     task->PushMessage(Pinetime::Applications::HeartRateTask::Messages::Enable);
   }
 }
 
 void HeartRateController::Disable() {
   if (task != nullptr) {
-    state = States::Stopped;
+    state = States::Disabled;
     task->PushMessage(Pinetime::Applications::HeartRateTask::Messages::Disable);
   }
 }

--- a/src/components/heartrate/HeartRateController.h
+++ b/src/components/heartrate/HeartRateController.h
@@ -15,12 +15,13 @@ namespace Pinetime {
   namespace Controllers {
     class HeartRateController {
     public:
-      enum class States : uint8_t { Stopped, NotEnoughData, NoTouch, Running };
+      enum class States : uint8_t { Disabled, Stopped, NotEnoughData, Searching, Ready, NoTouch };
 
       HeartRateController() = default;
       void Enable();
       void Disable();
-      void Update(States newState, uint8_t heartRate);
+      void UpdateState(States newState);
+      void UpdateHeartRate(uint8_t heartRate);
 
       void SetHeartRateTask(Applications::HeartRateTask* task);
 
@@ -36,7 +37,7 @@ namespace Pinetime {
 
     private:
       Applications::HeartRateTask* task = nullptr;
-      States state = States::Stopped;
+      States state = States::Disabled;
       uint8_t heartRate = 0;
       Pinetime::Controllers::HeartRateService* service = nullptr;
     };

--- a/src/components/heartrate/HeartRateController.h
+++ b/src/components/heartrate/HeartRateController.h
@@ -15,7 +15,7 @@ namespace Pinetime {
   namespace Controllers {
     class HeartRateController {
     public:
-      enum class States : uint8_t { Disabled, Stopped, NotEnoughData, Searching, Ready, NoTouch };
+      enum class States : uint8_t { Disabled, Stopped, NotEnoughData, Searching, Measuring, NoTouch };
 
       HeartRateController() = default;
       void Enable();

--- a/src/components/heartrate/IIR.h
+++ b/src/components/heartrate/IIR.h
@@ -1,0 +1,49 @@
+#include <array>
+
+namespace Pinetime {
+  namespace Utility {
+    struct SOSCoeffs {
+      float b0;
+      float b1;
+      float b2;
+      float a1;
+      float a2;
+    };
+
+    struct FilterState {
+      float s1;
+      float s2;
+    };
+
+    // Infinite impulse response digital filter
+    // Implemented as cascaded second order sections (SOS)
+    template <std::size_t NSections>
+    class IIRFilter {
+    public:
+      IIRFilter(const std::array<SOSCoeffs, NSections>& coeffs, const std::array<FilterState, NSections>& zi) : coeffs {coeffs}, zi {zi} {};
+
+      float FilterStep(float input) {
+        for (std::size_t i = 0; i < NSections; i++) {
+          // Transposed form II
+          float output = (coeffs[i].b0 * input) + filterStates[i].s1;
+          filterStates[i].s1 = ((-coeffs[i].a1) * output) + (coeffs[i].b1 * input) + filterStates[i].s2;
+          filterStates[i].s2 = ((-coeffs[i].a2) * output) + (coeffs[i].b2 * input);
+          input = output;
+        }
+        return input;
+      }
+
+      void Prime(float value) {
+        for (std::size_t i = 0; i < NSections; i++) {
+          filterStates[i].s1 = zi[i].s1 * value;
+          filterStates[i].s2 = zi[i].s2 * value;
+        }
+      }
+
+    private:
+      std::array<FilterState, NSections> filterStates;
+      const std::array<SOSCoeffs, NSections>& coeffs;
+      const std::array<FilterState, NSections>& zi;
+    };
+  }
+}

--- a/src/components/heartrate/IIR.h
+++ b/src/components/heartrate/IIR.h
@@ -40,6 +40,13 @@ namespace Pinetime {
         }
       }
 
+      void Scale(float scaleFactor) {
+        for (std::size_t i = 0; i < NSections; i++) {
+          filterStates[i].s1 *= scaleFactor;
+          filterStates[i].s2 *= scaleFactor;
+        }
+      }
+
     private:
       std::array<FilterState, NSections> filterStates;
       const std::array<SOSCoeffs, NSections>& coeffs;

--- a/src/components/heartrate/Ppg.cpp
+++ b/src/components/heartrate/Ppg.cpp
@@ -28,6 +28,10 @@ bool Ppg::SufficientData() const {
   return ready;
 }
 
+void Ppg::ScaleHrs(float scaleFactor) {
+  ppgFilter.Scale(scaleFactor);
+}
+
 void Ppg::Ingest(uint16_t hrs, int16_t accX, int16_t accY, int16_t accZ) {
   // Acceleration is normalised to 1024=1G in the BMA driver
   float accXNorm = static_cast<float>(accX) / 1024.f;

--- a/src/components/heartrate/Ppg.h
+++ b/src/components/heartrate/Ppg.h
@@ -1,81 +1,162 @@
 #pragma once
 
 #include <array>
+#include <cmath>
+#include <complex>
 #include <cstddef>
 #include <cstdint>
-// Note: Change internal define 'sqrt_internal sqrt' to
-// 'sqrt_internal sqrtf' to save ~3KB of flash.
-#define sqrt_internal sqrtf
-#define FFT_SPEED_OVER_PRECISION
-#include "libs/arduinoFFT/src/arduinoFFT.h"
+#include <optional>
+#include <span>
+
+#include "components/heartrate/FFT.h"
+#include "components/heartrate/IIR.h"
+#include "components/heartrate/RLS.h"
 
 namespace Pinetime {
   namespace Controllers {
     class Ppg {
     public:
       Ppg();
-      int8_t Preprocess(uint16_t hrs, uint16_t als);
-      int HeartRate();
-      void Reset(bool resetDaqBuffer);
-      static constexpr int deltaTms = 100;
-      // Daq dataLength: Must be power of 2
-      static constexpr uint16_t dataLength = 64;
-      static constexpr uint16_t spectrumLength = dataLength >> 1;
+      void Ingest(uint16_t hrs, int16_t accX, int16_t accY, int16_t accZ);
+      std::optional<uint8_t> HeartRate();
+      void Reset();
+      [[nodiscard]] bool SufficientData() const;
+      static constexpr float sampleDuration = 0.048f;
 
     private:
-      // The sampling frequency (Hz) based on sampling time in milliseconds (DeltaTms)
-      static constexpr float sampleFreq = 1000.0f / static_cast<float>(deltaTms);
-      // The frequency resolution (Hz)
-      static constexpr float freqResolution = sampleFreq / dataLength;
+      static constexpr float sampleRate = 1.f / sampleDuration;
+      // FFT length
+      static constexpr uint16_t fftLength = 256;
+      // Data going into FFT length (FFT is zero padded)
+      static constexpr uint16_t inputLength = std::round(8 * sampleRate);
+      // Uupdate rate
+      static constexpr float overlapTime = 0.5f;
       // Number of samples before each analysis
-      // 0.5 second update rate at 10Hz
-      static constexpr uint16_t overlapWindow = 5;
-      // Maximum number of spectrum running averages
-      // Note: actual number of spectra averaged = spectralAvgMax + 1
-      static constexpr uint16_t spectralAvgMax = 2;
-      // Multiple Peaks above this threshold (% of max) are rejected
-      static constexpr float peakDetectionThreshold = 0.6f;
-      // Maximum peak width (bins) at threshold for valid peak.
-      static constexpr float maxPeakWidth = 2.5f;
-      // Metric for spectrum noise level.
-      static constexpr float signalToNoiseThreshold = 3.0f;
-      // Heart rate Region Of Interest begin (bins)
-      static constexpr uint16_t hrROIbegin = static_cast<uint16_t>((30.0f / 60.0f) / freqResolution + 0.5f);
-      // Heart rate Region Of Interest end (bins)
-      static constexpr uint16_t hrROIend = static_cast<uint16_t>((240.0f / 60.0f) / freqResolution + 0.5f);
-      // Minimum HR (Hz)
-      static constexpr float minHR = 40.0f / 60.0f;
-      // Maximum HR (Hz)
-      static constexpr float maxHR = 230.0f / 60.0f;
-      // Threshold for high DC level after filtering
-      static constexpr float dcThreshold = 0.5f;
-      // ALS detection factor
-      static constexpr float alsFactor = 2.0f;
+      static constexpr uint16_t overlapWindow = std::round(sampleRate * overlapTime);
+      // Frequency resolution (Hz)
+      static constexpr float binWidth = 1.f / (fftLength * sampleDuration);
 
-      // Raw ADC data
-      std::array<uint16_t, dataLength> dataHRS;
-      // Stores Real numbers from FFT
-      std::array<float, dataLength> vReal;
-      // Stores Imaginary numbers from FFT
-      std::array<float, dataLength> vImag;
-      // Stores power spectrum calculated from FFT real and imag values
-      std::array<float, (spectrumLength)> spectrum;
-      // Stores each new HR value (Hz). Non zero values are averaged for HR output
-      std::array<float, 20> dataAverage;
+      // Input filtering coefficients
+      // Generated with scipy butter(4, 0.5, btype="highpass", output="sos", fs=sampleRate)
+      static constexpr std::array<Utility::SOSCoeffs, 2> inputCoeffs {
+        Utility::SOSCoeffs {.b0 = 0.8209900772315549,
+                            .b1 = -1.6419801544631099,
+                            .b2 = 0.8209900772315549,
+                            .a1 = -1.7363191518098462,
+                            .a2 = 0.7562495196628967},
+        Utility::SOSCoeffs {.b0 = 1., .b1 = -2., .b2 = 1., .a1 = -1.8698102590459458, .a2 = 0.89127290676215}};
+      // Input filtering initial state
+      static constexpr std::array<Utility::FilterState, 2> inputInitialState {Utility::FilterState {.s1 = -0.82099008, .s2 = 0.82099008},
+                                                                              Utility::FilterState {.s1 = 0., .s2 = 0.}};
 
-      uint16_t avgIndex = 0;
-      uint16_t spectralAvgCount = 0;
-      float lastPeakLocation = 0.0f;
-      uint16_t alsThreshold = UINT16_MAX;
-      uint16_t alsValue = 0;
-      uint16_t dataIndex = 0;
-      float peakLocation;
-      bool resetSpectralAvg = true;
-      bool enoughData = false;
+      // Adaptive filtering strength
+      static constexpr float adaptiveMu = 0.99f;
+      // Number of noise channels
+      static constexpr size_t noiseChannels = 3;
+      // Adaptive filter length
+      static constexpr size_t adaptiveLength = std::round(0.25f * sampleRate) * noiseChannels;
+      // Adaptive filter reset consideration window
+      static constexpr size_t adaptiveResetWindow = 1.f * sampleRate;
+      // Adaptive filter reset threshold
+      static constexpr float adaptiveResetThresh = 2.f;
 
-      int ProcessHeartRate(bool init);
-      float HeartRateAverage(float hr);
-      void SpectrumAverage(const float* data, float* spectrum, int length, bool reset);
+      // FFT constants (computed at compile time to avoid expensive runtime calculations)
+      static constexpr auto complexTwiddle = Utility::FFT::GenComplexTwiddle<fftLength / 2>();
+      static constexpr auto realTwiddle = Utility::FFT::GenRealTwiddle<fftLength>();
+
+      // Prominence filter constants
+      // Generated with scipy butter(2, (0.07, 0.65), btype="bandpass", output="sos")
+      static constexpr std::array<Utility::SOSCoeffs, 2> prominenceCoeffs {
+        Utility::SOSCoeffs {.b0 = 0.3705549357629432,
+                            .b1 = 0.7411098715258864,
+                            .b2 = 0.3705549357629432,
+                            .a1 = 0.5064122272787734,
+                            .a2 = 0.2534300618617984},
+        Utility::SOSCoeffs {.b0 = 1., .b1 = -2., .b2 = 1., .a1 = -1.6907167610529146, .a2 = 0.7379546730609459}};
+      // Prominence filtering initial state
+      static constexpr std::array<Utility::FilterState, 2> prominenceInitialState {
+        Utility::FilterState {.s1 = 0.47169084512212833, .s2 = 0.15710453541040081},
+        Utility::FilterState {.s1 = -0.8422457808850721, .s2 = 0.8422457808850718}};
+      static constexpr float primingFactor = 2.f;
+
+      // Threshold after bandpass filtering at which signal is allowed through
+      static constexpr float minProminence = 0.5f;
+      // Threshold after bandpass filtering at which all signal is allowed through
+      static constexpr float maxProminence = 0.8f;
+      // Clip values below floor to prevent huge negative logs
+      static constexpr float logFloor = 1e-4f;
+
+      // First harmonic minimum relative magnitude to be considered
+      static constexpr float f1MagMinimum = 0.5f;
+      // First harmonic phase penalty exponent
+      static constexpr float f1ExpAttenuationFactor = 4.f;
+      // First harmonic magnitude high threshold
+      static constexpr float f1MagHigh = 1.f;
+      // Second harmonic magnitude high threshold
+      static constexpr float f2MagHigh = 0.75f;
+      // First harmonic absent energy penality
+      static constexpr float noF1Penalty = 0.2f;
+      // First harmonic absent energy limit
+      static constexpr float noF1EnergyCeiling = 6.f;
+      // Harmonic magnitude high energy ceiling
+      static constexpr float fnMagHighEnergyCeiling = 3.f;
+
+      // Minimum frequency to consider
+      static constexpr float minFrequency = 30.f / 60.f;
+      // Maximum frequency to consider
+      // Cannot go higher as sample rate puts 2nd harmonic out of range
+      static constexpr float maxFrequency = 207.f / 60.f;
+      // Minimum frequency FFT bin
+      static constexpr size_t minFrequencyBin = (minFrequency / binWidth) + 1;
+      // Maximum frequency FFT bin
+      static constexpr size_t maxFrequencyBin = (maxFrequency / binWidth) + 1;
+      // Length of the region of interest
+      static constexpr size_t roiLength = maxFrequencyBin - minFrequencyBin;
+
+      // Minimum log energy to consider a peak strong
+      static constexpr float strongPeakEnergyMinimum = 3.f;
+      // Minimum prominence of a strong peak to be accepted
+      static constexpr float strongPeakProminenceMinimum = 0.8f;
+      // Minimum log energy to keep tracking a peak
+      static constexpr float trackingEnergyMinimum = -1.f;
+      // Minimum log energy to update the HR prediction
+      static constexpr float hrUpdateEnergyMinimum = 0.f;
+      // Exponential moving average alpha factor for rolling energy
+      static constexpr float rollingEnergyAlpha = 0.1f * overlapTime;
+      // Exponential moving average alpha factor for heart rate prediction
+      static constexpr float hrMovementAlpha = 0.25f * overlapTime;
+      // Minimum rolling energy to return the prediction
+      static constexpr float rollingEnergyDisplayMinimum = 0.f;
+      // Maximum energy at which new strong peaks will replace the current peak
+      static constexpr float rollingEnergyWeak = 1.f;
+
+      // Window size for pre-FFT segment RMS normalisation
+      static constexpr size_t segmentNormWindow = std::round((1.f / minFrequency) * sampleRate);
+
+      Utility::IIRFilter<inputCoeffs.size()> ppgFilter = Utility::IIRFilter(inputCoeffs, inputInitialState);
+      Utility::IIRFilter<inputCoeffs.size()> accXFilter = Utility::IIRFilter(inputCoeffs, inputInitialState);
+      Utility::IIRFilter<inputCoeffs.size()> accYFilter = Utility::IIRFilter(inputCoeffs, inputInitialState);
+      Utility::IIRFilter<inputCoeffs.size()> accZFilter = Utility::IIRFilter(inputCoeffs, inputInitialState);
+      std::array<float, inputLength> adaptiveHrsArray;
+      std::array<float, adaptiveResetWindow> filteredHrsArray;
+      uint8_t hrsCount;
+      uint8_t filteredHrsTailIndex;
+      Utility::RLS<adaptiveLength, noiseChannels> accAdaptive = Utility::RLS<adaptiveLength, noiseChannels>(adaptiveMu);
+
+      std::array<std::complex<float>, fftLength / 2> complexFftArray;
+      std::span<float, fftLength> fftArray {reinterpret_cast<float*>(complexFftArray.data()), fftLength};
+
+      Utility::IIRFilter<prominenceCoeffs.size()> prominenceFilter = Utility::IIRFilter(prominenceCoeffs, prominenceInitialState);
+
+      std::optional<float> lockedHrBin;
+      float rollingEnergy;
+      bool ready;
+
+      void StoreHrs(float filteredHrs);
+      void RunAlg();
+      void ProminenceFilter();
+      void SegmentRMSNorm();
+      void HarmonicFilter();
     };
   }
 }

--- a/src/components/heartrate/Ppg.h
+++ b/src/components/heartrate/Ppg.h
@@ -21,6 +21,7 @@ namespace Pinetime {
       std::optional<uint8_t> HeartRate();
       void Reset();
       [[nodiscard]] bool SufficientData() const;
+      void ScaleHrs(float scaleFactor);
       static constexpr float sampleDuration = 0.048f;
 
     private:

--- a/src/components/heartrate/RLS.h
+++ b/src/components/heartrate/RLS.h
@@ -1,0 +1,147 @@
+#include <array>
+#include <cstdlib>
+#include <optional>
+#include <functional>
+#include <numeric>
+
+namespace Pinetime {
+  namespace Utility {
+    // Recursive least squares adaptive filter
+    // Supports N noise channels concurrently (NoiseStep)
+    // See https://en.wikipedia.org/wiki/Recursive_least_squares_filter
+    // and https://matousc89.github.io/padasip/sources/filters/rls.html
+    template <std::size_t FIRLength, std::size_t NoiseStep>
+    class RLS {
+    public:
+      explicit RLS(float mu) {
+        this->mu = mu;
+        Reset();
+      }
+
+      void Reset(bool hard = true) {
+        if (hard) {
+          startupRemaining = FIRLength;
+        }
+        for (std::size_t i = 0; i < FIRLength; i++) {
+          for (std::size_t j = 0; j < FIRLength; j++) {
+            correlationInv[i][j] = 0.f;
+          }
+          correlationInv[i][i] = 1.f / eps;
+          weights[i] = 0.f;
+        }
+      }
+
+      float FilterStep(float dataPoint, std::array<float, NoiseStep> noisePoints, std::optional<float> resetThresh) {
+        for (std::size_t index = 0; index < FIRLength - NoiseStep; index++) {
+          noiseHistory[index] = noiseHistory[index + NoiseStep];
+        }
+        for (std::size_t index = FIRLength - NoiseStep; index < FIRLength; index++) {
+          noiseHistory[index] = noisePoints[index - FIRLength + NoiseStep];
+        }
+        // Don't filter until noise points ready
+        if (startupRemaining > 0) {
+          startupRemaining -= NoiseStep;
+          if (startupRemaining > 0) {
+            return dataPoint;
+          }
+        }
+
+        float noiseEstimate = DotProduct(weights, noiseHistory);
+        float denoisedDataPoint = dataPoint - noiseEstimate;
+
+        // Resetting is useful to recover from filter divergence
+        // If the denoised output exceeds the chosen threshold, reset the filter state
+        if (resetThresh.has_value()) {
+          if (std::abs(denoisedDataPoint) > resetThresh) {
+            Reset(false);
+            denoisedDataPoint = dataPoint;
+          }
+        }
+
+        std::array<std::array<float, FIRLength>, FIRLength> correlationUpdate;
+        for (auto& arr : correlationUpdate) {
+          arr.fill(0.f);
+        }
+
+        MatrixMulDynamic(
+          correlationInv,
+          [this](std::size_t x, std::size_t y) {
+            return noiseHistory[x] * noiseHistory[y];
+          },
+          correlationUpdate);
+
+        MatrixMulInplace(correlationUpdate, correlationInv);
+
+        float normFactor = mu + CalculateNormFactor();
+
+        for (std::size_t i = 0; i < FIRLength; i++) {
+          for (std::size_t j = 0; j < FIRLength; j++) {
+            correlationInv[i][j] = (1.f / mu) * (correlationInv[i][j] - (correlationUpdate[i][j] / normFactor));
+          }
+        }
+
+        DotMatrixInplaceAdd(correlationInv, noiseHistory, weights, denoisedDataPoint);
+
+        return denoisedDataPoint;
+      }
+
+    private:
+      // noinline to bound stack use more tightly
+      [[gnu::noinline]] float CalculateNormFactor() {
+        std::array<float, FIRLength> temp;
+        temp.fill(0.f);
+        DotMatrixInplaceAdd(correlationInv, noiseHistory, temp);
+        return DotProduct(temp, noiseHistory);
+      }
+
+      [[gnu::noinline]] static void MatrixMulInplace(std::array<std::array<float, FIRLength>, FIRLength>& a,
+                                                     const std::array<std::array<float, FIRLength>, FIRLength>& b) {
+        // Uses 1 row of extra space
+        for (std::size_t i = 0; i < FIRLength; i++) {
+          std::array<float, FIRLength> aPrior {a[i]};
+          for (std::size_t j = 0; j < FIRLength; j++) {
+            float acc = 0.f;
+            for (std::size_t k = 0; k < FIRLength; k++) {
+              acc += aPrior[k] * b[k][j];
+            }
+            a[i][j] = acc;
+          }
+        }
+      }
+
+      static float DotProduct(const std::array<float, FIRLength>& a, const std::array<float, FIRLength>& b) {
+        return std::inner_product(a.begin(), a.end(), b.begin(), 0.f);
+      }
+
+      static void DotMatrixInplaceAdd(std::array<std::array<float, FIRLength>, FIRLength>& mat,
+                                      const std::array<float, FIRLength>& vec,
+                                      std::array<float, FIRLength>& out,
+                                      float norm = 1.f) {
+        for (std::size_t i = 0; i < FIRLength; i++) {
+          out[i] += DotProduct(mat[i], vec) * norm;
+        }
+      }
+
+      static void MatrixMulDynamic(const std::array<std::array<float, FIRLength>, FIRLength>& mat,
+                                   const std::function<float(std::size_t x, std::size_t y)>& matGen,
+                                   std::array<std::array<float, FIRLength>, FIRLength>& out) {
+        for (std::size_t i = 0; i < FIRLength; i++) {
+          for (std::size_t j = 0; j < FIRLength; j++) {
+            float acc = 0.f;
+            for (std::size_t k = 0; k < FIRLength; k++) {
+              acc += mat[i][k] * matGen(k, j);
+            }
+            out[i][j] = acc;
+          }
+        }
+      }
+
+      static constexpr float eps = 1.f;
+      std::array<float, FIRLength> weights;
+      std::array<float, FIRLength> noiseHistory;
+      std::array<std::array<float, FIRLength>, FIRLength> correlationInv;
+      float mu;
+      std::size_t startupRemaining;
+    };
+  }
+}

--- a/src/displayapp/screens/HeartRate.cpp
+++ b/src/displayapp/screens/HeartRate.cpp
@@ -16,7 +16,7 @@ namespace {
         return "Searching...";
       case Pinetime::Controllers::HeartRateController::States::NoTouch:
         return "No touch detected";
-      case Pinetime::Controllers::HeartRateController::States::Ready:
+      case Pinetime::Controllers::HeartRateController::States::Measuring:
         return "Measuring...";
       case Pinetime::Controllers::HeartRateController::States::Stopped:
         return "Stopped";

--- a/src/displayapp/screens/HeartRate.h
+++ b/src/displayapp/screens/HeartRate.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <cstdint>
-#include <chrono>
 #include "displayapp/screens/Screen.h"
 #include "systemtask/SystemTask.h"
 #include "systemtask/WakeLock.h"
 #include "Symbols.h"
-#include <lvgl/src/lv_core/lv_style.h>
 #include <lvgl/src/lv_core/lv_obj.h>
+#include <lvgl/src/lv_core/lv_style.h>
 
 namespace Pinetime {
   namespace Controllers {

--- a/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
+++ b/src/displayapp/screens/WatchFaceCasioStyleG7710.cpp
@@ -290,7 +290,7 @@ void WatchFaceCasioStyleG7710::Refresh() {
   }
 
   heartbeat = heartRateController.HeartRate();
-  heartbeatRunning = heartRateController.State() != Controllers::HeartRateController::States::Stopped;
+  heartbeatRunning = heartRateController.State() != Controllers::HeartRateController::States::Disabled;
   if (heartbeat.IsUpdated() || heartbeatRunning.IsUpdated()) {
     if (heartbeatRunning.Get()) {
       lv_obj_set_style_local_text_color(heartbeatIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, color_text);

--- a/src/displayapp/screens/WatchFaceDigital.cpp
+++ b/src/displayapp/screens/WatchFaceDigital.cpp
@@ -151,7 +151,7 @@ void WatchFaceDigital::Refresh() {
   }
 
   heartbeat = heartRateController.HeartRate();
-  heartbeatRunning = heartRateController.State() != Controllers::HeartRateController::States::Stopped;
+  heartbeatRunning = heartRateController.State() != Controllers::HeartRateController::States::Disabled;
   if (heartbeat.IsUpdated() || heartbeatRunning.IsUpdated()) {
     if (heartbeatRunning.Get()) {
       lv_obj_set_style_local_text_color(heartbeatIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, lv_color_hex(0xCE1B1B));

--- a/src/displayapp/screens/WatchFaceTerminal.cpp
+++ b/src/displayapp/screens/WatchFaceTerminal.cpp
@@ -139,7 +139,7 @@ void WatchFaceTerminal::Refresh() {
   }
 
   heartbeat = heartRateController.HeartRate();
-  heartbeatRunning = heartRateController.State() != Controllers::HeartRateController::States::Stopped;
+  heartbeatRunning = heartRateController.State() != Controllers::HeartRateController::States::Disabled;
   if (heartbeat.IsUpdated() || heartbeatRunning.IsUpdated()) {
     if (heartbeatRunning.Get()) {
       lv_obj_set_style_local_text_color(heartbeatValue, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, Colors::deepOrange);

--- a/src/drivers/Bma421.cpp
+++ b/src/drivers/Bma421.cpp
@@ -85,7 +85,7 @@ void Bma421::Init() {
     return;
 
   accel_conf.odr = BMA4_OUTPUT_DATA_RATE_100HZ;
-  accel_conf.range = BMA4_ACCEL_RANGE_2G;
+  accel_conf.range = BMA4_ACCEL_RANGE_8G;
   accel_conf.bandwidth = BMA4_ACCEL_NORMAL_AVG4;
   accel_conf.perf_mode = BMA4_CIC_AVG_MODE;
   ret = bma4_set_accel_config(&accel_conf, &bma);

--- a/src/drivers/Hrs3300.cpp
+++ b/src/drivers/Hrs3300.cpp
@@ -6,7 +6,7 @@
 
 #include "drivers/Hrs3300.h"
 #include <algorithm>
-#include <iterator>
+#include <cstdint>
 #include <nrf_gpio.h>
 
 #include <FreeRTOS.h>
@@ -16,69 +16,104 @@
 using namespace Pinetime::Drivers;
 
 namespace {
-  static constexpr uint8_t ledDriveCurrentValue = 0x2e;
+  constexpr uint16_t hrsHighThresh = 15000;
+  constexpr uint16_t hrsLowThresh = 3000;
+  constexpr uint16_t alsHighThresh = 1500;
+  constexpr uint16_t alsLowThresh = 300;
+  constexpr uint16_t touchRegainedThresh = 70;
+  constexpr uint16_t touchLostThresh = 1000;
+  // The proprietary driver uses this and it seems to be required to re-initialise the sensor
+  constexpr std::array<std::array<uint8_t, 2>, 18> bootupRegisters = {{
+    {0x01, 0xd0},
+    {0x0c, 0x4e},
+    {0x16, 0x78},
+    {0x17, 0x0d},
+    {0x02, 0x80},
+    {0x03, 0x00},
+    {0x04, 0x00},
+    {0x05, 0x00},
+    {0x06, 0x00},
+    {0x07, 0x00},
+    {0x08, 0x74},
+    {0x09, 0x00},
+    {0x0a, 0x08},
+    {0x0b, 0x00},
+    {0x0c, 0x6e},
+    {0x0d, 0x02},
+    {0x0e, 0x07},
+    {0x0f, 0x0f},
+  }};
+
+  constexpr uint8_t powerChangeDelay = .25f / Pinetime::Controllers::Ppg::sampleDuration;
+  constexpr uint8_t noTouchDelay = 2 / Pinetime::Controllers::Ppg::sampleDuration;
+  // Duration ambient light must be low for gain up to trigger
+  // Long to prevent gaining up when high ambient light only occurs occasionally
+  // Much better to be in too low a gain than too high and saturate the ADC
+  constexpr uint16_t gainUpWaitTime = 30 / Pinetime::Controllers::Ppg::sampleDuration;
+  // If just gained up, wait at least this long before considering another gain up
+  constexpr uint16_t gainUpCascadeWaitTime = 5 / Pinetime::Controllers::Ppg::sampleDuration;
 }
 
 /** Driver for the HRS3300 heart rate sensor.
  * Original implementation from wasp-os : https://github.com/wasp-os/wasp-os/blob/master/wasp/drivers/hrs3300.py
  *
  * Experimentaly derived changes to improve signal/noise (see comments below) - Ceimour
+ *
+ * Refactored to include automatic drive and gain control using proprietary driver techniques - mark
  */
 Hrs3300::Hrs3300(TwiMaster& twiMaster, uint8_t twiAddress) : twiMaster {twiMaster}, twiAddress {twiAddress} {
 }
 
 void Hrs3300::Init() {
-  nrf_gpio_cfg_input(30, NRF_GPIO_PIN_NOPULL);
-
-  Disable();
-  vTaskDelay(100);
-
-  // HRS disabled, 0ms wait time between ADC conversion period, current 12.5mA
-  WriteRegister(static_cast<uint8_t>(Registers::Enable), 0x70);
-
-  // Current 12.5mA and low nibble 0xF.
-  // Note: Setting low nibble to 0x8 per the datasheet results in
-  // modulated LED driver output (50% PWM)
-  // Saves some power at the cost of some resolution
-  // 0xF sets 100% duty
-  WriteRegister(static_cast<uint8_t>(Registers::PDriver), ledDriveCurrentValue);
-
-  // HRS in 15-bit and ALS in 16-bit mode result in 48ms period
-  // See https://github.com/wasp-os/wasp-os/pull/363#issuecomment-1279733038
+  for (auto bootupRegister : bootupRegisters) {
+    WriteRegister(bootupRegister[0], bootupRegister[1]);
+  }
+  r7f = ReadRegister(0x7f);
+  r80 = ReadRegister(0x80);
+  r81 = ReadRegister(0x81);
+  r82 = ReadRegister(0x82);
+  // Top 4 bits of r80 clear and bottom 3 bits of r81 clear
+  if (((r80 & 0xf0) | (r81 & 0x07)) == 0) {
+    r81 |= 0x04;
+  }
   WriteRegister(static_cast<uint8_t>(Registers::Res), 0x78);
-
-  // Gain set to 8x
-  WriteRegister(static_cast<uint8_t>(Registers::Hgain), 0x0e);
+  Disable();
 }
 
 void Hrs3300::Enable() {
   NRF_LOG_INFO("ENABLE");
-  auto value = ReadRegister(static_cast<uint8_t>(Registers::Enable));
-  value |= 0x80;
-  WriteRegister(static_cast<uint8_t>(Registers::Enable), value);
 
-  WriteRegister(static_cast<uint8_t>(Registers::PDriver), ledDriveCurrentValue);
+  ppgDrive = PPGDrive::Current13mALow;
+  ppgGain = PPGGain::Gain8x;
+  ppgState = PPGState::Running;
+  actionDelay = powerChangeDelay;
+  hrsLowCount = 0;
+  hrsHighCount = 0;
+  alsLowCount = 0;
+  alsHighCount = 0;
+
+  // Needs to be initialised twice or sensor gets stuck in weird state
+  SetPower();
+  SetPower();
 }
 
 void Hrs3300::Disable() {
   NRF_LOG_INFO("DISABLE");
-  auto value = ReadRegister(static_cast<uint8_t>(Registers::Enable));
-  value &= ~0x80;
-  WriteRegister(static_cast<uint8_t>(Registers::Enable), value);
-
-  WriteRegister(static_cast<uint8_t>(Registers::PDriver), 0);
+  WriteRegister(static_cast<uint8_t>(Registers::Enable), 0x00);
+  WriteRegister(static_cast<uint8_t>(Registers::PDriver), 0x00);
+  ppgState = PPGState::Off;
 }
 
 Hrs3300::PackedHrsAls Hrs3300::ReadHrsAls() {
-  constexpr Registers dataRegisters[] =
-    {Registers::C1dataM, Registers::C0DataM, Registers::C0DataH, Registers::C1dataH, Registers::C1dataL, Registers::C0dataL};
-  // Calculate smallest register address
-  constexpr uint8_t baseOffset = static_cast<uint8_t>(*std::min_element(std::begin(dataRegisters), std::end(dataRegisters)));
-  // Calculate largest address to determine length of read needed
-  // Add one to largest relative index to find the length
-  constexpr uint8_t length = static_cast<uint8_t>(*std::max_element(std::begin(dataRegisters), std::end(dataRegisters))) - baseOffset + 1;
+  static constexpr Registers dataRegisters[] =
+    {Registers::C1DataM, Registers::C0DataM, Registers::C0DataH, Registers::C1DataH, Registers::C1DataL, Registers::C0DataL};
 
-  Hrs3300::PackedHrsAls res;
+  // Calculate smallest/largest register address
+  constexpr auto bounds = std::ranges::minmax(dataRegisters);
+  constexpr uint8_t baseOffset = static_cast<uint8_t>(bounds.min);
+  constexpr uint8_t length = static_cast<uint8_t>(bounds.max) - baseOffset + 1;
+
+  PackedHrsAls res;
   uint8_t buf[length];
   auto ret = twiMaster.Read(twiAddress, baseOffset, buf, length);
   if (ret != TwiMaster::ErrorCodes::NoError) {
@@ -87,16 +122,16 @@ Hrs3300::PackedHrsAls Hrs3300::ReadHrsAls() {
   // hrs
   uint8_t m = static_cast<uint8_t>(Registers::C0DataM) - baseOffset;
   uint8_t h = static_cast<uint8_t>(Registers::C0DataH) - baseOffset;
-  uint8_t l = static_cast<uint8_t>(Registers::C0dataL) - baseOffset;
+  uint8_t l = static_cast<uint8_t>(Registers::C0DataL) - baseOffset;
   // There are two extra bits (17 and 18) but they are not read here
   // as resolutions >16bit aren't practically useful (too slow) and
   // all hrs values throughout InfiniTime are 16bit
   res.hrs = (buf[m] << 8) | ((buf[h] & 0x0f) << 4) | (buf[l] & 0x0f);
 
   // als
-  m = static_cast<uint8_t>(Registers::C1dataM) - baseOffset;
-  h = static_cast<uint8_t>(Registers::C1dataH) - baseOffset;
-  l = static_cast<uint8_t>(Registers::C1dataL) - baseOffset;
+  m = static_cast<uint8_t>(Registers::C1DataM) - baseOffset;
+  h = static_cast<uint8_t>(Registers::C1DataH) - baseOffset;
+  l = static_cast<uint8_t>(Registers::C1DataL) - baseOffset;
   res.als = ((buf[h] & 0x3f) << 11) | (buf[m] << 3) | (buf[l] & 0x07);
 
   return res;
@@ -104,14 +139,201 @@ Hrs3300::PackedHrsAls Hrs3300::ReadHrsAls() {
 
 void Hrs3300::WriteRegister(uint8_t reg, uint8_t data) {
   auto ret = twiMaster.Write(twiAddress, reg, &data, 1);
-  if (ret != TwiMaster::ErrorCodes::NoError)
+  if (ret != TwiMaster::ErrorCodes::NoError) {
     NRF_LOG_INFO("WRITE ERROR");
+  }
 }
 
 uint8_t Hrs3300::ReadRegister(uint8_t reg) {
   uint8_t value;
   auto ret = twiMaster.Read(twiAddress, reg, &value, 1);
-  if (ret != TwiMaster::ErrorCodes::NoError)
+  if (ret != TwiMaster::ErrorCodes::NoError) {
     NRF_LOG_INFO("READ ERROR");
+  }
   return value;
+}
+
+void Hrs3300::SetPower() {
+  uint8_t r80Temp = r80;
+  uint8_t r81Temp = r81;
+  uint8_t r7aTemp = 0x00;
+
+  // All in MSB->LSB order
+  // It's just what the proprietary driver does
+  if (ppgDrive == PPGDrive::Current13mALow) {
+    r80Temp = (r81 & 0x01) << 7 | (r80 & 0xe0) >> 1 | (r80 & 0x0f);
+    r81Temp = (r81 & 0xf8) | (r81 & 0x06) >> 1;
+  } else if (ppgDrive == PPGDrive::Current40mAHigh) {
+    r80Temp = r80 | 0xf0;
+    r81Temp = r81 | 0x07;
+  } else if (ppgDrive == PPGDrive::NoTouchPowerSave) {
+    r80Temp = (r80 & 0x8f) | 0x30;
+    r81Temp = r81 & 0xf8;
+    r7aTemp = 0x02;
+  }
+  // Set special power registers
+  WriteRegister(0x85, 0x20);
+  WriteRegister(0x7f, r7f);
+  WriteRegister(0x80, r80Temp);
+  WriteRegister(0x81, r81Temp);
+  WriteRegister(0x82, r82);
+  WriteRegister(0x85, 0x00);
+  WriteRegister(0x7a, r7aTemp);
+
+  uint8_t gain = 0x01;
+  switch (ppgGain) {
+    case PPGGain::Gain1x:
+      break;
+    case PPGGain::Gain2x:
+      gain |= 0x04;
+      break;
+    case PPGGain::Gain4x:
+      gain |= 0x08;
+      break;
+    case PPGGain::Gain8x:
+      gain |= 0x0c;
+      break;
+  }
+
+  // HRS enabled, 800ms wait
+  uint8_t enable = 0x80;
+  // OSC on, 50% duty cycle (last 4 bits)
+  uint8_t drive = 0x2e;
+  // See https://github.com/wasp-os/wasp-os/pull/363#issuecomment-1279733038 for acquisition period details
+  switch (ppgDrive) {
+    // 800ms, 13mA (exact current unknown due to special power registers)
+    case PPGDrive::NoTouchPowerSave:
+      break;
+    // 48ms, 13mA/Lower
+    case PPGDrive::Current13mALow:
+    case PPGDrive::Current13mA:
+      enable |= 0x70;
+      break;
+    // 48ms, 20mA
+    case PPGDrive::Current20mA:
+      enable |= 0x70;
+      drive |= 0x40;
+      break;
+    // 48ms, 30mA
+    case PPGDrive::Current30mA:
+      enable |= 0x78;
+      break;
+    // 48ms, 40mA/Higher
+    case PPGDrive::Current40mA:
+    case PPGDrive::Current40mAHigh:
+      enable |= 0x78;
+      drive |= 0x40;
+      break;
+  }
+  WriteRegister(static_cast<uint8_t>(Registers::HGain), gain);
+  WriteRegister(static_cast<uint8_t>(Registers::Enable), enable);
+  WriteRegister(static_cast<uint8_t>(Registers::PDriver), drive);
+}
+
+Hrs3300::PPGState Hrs3300::AutoGain(uint16_t hrs, uint16_t als) {
+  PPGDrive previousPpgDrive = ppgDrive;
+  PPGGain previousPpgGain = ppgGain;
+
+  if (hrs > hrsHighThresh) {
+    hrsHighCount = std::max(hrsHighCount, static_cast<uint8_t>(hrsHighCount + 1));
+  } else {
+    hrsHighCount = 0;
+  }
+  if (hrs < hrsLowThresh) {
+    hrsLowCount = std::max(hrsLowCount, static_cast<uint8_t>(hrsLowCount + 1));
+  } else {
+    hrsLowCount = 0;
+  }
+
+  if (als > alsHighThresh) {
+    alsHighCount = std::max(alsHighCount, static_cast<uint8_t>(alsHighCount + 1));
+  } else {
+    alsHighCount = 0;
+  }
+  if (als < alsLowThresh) {
+    alsLowCount = std::max(alsLowCount, static_cast<uint16_t>(alsLowCount + 1));
+  } else {
+    alsLowCount = 0;
+  }
+
+  if (actionDelay > 0) {
+    actionDelay--;
+    return ppgState;
+  }
+
+  // No touch handling
+  if (ppgState == PPGState::NoTouch) {
+    // If touch regained, reinitialise
+    if (hrs >= touchRegainedThresh) {
+      // Disable then enable to avoid waiting for the 800ms inter-sample delay in no touch mode
+      Disable();
+      Enable();
+      return PPGState::Reset;
+    }
+    // Otherwise return early as waiting until touch is regained
+    return ppgState;
+  }
+
+  // Drive changes
+  if (hrsHighCount > powerChangeDelay) {
+    if (ppgDrive == PPGDrive::Current40mAHigh) {
+      ppgDrive = PPGDrive::Current40mA;
+    } else if (ppgDrive == PPGDrive::Current40mA) {
+      ppgDrive = PPGDrive::Current30mA;
+    } else if (ppgDrive == PPGDrive::Current30mA) {
+      ppgDrive = PPGDrive::Current20mA;
+    } else if (ppgDrive == PPGDrive::Current20mA) {
+      ppgDrive = PPGDrive::Current13mA;
+    } else if (ppgDrive == PPGDrive::Current13mA) {
+      ppgDrive = PPGDrive::Current13mALow;
+    }
+  } else if (hrsLowCount > powerChangeDelay) {
+    if (ppgDrive == PPGDrive::Current13mALow) {
+      ppgDrive = PPGDrive::Current13mA;
+    } else if (ppgDrive == PPGDrive::Current13mA) {
+      ppgDrive = PPGDrive::Current20mA;
+    } else if (ppgDrive == PPGDrive::Current20mA) {
+      ppgDrive = PPGDrive::Current30mA;
+    } else if (ppgDrive == PPGDrive::Current30mA) {
+      ppgDrive = PPGDrive::Current40mA;
+    } else if (ppgDrive == PPGDrive::Current40mA) {
+      ppgDrive = PPGDrive::Current40mAHigh;
+    }
+  }
+
+  // Gain changes
+  if (alsHighCount > powerChangeDelay) {
+    if (ppgGain == PPGGain::Gain8x) {
+      ppgGain = PPGGain::Gain4x;
+    } else if (ppgGain == PPGGain::Gain4x) {
+      ppgGain = PPGGain::Gain2x;
+    } else if (ppgGain == PPGGain::Gain2x) {
+      ppgGain = PPGGain::Gain1x;
+    }
+  } else if (alsLowCount > gainUpWaitTime) {
+    if (ppgGain == PPGGain::Gain1x) {
+      ppgGain = PPGGain::Gain2x;
+    } else if (ppgGain == PPGGain::Gain2x) {
+      ppgGain = PPGGain::Gain4x;
+    } else if (ppgGain == PPGGain::Gain4x) {
+      ppgGain = PPGGain::Gain8x;
+    }
+    if (ppgGain != previousPpgGain) {
+      alsLowCount = gainUpWaitTime - gainUpCascadeWaitTime;
+    }
+  }
+
+  // Transition into no touch if maximum drive and hrs low
+  // Otherwise apply any gain/drive changes
+  if (ppgDrive == PPGDrive::Current40mAHigh && previousPpgDrive == PPGDrive::Current40mAHigh && hrs < touchLostThresh) {
+    actionDelay = noTouchDelay;
+    ppgState = PPGState::NoTouch;
+    ppgDrive = PPGDrive::NoTouchPowerSave;
+    ppgGain = PPGGain::Gain8x;
+    SetPower();
+  } else if (ppgDrive != previousPpgDrive || ppgGain != previousPpgGain) {
+    actionDelay = powerChangeDelay;
+    SetPower();
+  }
+  return ppgState;
 }

--- a/src/drivers/Hrs3300.h
+++ b/src/drivers/Hrs3300.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "drivers/TwiMaster.h"
+#include <components/heartrate/Ppg.h>
+#include <cstdint>
 
 namespace Pinetime {
   namespace Drivers {
@@ -9,17 +11,19 @@ namespace Pinetime {
       enum class Registers : uint8_t {
         Id = 0x00,
         Enable = 0x01,
-        EnableHen = 0x80,
-        C1dataM = 0x08,
+        C1DataM = 0x08,
         C0DataM = 0x09,
         C0DataH = 0x0a,
         PDriver = 0x0c,
-        C1dataH = 0x0d,
-        C1dataL = 0x0e,
-        C0dataL = 0x0f,
+        C1DataH = 0x0d,
+        C1DataL = 0x0e,
+        C0DataL = 0x0f,
         Res = 0x16,
-        Hgain = 0x17
+        HGain = 0x17
       };
+      // Reset is not used internally, it exists to inform the heart
+      // rate task that it should reset its state
+      enum class PPGState : uint8_t { Off, Running, NoTouch, Reset };
 
       struct PackedHrsAls {
         uint16_t hrs;
@@ -36,13 +40,42 @@ namespace Pinetime {
       void Enable();
       void Disable();
       PackedHrsAls ReadHrsAls();
+      PPGState AutoGain(uint16_t hrsAvg, uint16_t currentAls);
 
     private:
+      enum class PPGDrive : uint8_t {
+        NoTouchPowerSave,
+        // Special registers set
+        Current13mALow,
+        Current13mA,
+        Current20mA,
+        Current30mA,
+        Current40mA,
+        // Special registers set
+        Current40mAHigh,
+      };
+      enum class PPGGain : uint8_t { Gain1x, Gain2x, Gain4x, Gain8x };
       TwiMaster& twiMaster;
       uint8_t twiAddress;
 
+      uint8_t r7f;
+      uint8_t r80;
+      uint8_t r81;
+      uint8_t r82;
+      PPGDrive ppgDrive;
+      PPGGain ppgGain;
+      PPGState ppgState;
+
+      uint8_t actionDelay;
+
+      uint8_t hrsLowCount;
+      uint8_t hrsHighCount;
+      uint16_t alsLowCount;
+      uint8_t alsHighCount;
+
       void WriteRegister(uint8_t reg, uint8_t data);
       uint8_t ReadRegister(uint8_t reg);
+      void SetPower();
     };
   }
 }

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -1,11 +1,14 @@
 #include "heartratetask/HeartRateTask.h"
-#include <drivers/Hrs3300.h>
 #include <components/heartrate/HeartRateController.h>
+#include <drivers/Hrs3300.h>
+#include <drivers/Bma421.h>
 #include <limits>
+#include <optional>
 
 #include "utility/Math.h"
 
 using namespace Pinetime::Applications;
+using ControllerStates = Pinetime::Controllers::HeartRateController::States;
 
 namespace {
   constexpr TickType_t backgroundMeasurementTimeLimit = 30 * configTICK_RATE_HZ;
@@ -39,13 +42,13 @@ TickType_t HeartRateTask::CurrentTaskDelay() {
     // To avoid the number of milliseconds overflowing a u32, we take a factor of 2 out of the divisor and dividend
     // (1024 / 2) * 65536 * 100 = 3355443200 which is less than 2^32
 
+    constexpr uint16_t deltaTms = Controllers::Ppg::sampleDuration * 1000;
     // Guard against future tick rate changes
-    static_assert((configTICK_RATE_HZ / 2ULL) * (std::numeric_limits<decltype(count)>::max() + 1ULL) *
-                      static_cast<uint64_t>((Pinetime::Controllers::Ppg::deltaTms)) <
+    static_assert((configTICK_RATE_HZ / 2ULL) * (std::numeric_limits<decltype(count)>::max() + 1ULL) * static_cast<uint64_t>((deltaTms)) <
                     std::numeric_limits<uint32_t>::max(),
                   "Overflow");
     TickType_t elapsedTarget = Utility::RoundedDiv(static_cast<uint32_t>(configTICK_RATE_HZ / 2) * (static_cast<uint32_t>(count) + 1U) *
-                                                     static_cast<uint32_t>((Pinetime::Controllers::Ppg::deltaTms)),
+                                                     static_cast<uint32_t>((deltaTms)),
                                                    static_cast<uint32_t>(1000 / 2));
 
     // On count overflow, reset both count and start time
@@ -86,15 +89,16 @@ TickType_t HeartRateTask::CurrentTaskDelay() {
 
 HeartRateTask::HeartRateTask(Drivers::Hrs3300& heartRateSensor,
                              Controllers::HeartRateController& controller,
-                             Controllers::Settings& settings)
-  : heartRateSensor {heartRateSensor}, controller {controller}, settings {settings} {
+                             Controllers::Settings& settings,
+                             Drivers::Bma421& motionSensor)
+  : heartRateSensor {heartRateSensor}, controller {controller}, settings {settings}, motionSensor {motionSensor} {
 }
 
 void HeartRateTask::Start() {
   messageQueue = xQueueCreate(10, 1);
   controller.SetHeartRateTask(this);
 
-  if (pdPASS != xTaskCreate(HeartRateTask::Process, "Heartrate", 500, this, 1, &taskHandle)) {
+  if (xTaskCreate(HeartRateTask::Process, "HRM", 400, this, 1, &taskHandle) != pdPASS) {
     APP_ERROR_HANDLER(NRF_ERROR_NO_MEM);
   }
 }
@@ -142,10 +146,10 @@ void HeartRateTask::Work() {
           // If this constraint is somehow violated, the unexpected state
           // will self-resolve at the next screen on event
           newState = States::ForegroundMeasuring;
-          valueCurrentlyShown = false;
           break;
         case Messages::Disable:
           newState = States::Disabled;
+          SendHeartRate(ControllerStates::Disabled, 0);
           break;
       }
     }
@@ -180,50 +184,43 @@ void HeartRateTask::PushMessage(HeartRateTask::Messages msg) {
 
 void HeartRateTask::StartMeasurement() {
   heartRateSensor.Enable();
-  ppg.Reset(true);
-  vTaskDelay(100);
-  measurementSucceeded = false;
+  ppg.Reset();
   count = 0;
   measurementStartTime = xTaskGetTickCount();
 }
 
 void HeartRateTask::StopMeasurement() {
   heartRateSensor.Disable();
-  ppg.Reset(true);
-  vTaskDelay(100);
+  ppg.Reset();
+  controller.UpdateState(ControllerStates::Stopped);
 }
 
 void HeartRateTask::HandleSensorData() {
   auto sensorData = heartRateSensor.ReadHrsAls();
-  int8_t ambient = ppg.Preprocess(sensorData.hrs, sensorData.als);
-  int bpm = ppg.HeartRate();
-
-  // Ambient light detected
-  if (ambient > 0) {
-    // Reset all DAQ buffers
-    ppg.Reset(true);
-    controller.Update(Controllers::HeartRateController::States::NotEnoughData, bpm);
-    bpm = 0;
-    valueCurrentlyShown = false;
+  auto motionValues = motionSensor.Process();
+  // Sensor starting up
+  if (sensorData.hrs == 0) {
+    return;
   }
 
-  // Reset requested, or not enough data
-  if (bpm == -1) {
-    // Reset all DAQ buffers except HRS buffer
-    ppg.Reset(false);
-    // Set HR to zero and update
-    bpm = 0;
-    controller.Update(Controllers::HeartRateController::States::Running, bpm);
-    valueCurrentlyShown = false;
-  } else if (bpm == -2) {
-    // Not enough data
-    bpm = 0;
-    if (!valueCurrentlyShown) {
-      controller.Update(Controllers::HeartRateController::States::NotEnoughData, bpm);
+  ppg.Ingest(sensorData.hrs, motionValues.x, motionValues.y, motionValues.z);
+
+  std::optional<uint8_t> bpm = ppg.HeartRate();
+  if (bpm.has_value()) {
+    SendHeartRate(ControllerStates::Ready, bpm.value());
+  } else if (ppg.SufficientData()) {
+    SendHeartRate(ControllerStates::Searching, 0);
+  } else {
+    // If there's currently a value shown, don't clear it
+    // But still update the algorithm state
+    if (valueCurrentlyShown) {
+      controller.UpdateState(ControllerStates::NotEnoughData);
+    } else {
+      SendHeartRate(ControllerStates::NotEnoughData, 0);
     }
   }
 
-  if (bpm != 0) {
+  if (bpm.has_value()) {
     // Maintain constant frequency acquisition in background mode
     // If the last measurement time is set to the start time, then the next measurement
     // will start exactly one background period after this one
@@ -233,9 +230,6 @@ void HeartRateTask::HandleSensorData() {
     } else {
       lastMeasurementTime = xTaskGetTickCount();
     }
-    measurementSucceeded = true;
-    valueCurrentlyShown = true;
-    controller.Update(Controllers::HeartRateController::States::Running, bpm);
     return;
   }
   // If been measuring for longer than the time limit, set the last measurement time
@@ -243,19 +237,16 @@ void HeartRateTask::HandleSensorData() {
   // and also means that background measurement won't begin immediately after
   // an unsuccessful long foreground measurement
   if (xTaskGetTickCount() - measurementStartTime > backgroundMeasurementTimeLimit) {
-    // When measuring, propagate failure if no value within the time limit
-    // Prevents stale heart rates from being displayed for >1 background period
-    // Or more than the time limit after switching to screen on (where the last background measurement was successful)
-    // Note: Once a successful measurement is recorded in screen on it will never be cleared
-    // without some other state change e.g. ambient light reset
-    if (!measurementSucceeded) {
-      controller.Update(Controllers::HeartRateController::States::Running, 0);
-      valueCurrentlyShown = false;
-    }
     if (state == States::BackgroundMeasuring) {
       lastMeasurementTime = xTaskGetTickCount() - backgroundMeasurementTimeLimit;
     } else {
       lastMeasurementTime = xTaskGetTickCount();
     }
   }
+}
+
+void HeartRateTask::SendHeartRate(ControllerStates state, int bpm) {
+  valueCurrentlyShown = bpm != 0;
+  controller.UpdateState(state);
+  controller.UpdateHeartRate(bpm);
 }

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -222,7 +222,6 @@ void HeartRateTask::HandleSensorData() {
     SendHeartRate(ControllerStates::NoTouch, 0);
   } else if (ppgState == Drivers::Hrs3300::PPGState::Reset) {
     ppg.Reset();
-    count = 0;
     lastHrs = 0;
     SendHeartRate(ControllerStates::NotEnoughData, 0);
   } else if (ppgState == Drivers::Hrs3300::PPGState::Running) {

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -203,23 +203,42 @@ void HeartRateTask::HandleSensorData() {
     return;
   }
 
+  // If there are large discontinuities in the heart rate signal, scale the heart rate signal filter
+  // These discontinuities will be due to sensor gain or drive changes
+  static constexpr float discontinuityThreshold = 0.2f;
+  if (lastHrs != 0 && std::abs(static_cast<int32_t>(sensorData.hrs) - static_cast<int32_t>(lastHrs)) >
+                        std::min(lastHrs, sensorData.hrs) * discontinuityThreshold) {
+    ppg.ScaleHrs(static_cast<float>(sensorData.hrs) / static_cast<float>(lastHrs));
+  }
+  lastHrs = sensorData.hrs;
   ppg.Ingest(sensorData.hrs, motionValues.x, motionValues.y, motionValues.z);
 
-  std::optional<uint8_t> bpm = ppg.HeartRate();
-  if (bpm.has_value()) {
-    SendHeartRate(ControllerStates::Ready, bpm.value());
-  } else if (ppg.SufficientData()) {
-    SendHeartRate(ControllerStates::Searching, 0);
-  } else {
-    // If there's currently a value shown, don't clear it
-    // But still update the algorithm state
-    if (valueCurrentlyShown) {
-      controller.UpdateState(ControllerStates::NotEnoughData);
+  auto ppgState = heartRateSensor.AutoGain(sensorData.hrs, sensorData.als);
+
+  std::optional<uint8_t> bpm = std::nullopt;
+  if (ppgState == Drivers::Hrs3300::PPGState::NoTouch) {
+    SendHeartRate(ControllerStates::NoTouch, 0);
+  } else if (ppgState == Drivers::Hrs3300::PPGState::Reset) {
+    ppg.Reset();
+    count = 0;
+    lastHrs = 0;
+    SendHeartRate(ControllerStates::NotEnoughData, 0);
+  } else if (ppgState == Drivers::Hrs3300::PPGState::Running) {
+    bpm = ppg.HeartRate();
+    if (bpm.has_value()) {
+      SendHeartRate(ControllerStates::Ready, bpm.value());
+    } else if (ppg.SufficientData()) {
+      SendHeartRate(ControllerStates::Searching, 0);
     } else {
-      SendHeartRate(ControllerStates::NotEnoughData, 0);
+      // If there's currently a value shown, don't clear it
+      // But still update the algorithm state
+      if (valueCurrentlyShown) {
+        controller.UpdateState(ControllerStates::NotEnoughData);
+      } else {
+        SendHeartRate(ControllerStates::NotEnoughData, 0);
+      }
     }
   }
-
   if (bpm.has_value()) {
     // Maintain constant frequency acquisition in background mode
     // If the last measurement time is set to the start time, then the next measurement

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -149,7 +149,6 @@ void HeartRateTask::Work() {
           break;
         case Messages::Disable:
           newState = States::Disabled;
-          SendHeartRate(ControllerStates::Disabled, 0);
           break;
       }
     }
@@ -166,6 +165,10 @@ void HeartRateTask::Work() {
     } else if ((newState == States::Waiting || newState == States::Disabled) &&
                (state == States::ForegroundMeasuring || state == States::BackgroundMeasuring)) {
       StopMeasurement();
+      controller.UpdateState(ControllerStates::Stopped);
+    }
+    if (newState == States::Disabled) {
+      SendHeartRate(ControllerStates::Disabled, 0);
     }
     state = newState;
 
@@ -192,7 +195,6 @@ void HeartRateTask::StartMeasurement() {
 void HeartRateTask::StopMeasurement() {
   heartRateSensor.Disable();
   ppg.Reset();
-  controller.UpdateState(ControllerStates::Stopped);
 }
 
 void HeartRateTask::HandleSensorData() {

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -187,22 +187,27 @@ void HeartRateTask::PushMessage(HeartRateTask::Messages msg) {
 
 void HeartRateTask::StartMeasurement() {
   heartRateSensor.Enable();
+  // Need to clear tracking state
   ppg.Reset();
+  lastHrs = 0;
   count = 0;
   measurementStartTime = xTaskGetTickCount();
 }
 
 void HeartRateTask::StopMeasurement() {
   heartRateSensor.Disable();
-  ppg.Reset();
 }
 
 void HeartRateTask::HandleSensorData() {
   auto sensorData = heartRateSensor.ReadHrsAls();
   auto motionValues = motionSensor.Process();
-  // Sensor starting up
-  if (sensorData.hrs == 0) {
-    return;
+
+  // Reset whenever signal becomes active
+  // Need to avoid feeding 0 values into the algorithm
+  // without resetting after, as this causes
+  // severe ringing in the IIR filter stages
+  if (sensorData.hrs != 0 && lastHrs == 0) {
+    ppg.Reset();
   }
 
   // If there are large discontinuities in the heart rate signal, scale the heart rate signal filter
@@ -222,12 +227,11 @@ void HeartRateTask::HandleSensorData() {
     SendHeartRate(ControllerStates::NoTouch, 0);
   } else if (ppgState == Drivers::Hrs3300::PPGState::Reset) {
     ppg.Reset();
-    lastHrs = 0;
     SendHeartRate(ControllerStates::NotEnoughData, 0);
   } else if (ppgState == Drivers::Hrs3300::PPGState::Running) {
     bpm = ppg.HeartRate();
     if (bpm.has_value()) {
-      SendHeartRate(ControllerStates::Ready, bpm.value());
+      SendHeartRate(ControllerStates::Measuring, bpm.value());
     } else if (ppg.SufficientData()) {
       SendHeartRate(ControllerStates::Searching, 0);
     } else {
@@ -250,13 +254,11 @@ void HeartRateTask::HandleSensorData() {
     } else {
       lastMeasurementTime = xTaskGetTickCount();
     }
-    return;
-  }
-  // If been measuring for longer than the time limit, set the last measurement time
-  // This allows giving up on background measurement after a while
-  // and also means that background measurement won't begin immediately after
-  // an unsuccessful long foreground measurement
-  if (xTaskGetTickCount() - measurementStartTime > backgroundMeasurementTimeLimit) {
+  } else if (xTaskGetTickCount() - measurementStartTime > backgroundMeasurementTimeLimit) {
+    // If been measuring for longer than the time limit, set the last measurement time
+    // This allows giving up on background measurement after a while
+    // and also means that background measurement won't begin immediately after
+    // an unsuccessful long foreground measurement
     if (state == States::BackgroundMeasuring) {
       lastMeasurementTime = xTaskGetTickCount() - backgroundMeasurementTimeLimit;
     } else {

--- a/src/heartratetask/HeartRateTask.h
+++ b/src/heartratetask/HeartRateTask.h
@@ -43,6 +43,7 @@ namespace Pinetime {
       bool valueCurrentlyShown;
       States state = States::Disabled;
       uint16_t count;
+      uint16_t lastHrs = 0;
       Drivers::Hrs3300& heartRateSensor;
       Controllers::HeartRateController& controller;
       Controllers::Settings& settings;

--- a/src/heartratetask/HeartRateTask.h
+++ b/src/heartratetask/HeartRateTask.h
@@ -4,26 +4,24 @@
 #include <optional>
 #include <task.h>
 #include <queue.h>
-#include <components/heartrate/Ppg.h>
+#include "components/heartrate/Ppg.h"
 #include "components/settings/Settings.h"
+#include "components/heartrate/HeartRateController.h"
 
 namespace Pinetime {
   namespace Drivers {
     class Hrs3300;
-  }
-
-  namespace Controllers {
-    class HeartRateController;
+    class Bma421;
   }
 
   namespace Applications {
     class HeartRateTask {
     public:
       enum class Messages : uint8_t { GoToSleep, WakeUp, Enable, Disable };
-
       explicit HeartRateTask(Drivers::Hrs3300& heartRateSensor,
                              Controllers::HeartRateController& controller,
-                             Controllers::Settings& settings);
+                             Controllers::Settings& settings,
+                             Pinetime::Drivers::Bma421& motionSensor);
       void Start();
       void Work();
       void PushMessage(Messages msg);
@@ -38,16 +36,17 @@ namespace Pinetime {
       [[nodiscard]] bool BackgroundMeasurementNeeded() const;
       [[nodiscard]] std::optional<TickType_t> BackgroundMeasurementInterval() const;
       TickType_t CurrentTaskDelay();
+      void SendHeartRate(Controllers::HeartRateController::States state, int bpm);
 
       TaskHandle_t taskHandle;
       QueueHandle_t messageQueue;
       bool valueCurrentlyShown;
-      bool measurementSucceeded;
       States state = States::Disabled;
       uint16_t count;
       Drivers::Hrs3300& heartRateSensor;
       Controllers::HeartRateController& controller;
       Controllers::Settings& settings;
+      Drivers::Bma421& motionSensor;
       Controllers::Ppg ppg;
       TickType_t lastMeasurementTime;
       TickType_t measurementStartTime;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,7 @@ Pinetime::Controllers::Settings settingsController {fs};
 Pinetime::Controllers::MotorController motorController {};
 
 Pinetime::Controllers::HeartRateController heartRateController;
-Pinetime::Applications::HeartRateTask heartRateApp(heartRateSensor, heartRateController, settingsController);
+Pinetime::Applications::HeartRateTask heartRateApp(heartRateSensor, heartRateController, settingsController, motionSensor);
 
 Pinetime::Controllers::DateTime dateTimeController {settingsController};
 Pinetime::Drivers::Watchdog watchdog;


### PR DESCRIPTION
- New heart rate algorithm
   - Adaptive filtering to remove noise caused by motion
   - Harmonic analysis to match measured waveform with a real PPG waveform to reject noise
   - Frequency tracking and refinement over time
- Heart rate detection can now function in more challenging environments e.g. while running
- Full automatic gain and drive implementation for HRS3300 resulting in power saving in most scenarios while being able to adapt to full sunlight conditions on light skin, also adapts to darker skin tones better
  - Including no touch detection
- Much better noise tolerance: this algorithm reports failure instead of an incorrect heart rate value when the signal is poor. The heart rate values reported can be trusted a lot more
   - Algorithm accuracy validated against an ECG chest strap (Polar H10)
   - Also good performance on PPG-DaLiA (public PPG dataset): Mean absolute error (MAE) ~8BPM

Just to set expectations, while this is a solid improvement the HRS3300 sensor is really not that great so this implementation is nowhere the performance of flagship smartwatches today in terms of accuracy and recall


Big thanks to everyone over at wasp-os who [investigated the sensor performance](https://github.com/wasp-os/wasp-os/pull/363#issuecomment-1279733038), this work wouldn't have been possible without

I'm not sure it will be possible to merge this due to the memory usage of the adaptive filter. It might conflict with the G7710 watchface (I haven't tested as I use a custom G7710 version with seconds, so the fonts are smaller and use less memory)

This changes the way heart rate values are presented. With this implementation, you will only see a number when the algorithm is actively tracking the heart rate, or if the last background measurement was successful and the algorithm does not yet have enough data to begin searching for a heart rate (8 seconds of data)