### PR TITLE
Add a no-op LVGL guard hook to DisplayApp::Refresh (companion to InfiniSim thread-race fix)

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -1,4 +1,5 @@
 #include "displayapp/DisplayApp.h"
+#include "displayapp/LvglGuard.h"
 #include <libraries/log/nrf_log.h>
 #include "displayapp/screens/HeartRate.h"
 #include "displayapp/screens/Motion.h"
@@ -234,10 +235,12 @@ void DisplayApp::Refresh() {
   };
 
   TickType_t queueTimeout;
-  switch (state) {
-    case States::Idle:
-      queueTimeout = portMAX_DELAY;
-      break;
+  {
+    LVGL_GUARD();
+    switch (state) {
+      case States::Idle:
+        queueTimeout = portMAX_DELAY;
+        break;
     case States::AOD:
       if (!currentScreen->IsRunning()) {
         LoadPreviousScreen();
@@ -290,13 +293,18 @@ void DisplayApp::Refresh() {
         ApplyBrightness();
       }
       break;
-    default:
-      queueTimeout = portMAX_DELAY;
-      break;
+      default:
+        queueTimeout = portMAX_DELAY;
+        break;
+    }
   }
 
   Messages msg;
-  if (xQueueReceive(msgQueue, &msg, queueTimeout) == pdTRUE) {
+  const bool receivedMsg = xQueueReceive(msgQueue, &msg, queueTimeout) == pdTRUE;
+  // Guard everything after the (unguarded) queue wait: message handling loads
+  // screens and the tail touches LVGL too.
+  LVGL_GUARD();
+  if (receivedMsg) {
     switch (msg) {
       case Messages::GoToSleep:
       case Messages::GoToAOD:

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -241,58 +241,58 @@ void DisplayApp::Refresh() {
       case States::Idle:
         queueTimeout = portMAX_DELAY;
         break;
-    case States::AOD:
-      if (!currentScreen->IsRunning()) {
-        LoadPreviousScreen();
-      }
-      // Check we've slept long enough
-      // Might not be true if the loop received an event
-      // If not true, then wait that amount of time
-      queueTimeout = CalculateSleepTime();
-      if (queueTimeout == 0) {
-        // Only advance the tick count when LVGL is done
-        // Otherwise keep running the task handler while it still has things to draw
-        // Note: under high graphics load, LVGL will always have more work to do
-        if (lv_task_handler() > 0) {
-          // Drop frames that we've missed if drawing/event handling took way longer than expected
-          while (queueTimeout == 0) {
-            alwaysOnFrameCount += 1;
-            queueTimeout = CalculateSleepTime();
+      case States::AOD:
+        if (!currentScreen->IsRunning()) {
+          LoadPreviousScreen();
+        }
+        // Check we've slept long enough
+        // Might not be true if the loop received an event
+        // If not true, then wait that amount of time
+        queueTimeout = CalculateSleepTime();
+        if (queueTimeout == 0) {
+          // Only advance the tick count when LVGL is done
+          // Otherwise keep running the task handler while it still has things to draw
+          // Note: under high graphics load, LVGL will always have more work to do
+          if (lv_task_handler() > 0) {
+            // Drop frames that we've missed if drawing/event handling took way longer than expected
+            while (queueTimeout == 0) {
+              alwaysOnFrameCount += 1;
+              queueTimeout = CalculateSleepTime();
+            }
           }
         }
-      }
-      break;
-    case States::Running:
-      if (!currentScreen->IsRunning()) {
-        LoadPreviousScreen();
-      }
-      queueTimeout = lv_task_handler();
+        break;
+      case States::Running:
+        if (!currentScreen->IsRunning()) {
+          LoadPreviousScreen();
+        }
+        queueTimeout = lv_task_handler();
 
-      if (!systemTask->IsSleepDisabled() && IsPastDimTime()) {
-        if (!isDimmed) {
-          isDimmed = true;
-          brightnessController.Set(Controllers::BrightnessController::Levels::Low);
+        if (!systemTask->IsSleepDisabled() && IsPastDimTime()) {
+          if (!isDimmed) {
+            isDimmed = true;
+            brightnessController.Set(Controllers::BrightnessController::Levels::Low);
+          }
+          if (IsPastSleepTime() && uxQueueMessagesWaiting(msgQueue) == 0) {
+            PushMessageToSystemTask(System::Messages::GoToSleep);
+            // Can't set state to Idle here, something may send
+            // DisableSleeping before this GoToSleep arrives
+            // Instead we check we have no messages queued before sending GoToSleep
+            // This works as the SystemTask is higher priority than DisplayApp
+            // As soon as we send GoToSleep, SystemTask pre-empts DisplayApp
+            // Whenever DisplayApp is running again, it is guaranteed that
+            // SystemTask has handled the message
+            // If it responded, we will have a GoToSleep waiting in the queue
+            // By checking that there are no messages in the queue, we avoid
+            // resending GoToSleep when we already have a response
+            // SystemTask is resilient to duplicate messages, this is an
+            // optimisation to reduce pressure on the message queues
+          }
+        } else if (isDimmed) {
+          isDimmed = false;
+          ApplyBrightness();
         }
-        if (IsPastSleepTime() && uxQueueMessagesWaiting(msgQueue) == 0) {
-          PushMessageToSystemTask(System::Messages::GoToSleep);
-          // Can't set state to Idle here, something may send
-          // DisableSleeping before this GoToSleep arrives
-          // Instead we check we have no messages queued before sending GoToSleep
-          // This works as the SystemTask is higher priority than DisplayApp
-          // As soon as we send GoToSleep, SystemTask pre-empts DisplayApp
-          // Whenever DisplayApp is running again, it is guaranteed that
-          // SystemTask has handled the message
-          // If it responded, we will have a GoToSleep waiting in the queue
-          // By checking that there are no messages in the queue, we avoid
-          // resending GoToSleep when we already have a response
-          // SystemTask is resilient to duplicate messages, this is an
-          // optimisation to reduce pressure on the message queues
-        }
-      } else if (isDimmed) {
-        isDimmed = false;
-        ApplyBrightness();
-      }
-      break;
+        break;
       default:
         queueTimeout = portMAX_DELAY;
         break;

--- a/src/displayapp/LvglGuard.h
+++ b/src/displayapp/LvglGuard.h
@@ -1,0 +1,8 @@
+#pragma once
+
+// On hardware, LVGL is only ever touched by the display task, so no locking is
+// needed and this is a no-op. InfiniSim shadows this header (sim/displayapp/
+// LvglGuard.h) with a real mutex: the simulator's main thread also drives LVGL
+// while the display task sleeps (the "Screen is OFF" overlay), and the
+// wake/sleep handoff races the display task without it.
+#define LVGL_GUARD() (void) 0


### PR DESCRIPTION
Companion to InfiniTimeOrg/InfiniSim#198.

## What this does

Adds `src/displayapp/LvglGuard.h` with a single macro, `LVGL_GUARD()`, and calls it around the two LVGL regions of `DisplayApp::Refresh` (the state switch that runs `lv_task_handler`, and the message-handling block). It deliberately does not wrap the blocking queue wait between them.

On hardware the macro is a no-op:

```c
#define LVGL_GUARD() (void) 0
```

So this changes nothing on the watch. LVGL there has a single owner, the display task, and the compiler drops the macro entirely.

## Why

The value is in the simulator. InfiniSim drives LVGL from two threads: the DisplayApp task, and its SDL main thread, which renders the "Screen is OFF" overlay and runs `lv_task_handler` while the display task sleeps. The wake/sleep handoff between them corrupts the LVGL heap. InfiniSim shadows this header (via include-path order, the same mechanism it already uses for `nrf_log.h`) with a version that defines `LVGL_GUARD()` as a real mutex, so both threads serialize. That side of the fix, the crash reproduction, and the AddressSanitizer trace are in InfiniTimeOrg/InfiniSim#198.

The guard has to live in InfiniTime because the DisplayApp task is InfiniTime code; InfiniSim cannot serialize against it from the outside. This PR is the minimal hook that lets it.

## Scope

Two files, +24/-8. No behavior change on hardware. The mutex, the try-lock on the simulator's main thread, and the verification all live in the InfiniSim PR.