### PR TITLE
Increase battery measurement precision and frequency

### DIFF
--- a/src/components/battery/BatteryController.cpp
+++ b/src/components/battery/BatteryController.cpp
@@ -12,7 +12,8 @@ Battery* Battery::instance = nullptr;
 
 Battery::Battery() {
   instance = this;
-  nrf_gpio_cfg_input(PinMap::Charging, static_cast<nrf_gpio_pin_pull_t> GPIO_PIN_CNF_PULL_Disabled);
+  nrf_gpio_cfg_input(PinMap::Charging, NRF_GPIO_PIN_NOPULL);
+  SaadcInit();
 }
 
 void Battery::ReadPowerState() {
@@ -34,7 +35,6 @@ void Battery::MeasureVoltage() {
   }
   // Non blocking read
   isReading = true;
-  SaadcInit();
 
   nrfx_saadc_sample();
 }
@@ -44,7 +44,11 @@ void Battery::AdcCallbackStatic(nrfx_saadc_evt_t const* event) {
 }
 
 void Battery::SaadcInit() {
-  nrfx_saadc_config_t adcConfig = NRFX_SAADC_DEFAULT_CONFIG;
+  nrfx_saadc_config_t adcConfig;
+  adcConfig.low_power_mode = true;
+  adcConfig.resolution = NRF_SAADC_RESOLUTION_14BIT;
+  adcConfig.oversample = NRF_SAADC_OVERSAMPLE_256X;
+  adcConfig.interrupt_priority = APP_IRQ_PRIORITY_LOW;
   APP_ERROR_CHECK(nrfx_saadc_init(&adcConfig, AdcCallbackStatic));
 
   nrf_saadc_channel_config_t adcChannelConfig = {.resistor_p = NRF_SAADC_RESISTOR_DISABLED,
@@ -72,8 +76,8 @@ void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
     // ADC gain is 1/4
     // thus adc_voltage = battery_voltage / 2 * gain = battery_voltage / 8
     // reference_voltage is 600mV
-    // p_event->data.done.p_buffer[0] = (adc_voltage / reference_voltage) * 1024
-    voltage = p_event->data.done.p_buffer[0] * (8 * 600) / 1024;
+    // p_event->data.done.p_buffer[0] = (adc_voltage / reference_voltage) * (2^(sampling res) )
+    voltage = p_event->data.done.p_buffer[0] * (8 * 600) / 16384;
 
     uint8_t newPercent = 100;
     if (!isFull) {
@@ -81,13 +85,9 @@ void Battery::SaadcEventHandler(nrfx_saadc_evt_t const* p_event) {
       newPercent = std::min(approx.GetValue(voltage), isCharging ? uint8_t {99} : uint8_t {100});
     }
 
-    if ((isPowerPresent && newPercent > percentRemaining) || (!isPowerPresent && newPercent < percentRemaining) || firstMeasurement) {
-      firstMeasurement = false;
-      percentRemaining = newPercent;
-      systemTask->PushMessage(System::Messages::BatteryPercentageUpdated);
-    }
+    percentRemaining = newPercent;
+    systemTask->PushMessage(System::Messages::BatteryPercentageUpdated);
 
-    nrfx_saadc_uninit();
     isReading = false;
   }
 }

--- a/src/components/battery/BatteryController.h
+++ b/src/components/battery/BatteryController.h
@@ -43,7 +43,6 @@ namespace Pinetime {
       bool isFull = false;
       bool isCharging = false;
       bool isPowerPresent = false;
-      bool firstMeasurement = true;
 
       void SaadcInit();
 

--- a/src/systemtask/SystemTask.h
+++ b/src/systemtask/SystemTask.h
@@ -142,7 +142,7 @@ namespace Pinetime {
       void GoToRunning();
       void GoToSleep();
       void UpdateMotion();
-      static constexpr TickType_t batteryMeasurementPeriod = pdMS_TO_TICKS(10 * 60 * 1000);
+      static constexpr TickType_t batteryMeasurementPeriod = 60 * configTICK_RATE_HZ;
 
       SystemMonitor monitor;
     };


### PR DESCRIPTION
- Use SAADC oversampling and higher bit depth to get more precise measurements
  - Currently the sampling resolution means that some percentage values are impossible! \[1\]
- Sample battery every minute rather than every 10 minutes
- The power usage from running the ADC more often should be negligible (calculated to be the equivalent of constantly drawing \<400nA)

This removes the battery smoothing that prevents the reported percentage from going up while off charge. I'm personally not a fan of it, as if someone uses high brightness than if the battery is measured while the screen is on the battery charge is underestimated significantly, and this results in the percentage staying at this underestimate for a long time since it's not allowed back up. But maybe this will be confusing to users? I'm not sure what the best choice is here. We could also keep the clamping but have some smoothing applied to the battery value so the occasional measurement while the screen is on doesn't tank it too much?

![ceebd5c5-b579-400d-9182-ecd2418c3bf5](https://github.com/user-attachments/assets/f178dd50-964b-4aad-b4ea-6bc1869ec453)

Example of how it looks, note there are a few spots of missing data as out of range on bluetooth. AOD is used here.
  
\[1\]
  
Battery measured from 4180mV-3500mV, so 680mV range. ADC ref: 0.6v, ADC gain: 1/4, HW gain: 1/2, so the ADC can measure from 0V to 0.6\*4\*2=4.8V, 4800mV total. So about 14.2% of the measurement range is used ~(2<sup>-3</sup>). So with 10bit ADC (current resolution), assuming no measurement noise (unrealistic, expect at least 1bit noise), we have 10 bit - 3 bit = 7 bits of resolution or 128 possible values (just more than the 100 percentage points).

However, the mapping from voltage to percentage is nonlinear. 3776mV-3723mV accounts for 26%, actual range 53mV (2<sup>-6.5</sup>). 10 bit - 6.5bit = 3.5 bit or 11 values, which is less than the 26 percentage points it is mapped to. So some of the percentages are impossible.

  
  