### PR TITLE
Keep heart rate tracking setting after reboot

### DIFF
--- a/src/components/heartrate/HeartRateController.h
+++ b/src/components/heartrate/HeartRateController.h
@@ -32,6 +32,8 @@ namespace Pinetime {
         return heartRate;
       }
 
+      void SaveSettings() const;
+
       void SetService(Pinetime::Controllers::HeartRateService* service);
 
     private:

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -336,6 +336,15 @@ namespace Pinetime {
         return (settings.dfuAndFsEnabledOnBoot ? DfuAndFsMode::Enabled : DfuAndFsMode::Disabled);
       };
 
+      void SetHeartRateRebootMode(bool enabled) {
+        settingsChanged = settingsChanged || (enabled != settings.heartRateEnabledOnBoot);
+        settings.heartRateEnabledOnBoot = enabled;
+      }
+
+      bool GetHeartRateRebootMode() {
+        return settings.heartRateEnabledOnBoot;
+      }
+
       std::optional<uint16_t> GetHeartRateBackgroundMeasurementInterval() const {
         if (settings.heartRateBackgroundPeriod == std::numeric_limits<uint16_t>::max()) {
           return std::nullopt;
@@ -354,7 +363,7 @@ namespace Pinetime {
     private:
       Pinetime::Controllers::FS& fs;
 
-      static constexpr uint32_t settingsVersion = 0x000a;
+      static constexpr uint32_t settingsVersion = 0x000b;
 
       struct SettingsData {
         uint32_t version = settingsVersion;
@@ -383,6 +392,7 @@ namespace Pinetime {
 
         bool dfuAndFsEnabledOnBoot = false;
         uint16_t heartRateBackgroundPeriod = std::numeric_limits<uint16_t>::max(); // Disabled by default
+        bool heartRateEnabledOnBoot = false;
       };
 
       SettingsData settings;

--- a/src/displayapp/screens/HeartRate.cpp
+++ b/src/displayapp/screens/HeartRate.cpp
@@ -72,6 +72,7 @@ HeartRate::HeartRate(Controllers::HeartRateController& heartRateController, Syst
 HeartRate::~HeartRate() {
   lv_task_del(taskRefresh);
   lv_obj_clean(lv_scr_act());
+  heartRateController.SaveSettings();
 }
 
 void HeartRate::Refresh() {

--- a/src/heartratetask/HeartRateTask.cpp
+++ b/src/heartratetask/HeartRateTask.cpp
@@ -96,7 +96,15 @@ void HeartRateTask::Start() {
 
   if (pdPASS != xTaskCreate(HeartRateTask::Process, "Heartrate", 500, this, 1, &taskHandle)) {
     APP_ERROR_HANDLER(NRF_ERROR_NO_MEM);
+  } else {
+    if (settings.GetHeartRateRebootMode())
+      controller.Enable();
   }
+}
+
+void HeartRateTask::SaveSettings() {
+  if (task)
+    task->SaveSettings();
 }
 
 void HeartRateTask::Process(void* instance) {
@@ -143,9 +151,11 @@ void HeartRateTask::Work() {
           // will self-resolve at the next screen on event
           newState = States::ForegroundMeasuring;
           valueCurrentlyShown = false;
+          settings.SetHeartRateRebootMode(true);
           break;
         case Messages::Disable:
           newState = States::Disabled;
+          settings.SetHeartRateRebootMode(false);
           break;
       }
     }
@@ -170,6 +180,10 @@ void HeartRateTask::Work() {
       count++;
     }
   }
+}
+
+void HeartRateTask::SaveSettings() {
+  settings.SaveSettings();
 }
 
 void HeartRateTask::PushMessage(HeartRateTask::Messages msg) {

--- a/src/heartratetask/HeartRateTask.h
+++ b/src/heartratetask/HeartRateTask.h
@@ -27,6 +27,7 @@ namespace Pinetime {
       void Start();
       void Work();
       void PushMessage(Messages msg);
+      void SaveSettings();
 
     private:
       enum class States : uint8_t { Disabled, Waiting, BackgroundMeasuring, ForegroundMeasuring };


### PR DESCRIPTION
When the watch boots check the user's last known setting.

See: #2364

