### PR TITLE
Adjust display init sequence to fix a rotation issue on the new ST7789P3 display controller

### DIFF
--- a/src/drivers/St7789.cpp
+++ b/src/drivers/St7789.cpp
@@ -17,7 +17,6 @@ void St7789::Init() {
   HardwareReset();
   SoftwareReset();
   Command2Enable();
-  SleepOut();
   PixelFormat();
   MemoryDataAccessControl();
   SetAddrWindow(0, 0, Width, Height);
@@ -32,6 +31,7 @@ void St7789::Init() {
   SetVdv();
   PowerControl();
   GateControl();
+  SleepOut();
   DisplayOn();
 }
 


### PR DESCRIPTION
Those changes were suggested by PineStore engineering team to ensure that the new ST7789P3 will be supported by InfiniTime.

They basically move the call to the SLEEPOUT command after all the registers have been set. This should fix the rotation issue they detected while testing the new display.

Fixes #2439 