### PR TITLE
DateTimeController: Fix build with libc++

### DIFF
--- a/src/components/datetime/DateTimeController.cpp
+++ b/src/components/datetime/DateTimeController.cpp
@@ -104,7 +104,8 @@ void DateTime::UpdateTime(uint32_t systickCounter, bool forceUpdate) {
   currentDateTime += std::chrono::seconds(correctedDelta);
   uptime += std::chrono::seconds(correctedDelta);
 
-  std::time_t currentTime = std::chrono::system_clock::to_time_t(currentDateTime);
+  std::time_t currentTime =
+    std::chrono::system_clock::to_time_t(std::chrono::time_point_cast<std::chrono::system_clock::duration>(currentDateTime));
   localTime = *std::localtime(&currentTime);
 
   auto minute = Minutes();


### PR DESCRIPTION
std::chrono::system_clock::to_time_t() takes a time_point specialized on
the clock's own duration type.  With libstdc++, system_clock::duration is
nanoseconds, so passing currentDateTime (explicitly declared as
time_point<system_clock, nanoseconds>) matches exactly and compiles.  With
libc++, system_clock::duration is microseconds, and so the call fails to
compile.

This breaks the build of the InfiniSim simulator on macOS, where Apple
clang uses libc++.  CI does not catch it because the simulator is only
built on Linux.

This change casts the time_point to the clock's duration before the call,
which is already what AlarmController.cpp and WatchFaceCasioStyleG7710.cpp
do at their equivalent call sites.  This is an identity cast with libstdc++,
so the firmware build is unaffected; with libc++ it truncates nanoseconds
to microseconds, which is irrelevant because to_time_t truncates to whole
seconds anyway.

So, this change should have no effect other than enabling InfiniSim to
build successfully on macOS.
