### PR TITLE
[WIP] Disable heart rate tracking while power is connected (charging)

### DIFF
--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -1,6 +1,7 @@
 #include "heartratetask/HeartRateTask.h"
 #include <drivers/Hrs3300.h>
 #include <components/heartrate/HeartRateController.h>
+#include <components/battery/BatteryController.h>
 #include <limits>
 
 using namespace Pinetime::Applications;
@@ -90,8 +91,9 @@ TickType_t HeartRateTask::CurrentTaskDelay() {
 
 HeartRateTask::HeartRateTask(Drivers::Hrs3300& heartRateSensor,
                              Controllers::HeartRateController& controller,
+                             Controllers::Battery& battery,
                              Controllers::Settings& settings)
-  : heartRateSensor {heartRateSensor}, controller {controller}, settings {settings} {
+  : heartRateSensor {heartRateSensor}, controller {controller}, battery {battery}, settings {settings} {
 }
 
 void HeartRateTask::Start() {
@@ -153,10 +155,15 @@ void HeartRateTask::Work() {
           break;
       }
     }
-    if (newState == States::Waiting && BackgroundMeasurementNeeded()) {
-      newState = States::BackgroundMeasuring;
-    } else if (newState == States::BackgroundMeasuring && !BackgroundMeasurementNeeded()) {
+
+    if (newState != States::Disabled && battery.IsPowerPresent()) {
       newState = States::Waiting;
+    } else {
+      if (newState == States::Waiting && BackgroundMeasurementNeeded()) {
+        newState = States::BackgroundMeasuring;
+      } else if (newState == States::BackgroundMeasuring && !BackgroundMeasurementNeeded()) {
+        newState = States::Waiting;
+      }
     }
 
     // Apply state transition (switch sensor on/off)

--- a/src/heartratetask/HeartRateTask.h
+++ b/src/heartratetask/HeartRateTask.h
@@ -14,6 +14,7 @@ namespace Pinetime {
 
   namespace Controllers {
     class HeartRateController;
+    class Battery;
   }
 
   namespace Applications {
@@ -23,6 +24,7 @@ namespace Pinetime {
 
       explicit HeartRateTask(Drivers::Hrs3300& heartRateSensor,
                              Controllers::HeartRateController& controller,
+                             Controllers::Battery& battery,
                              Controllers::Settings& settings);
       void Start();
       void Work();
@@ -47,6 +49,7 @@ namespace Pinetime {
       uint16_t count;
       Drivers::Hrs3300& heartRateSensor;
       Controllers::HeartRateController& controller;
+      Controllers::Battery& battery;
       Controllers::Settings& settings;
       Controllers::Ppg ppg;
       TickType_t lastMeasurementTime;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,7 +99,7 @@ Pinetime::Controllers::Settings settingsController {fs};
 Pinetime::Controllers::MotorController motorController {};
 
 Pinetime::Controllers::HeartRateController heartRateController;
-Pinetime::Applications::HeartRateTask heartRateApp(heartRateSensor, heartRateController, settingsController);
+Pinetime::Applications::HeartRateTask heartRateApp(heartRateSensor, heartRateController, batteryController, settingsController);
 
 Pinetime::Controllers::DateTime dateTimeController {settingsController};
 Pinetime::Drivers::Watchdog watchdog;


### PR DESCRIPTION
This does not appear to actually disable heart rate monitoring. I think it may be worth adding new message states to communicate to the heart rate task via `SystemTask.cpp`.

Conceptually, the idea here was to force the task into a waiting state if the battery controller indicated power was present.

A similar idea would apply to the step tracker. I did not add a boolean flag to control whether this feature was on or off, but conceptually if someone built an external wearable battery or charger then this would be incomplete.

See #2369

Edit: Do not use as is in [0e67cff](https://github.com/InfiniTimeOrg/InfiniTime/commit/0e67cff623d0ed43d7b89b0261a96341fc0ecc8a), this introduces a crash when the heart rate setting is turned on in the heart rate app.