### PR TITLE
lv_img_conv: Add CF_TRUE_COLOR output

### DIFF
--- a/src/resources/lv_img_conv.py
+++ b/src/resources/lv_img_conv.py
@@ -79,12 +79,12 @@ def main():
         if args.force:
             print(f"overwriting {args.output_file}")
         else:
-            pritn(f"Error: refusing to overwrite {args.output_file} without -f specified.")
+            print(f"Error: refusing to overwrite {args.output_file} without -f specified.")
             return 1
     out.touch()
 
     # only implemented the bare minimum, everything else is not implemented
-    if args.color_format not in ["CF_INDEXED_1_BIT", "CF_TRUE_COLOR_ALPHA"]:
+    if args.color_format not in ["CF_INDEXED_1_BIT", "CF_TRUE_COLOR", "CF_TRUE_COLOR_ALPHA"]:
         raise NotImplementedError(f"argument --color-format '{args.color_format}' not implemented")
     if args.output_format != "bin":
         raise NotImplementedError(f"argument --output-format '{args.output_format}' not implemented")
@@ -105,6 +105,9 @@ def main():
         # support pictures stored in other formats like with a color palette 'P'
         # see: https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes
         img = img.convert(mode="RGBA")
+    elif args.color_format == "CF_TRUE_COLOR" and img.mode != "RGB":
+        # CF_TRUE_COLOR carries no alpha, so drop any it may have
+        img = img.convert(mode="RGB")
     elif args.color_format == "CF_INDEXED_1_BIT" and img.mode != "L":
         # for CF_INDEXED_1_BIT we need just a grayscale value per pixel
         img = img.convert(mode="L")
@@ -138,6 +141,22 @@ def main():
                 buf[i + 1] = c16 & 0xFF
                 buf[i + 2] = a
 
+    elif args.color_format == "CF_TRUE_COLOR" and args.binary_format == "ARGB8565_RBSWAP":
+        buf = bytearray(img_height*img_width*2) # 2 bytes (16 bit) per pixel
+        for y in range(img_height):
+            for x in range(img_width):
+                i = (y*img_width + x)*2 # buffer-index
+                pixel = img.getpixel((x,y))
+                r_act = classify_pixel(pixel[0], 5)
+                g_act = classify_pixel(pixel[1], 6)
+                b_act = classify_pixel(pixel[2], 5)
+                r_act = min(r_act, 0xF8)
+                g_act = min(g_act, 0xFC)
+                b_act = min(b_act, 0xF8)
+                c16 = ((r_act) << 8) | ((g_act) << 3) | ((b_act) >> 3) # RGB565
+                buf[i + 0] = (c16 >> 8) & 0xFF
+                buf[i + 1] = c16 & 0xFF
+
     elif args.color_format == "CF_INDEXED_1_BIT": # ignore binary format, use color format as binary format
         w = img_width >> 3
         if img_width & 0x07:
@@ -168,6 +187,8 @@ def main():
 
     # write header
     match args.color_format:
+        case "CF_TRUE_COLOR":
+            lv_cf = 4
         case "CF_TRUE_COLOR_ALPHA":
             lv_cf = 5
         case "CF_INDEXED_1_BIT":


### PR DESCRIPTION
Only CF_INDEXED_1_BIT and CF_TRUE_COLOR_ALPHA were implemented, so a plain true-color image without alpha could not be converted into a 2-bytes-per-pixel file.  (I ran into this while trying to use a full-color image as a watch background.)

This PR adds support for CF_TRUE_COLOR with binary format ARGB8565_RBSWAP, written as 2 bytes per pixel, RGB565 high byte first, matching the existing alpha path and LV_COLOR_16_SWAP=1, with cf = 4 in the header. Alpha is dropped on input, since the format does not carry it.

(You might wonder why the format is ARGB8565_RBSWAP in this case, which claims an alpha channel.  That's because all the format choices claim an alpha channel; there is no plain RGB565_SWAP option.  Yet some existing `color_format` options (see the `--color-format` choices list) imply no alpha, and this is the part that determines whether we actually have an alpha channel or not.  When used with a format with no alpha, ARGB8565_RBSWAP would reduce to just RGB565_RBSWAP.  We could add that as an alias just to reduce confusion, but it's not necessary and seemed out of scope for this PR.  This also matches how CF_INDEXED_1_BIT overrides the given binary format as needed.)

Verified by using this to convert a full-color 240x240 pixel image into a 115,200-byte file (plus header) that exactly matched a hand-built one, and which displays correctly both in InfiniSim and on device.

This PR also fixes a typo on a nearby line: `pritn` -> `print` in the refuse-to-overwrite path, which raised NameError instead of printing the intended message.