### PR TITLE
Show blue icon when connected, grey when disconnected and hide when disabled

### DIFF
--- a/src/displayapp/widgets/StatusIcons.cpp
+++ b/src/displayapp/widgets/StatusIcons.cpp
@@ -48,10 +48,14 @@ void StatusIcons::Update() {
     lv_obj_set_hidden(alarmIcon, !alarmEnabled.Get());
   }
 
-  bleState = bleController.IsConnected();
   bleRadioEnabled = bleController.IsRadioEnabled();
-  if (bleState.IsUpdated() || bleRadioEnabled.IsUpdated()) {
-    lv_obj_set_hidden(bleIcon, !bleState.Get());
+  if (bleRadioEnabled.IsUpdated()) {
+    lv_obj_set_hidden(bleIcon, !bleRadioEnabled.Get());
+  }
+
+  bleState = bleController.IsConnected();
+  if (bleState.IsUpdated()) {
+    lv_obj_set_style_local_text_color(bleIcon, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, bleState.Get() ? LV_COLOR_BLUE : LV_COLOR_GRAY);
   }
 
   lv_obj_realign(container);


### PR DESCRIPTION
This is a rebased version of #1974 since there are longstanding conflicts in the branch. Attribution in the commit remains to the original author.

> This PR changes behaviour of bluetooth icon display.
> 
> Previous behaviour was that the icon showed coloured white when enabled and connected.
> 
> New behaviou is that the icon shows blue when connected, grey when disconnected and is hidden when disabled. This provides more info in the same space and is consistent with many common implementations which may offer a more familiar workflow.