### PR TITLE
Keep external flash awake during AOD

### DIFF
--- a/src/systemtask/SystemTask.cpp
+++ b/src/systemtask/SystemTask.cpp
@@ -310,14 +310,14 @@ void SystemTask::Work() {
           if (state != SystemTaskState::GoingToSleep) {
             break;
           }
-          if (BootloaderVersion::IsValid()) {
-            // First versions of the bootloader do not expose their version and cannot initialize the SPI NOR FLASH
-            // if it's in sleep mode. Avoid bricked device by disabling sleep mode on these versions.
-            spiNorFlash.Sleep();
-          }
 
-          // Must keep SPI awake when still updating the display for always on
+          // Must keep SPI and flash awake when still updating the display for always on
           if (msg == Messages::OnDisplayTaskSleeping) {
+            if (BootloaderVersion::IsValid()) {
+              // First versions of the bootloader do not expose their version and cannot initialize the SPI NOR FLASH
+              // if it's in sleep mode. Avoid bricked device by disabling sleep mode on these versions.
+              spiNorFlash.Sleep();
+            }
             spi.Sleep();
           }
 
@@ -409,14 +409,13 @@ void SystemTask::GoToRunning() {
     // SPI only switched off when entering Sleeping, not AOD or GoingToSleep
     if (state == SystemTaskState::Sleeping) {
       spi.Wakeup();
+      spiNorFlash.Wakeup();
     }
 
     // Double Tap needs the touch screen to be in normal mode
     if (!settingsController.isWakeUpModeOn(Pinetime::Controllers::Settings::WakeUpMode::DoubleTap)) {
       touchPanel.Wakeup();
     }
-
-    spiNorFlash.Wakeup();
   }
 
   displayApp.PushMessage(Pinetime::Applications::Display::Messages::GoToRunning);


### PR DESCRIPTION
Fixes #2451 

According to https://pine64.org/documentation/PineTime/_full/#reducing-power-consumption this costs 14uA.
Given that AOD already uses ~3mA, which is ~200x more, I expect no battery life changes