### PR TITLE
flashlight: Add multiple display modes

### DIFF
--- a/src/displayapp/screens/FlashLight.h
+++ b/src/displayapp/screens/FlashLight.h
@@ -21,6 +21,9 @@ namespace Pinetime {
         void Toggle();
 
       private:
+        enum class Mode : uint8_t { Off = 0, Red = 1, White = 2, Strobe = 3 };
+
+        void Refresh() override;
         void SetIndicators();
         void SetColors();
 
@@ -33,7 +36,9 @@ namespace Pinetime {
         lv_obj_t* flashLight;
         lv_obj_t* backgroundAction;
         lv_obj_t* indicators[3];
-        bool isOn = false;
+        Mode currentMode = Mode::Off;
+
+        lv_task_t* taskRefresh = nullptr;
       };
     }
   }


### PR DESCRIPTION
Adds various modes to the flashlight app:
- Off
- Red (night mode)
- White (normal)
- Strobe (safety/emergency signaling)

Tapping the screen cycles through these modes. This makes it behave more like standard headlamps or safety hiking/cycling lights, with the first mode always red to not affect your pupils in the dark.

![InfiniSim_2025-11-25_170421](https://github.com/user-attachments/assets/e667fa3c-a3b3-4152-beb7-b60c6db7f884)

Note: The strobe looks strange in the animation because of the InfiniSim refresh rate. It looks better on the real watch, since it turns the backlight on and off directly.

Also the strobe is 2Hz at 20% duty cycle (100ms on, 400ms off), which provides good visibility from a distance and is low enough that it won't trigger people with photosensitive epilepsy.