### PR TITLE
Split oversized SPI reads

### DIFF
--- a/src/drivers/SpiMaster.cpp
+++ b/src/drivers/SpiMaster.cpp
@@ -161,6 +161,7 @@ void SpiMaster::OnStartedEvent() {
 }
 
 void SpiMaster::PrepareTx(const uint32_t bufferAddress, const size_t size) {
+  ASSERT(size < 256);
   spiBaseAddress->TXD.PTR = bufferAddress;
   spiBaseAddress->TXD.MAXCNT = size;
   spiBaseAddress->TXD.LIST = 0;
@@ -171,6 +172,7 @@ void SpiMaster::PrepareTx(const uint32_t bufferAddress, const size_t size) {
 }
 
 void SpiMaster::PrepareRx(const uint32_t bufferAddress, const size_t size) {
+  ASSERT(size < 256);
   spiBaseAddress->TXD.PTR = 0;
   spiBaseAddress->TXD.MAXCNT = 0;
   spiBaseAddress->TXD.LIST = 0;
@@ -240,12 +242,17 @@ bool SpiMaster::Read(uint8_t pinCsn, uint8_t* cmd, size_t cmdSize, uint8_t* data
   spiBaseAddress->TASKS_START = 1;
   while (spiBaseAddress->EVENTS_END == 0)
     ;
+  while (dataSize > 0) {
+    size_t readSize = std::min(dataSize, 255U);
+    PrepareRx((uint32_t) data, readSize);
+    spiBaseAddress->TASKS_START = 1;
 
-  PrepareRx((uint32_t) data, dataSize);
-  spiBaseAddress->TASKS_START = 1;
-
-  while (spiBaseAddress->EVENTS_END == 0)
-    ;
+    while (spiBaseAddress->EVENTS_END == 0) {
+      ;
+    }
+    data += readSize;
+    dataSize -= readSize;
+  }
   nrf_gpio_pin_set(this->pinCsn);
 
   xSemaphoreGive(mutex);


### PR DESCRIPTION
SPI reads larger than 255 bytes are not split up into smaller transactions (this is already implemented for writes)

I don't think this currently impacts anything in InfiniTime, but maybe it is causing subtle issues somewhere


@pipe01 you might want to check for transaction size in InfiniEmu :)