### PR TITLE
Add a configurable quick access app on the right of the home screen

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -418,6 +418,7 @@ list(APPEND SOURCE_FILES
         displayapp/screens/settings/SettingSetDate.cpp
         displayapp/screens/settings/SettingSetTime.cpp
         displayapp/screens/settings/SettingChimes.cpp
+        displayapp/screens/settings/SettingQuickAccess.cpp
         displayapp/screens/settings/SettingShakeThreshold.cpp
         displayapp/screens/settings/SettingBluetooth.cpp
         displayapp/screens/settings/SettingOTA.cpp

--- a/src/components/settings/Settings.h
+++ b/src/components/settings/Settings.h
@@ -87,6 +87,17 @@ namespace Pinetime {
         return settings.chimesOption;
       };
 
+      void SetQuickAccessApp(Pinetime::Applications::Apps app) {
+        if (app != settings.quickAccessApp) {
+          settingsChanged = true;
+        }
+        settings.quickAccessApp = app;
+      }
+
+      Pinetime::Applications::Apps GetQuickAccessApp() const {
+        return settings.quickAccessApp;
+      };
+
       void SetPTSColorTime(Colors colorTime) {
         if (colorTime != settings.PTS.ColorTime)
           settingsChanged = true;
@@ -369,6 +380,7 @@ namespace Pinetime {
 
         Pinetime::Applications::WatchFace watchFace = Pinetime::Applications::WatchFace::Digital;
         ChimesOption chimesOption = ChimesOption::None;
+        Pinetime::Applications::Apps quickAccessApp = Pinetime::Applications::Apps::None;
 
         PineTimeStyle PTS;
 

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -48,6 +48,7 @@
 #include "displayapp/screens/settings/SettingSteps.h"
 #include "displayapp/screens/settings/SettingSetDateTime.h"
 #include "displayapp/screens/settings/SettingChimes.h"
+#include "displayapp/screens/settings/SettingQuickAccess.h"
 #include "displayapp/screens/settings/SettingHeartRate.h"
 #include "displayapp/screens/settings/SettingShakeThreshold.h"
 #include "displayapp/screens/settings/SettingBluetooth.h"
@@ -624,6 +625,9 @@ void DisplayApp::LoadScreen(Apps app, DisplayApp::FullRefreshDirections directio
       break;
     case Apps::SettingChimes:
       currentScreen = std::make_unique<Screens::SettingChimes>(settingsController);
+      break;
+    case Apps::SettingQuickAccess:
+      currentScreen = std::make_unique<Screens::SettingQuickAccess>(settingsController);
       break;
     case Apps::SettingShakeThreshold:
       currentScreen = std::make_unique<Screens::SettingShakeThreshold>(settingsController, motionController, *systemTask);

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -431,6 +431,11 @@ void DisplayApp::Refresh() {
               case TouchEvents::SwipeRight:
                 LoadNewScreen(Apps::QuickSettings, DisplayApp::FullRefreshDirections::RightAnim);
                 break;
+              case TouchEvents::SwipeLeft:
+                if (settingsController.GetQuickAccessApp() != Apps::None) {
+                  LoadNewScreen(settingsController.GetQuickAccessApp(), DisplayApp::FullRefreshDirections::LeftAnim);
+                }
+                break;
               case TouchEvents::DoubleTap:
                 PushMessageToSystemTask(System::Messages::GoToSleep);
                 break;

--- a/src/displayapp/apps/Apps.h.in
+++ b/src/displayapp/apps/Apps.h.in
@@ -42,6 +42,7 @@ namespace Pinetime {
       SettingSteps,
       SettingSetDateTime,
       SettingChimes,
+      SettingQuickAccess,
       SettingShakeThreshold,
       SettingBluetooth,
       SettingOTA,

--- a/src/displayapp/fonts/fonts.json
+++ b/src/displayapp/fonts/fonts.json
@@ -12,7 +12,10 @@
       ],
       "bpp": 1,
       "size": 20,
-      "patches": ["jetbrains_mono_bold_20.c_zero.patch", "jetbrains_mono_bold_20.c_M.patch"]
+      "patches": [
+         "jetbrains_mono_bold_20.c_zero.patch",
+         "jetbrains_mono_bold_20.c_M.patch"
+      ]
    },
    "jetbrains_mono_42": {
       "sources": [

--- a/src/displayapp/screens/settings/SettingQuickAccess.cpp
+++ b/src/displayapp/screens/settings/SettingQuickAccess.cpp
@@ -14,7 +14,8 @@ namespace {
     const char* name;
   };
 
-  constexpr std::array<Option, 3> options = {{
+  constexpr std::array<Option, 4> options = {{
+    {Pinetime::Applications::Apps::None, "None"},
     {Pinetime::Applications::Apps::Music, "Music"},
     {Pinetime::Applications::Apps::HeartRate, "Heart Rate"},
     {Pinetime::Applications::Apps::StopWatch, "Stopwatch"},

--- a/src/displayapp/screens/settings/SettingQuickAccess.cpp
+++ b/src/displayapp/screens/settings/SettingQuickAccess.cpp
@@ -1,0 +1,63 @@
+#include "displayapp/screens/settings/SettingQuickAccess.h"
+#include <lvgl/lvgl.h>
+#include "displayapp/DisplayApp.h"
+#include "displayapp/screens/Styles.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/Symbols.h"
+#include <array>
+
+using namespace Pinetime::Applications::Screens;
+
+namespace {
+  struct Option {
+    Pinetime::Applications::Apps app;
+    const char* name;
+  };
+
+  constexpr std::array<Option, 3> options = {{
+    {Pinetime::Applications::Apps::Music, "Music"},
+    {Pinetime::Applications::Apps::HeartRate, "Heart Rate"},
+    {Pinetime::Applications::Apps::StopWatch, "Stopwatch"},
+  }};
+
+  std::array<CheckboxList::Item, CheckboxList::MaxItems> CreateOptionArray() {
+    std::array<Pinetime::Applications::Screens::CheckboxList::Item, CheckboxList::MaxItems> optionArray;
+    for (size_t i = 0; i < CheckboxList::MaxItems; i++) {
+      if (i >= options.size()) {
+        optionArray[i].name = "";
+        optionArray[i].enabled = false;
+      } else {
+        optionArray[i].name = options[i].name;
+        optionArray[i].enabled = true;
+      }
+    }
+    return optionArray;
+  }
+
+  uint32_t GetDefaultOption(Pinetime::Applications::Apps currentApp) {
+    for (size_t i = 0; i < options.size(); i++) {
+      if (options[i].app == currentApp) {
+        return i;
+      }
+    }
+    return 0;
+  }
+}
+
+SettingQuickAccess::SettingQuickAccess(Pinetime::Controllers::Settings& settingsController)
+  : checkboxList(
+      0,
+      1,
+      "Quick Access",
+      Symbols::list,
+      GetDefaultOption(settingsController.GetQuickAccessApp()),
+      [&settings = settingsController](uint32_t index) {
+        settings.SetQuickAccessApp(options[index].app);
+        settings.SaveSettings();
+      },
+      CreateOptionArray()) {
+}
+
+SettingQuickAccess::~SettingQuickAccess() {
+  lv_obj_clean(lv_scr_act());
+}

--- a/src/displayapp/screens/settings/SettingQuickAccess.h
+++ b/src/displayapp/screens/settings/SettingQuickAccess.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+#include <lvgl/lvgl.h>
+
+#include "components/settings/Settings.h"
+#include "displayapp/screens/Screen.h"
+#include "displayapp/screens/CheckboxList.h"
+
+namespace Pinetime {
+
+  namespace Applications {
+    namespace Screens {
+
+      class SettingQuickAccess : public Screen {
+      public:
+        SettingQuickAccess(Pinetime::Controllers::Settings& settingsController);
+        ~SettingQuickAccess() override;
+
+        void UpdateSelected(lv_obj_t* object, lv_event_t event);
+
+      private:
+        CheckboxList checkboxList;
+      };
+    }
+  }
+}

--- a/src/displayapp/screens/settings/Settings.h
+++ b/src/displayapp/screens/settings/Settings.h
@@ -34,7 +34,7 @@ namespace Pinetime {
         static constexpr std::array<List::Applications, entriesPerScreen * nScreens> entries {{
           {Symbols::sun, "Display", Apps::SettingDisplay},
           {Symbols::eye, "Wake Up", Apps::SettingWakeUp},
-          {Symbols::clock, "Time format", Apps::SettingTimeFormat},
+          {Symbols::list, "Quick Access", Apps::SettingQuickAccess},
           {Symbols::home, "Watch face", Apps::SettingWatchFace},
 
           {Symbols::shoe, "Steps", Apps::SettingSteps},
@@ -47,6 +47,7 @@ namespace Pinetime {
           {Symbols::tachometer, "Shake Calib.", Apps::SettingShakeThreshold},
           {Symbols::check, "Firmware", Apps::FirmwareValidation},
 
+          {Symbols::clock, "Time format", Apps::SettingTimeFormat},
           {Symbols::shieldAlt, "Over-the-air", Apps::SettingOTA},
           {Symbols::bluetooth, "Bluetooth", Apps::SettingBluetooth},
           {Symbols::list, "About", Apps::SysInfo},


### PR DESCRIPTION
### Summary

This PR adds functionality to pick an app for "quick access" by swiping right on the home screen. A swipe left opens the home screen again.

The current PR only supports three predefined apps, because I wanted to see if more people would enjoy this functionality before spending more time on generalizing this. My personal use case is to quickly open my (WIP) home assistant app, allowing me to control my devices without having to go through the app menu first.

### Notes:

- Currently, the icon in the settings app is reused from the about option. Maybe a new icon would be a better fit.
- Swiping back doesn't work for apps that capture the event, such as the music app.