### PR TITLE
CurrentTimeService: Initialize the whole current-time response

### DIFF
--- a/src/components/ble/CurrentTimeService.cpp
+++ b/src/components/ble/CurrentTimeService.cpp
@@ -60,7 +60,9 @@ int CurrentTimeService::OnCurrentTimeAccessed(struct ble_gatt_access_ctxt* ctxt)
     currentDateTime.hour = m_dateTimeController.Hours();
     currentDateTime.minute = m_dateTimeController.Minutes();
     currentDateTime.second = m_dateTimeController.Seconds();
+    currentDateTime.dayofweek = static_cast<uint8_t>(m_dateTimeController.DayOfWeek());
     currentDateTime.fractions256 = 0;
+    currentDateTime.reason = 0;
 
     int res = os_mbuf_append(ctxt->om, &currentDateTime, sizeof(CtsCurrentTimeData));
     return (res == 0) ? 0 : BLE_ATT_ERR_INSUFFICIENT_RES;


### PR DESCRIPTION
The read handler for the Current Time characteristic fills in seven of the nine fields of CtsCurrentTimeData. `dayofweek` and `reason` are never assigned, and the struct is a plain local, so those two bytes go out over the air as whatever was on the stack.

`dayofweek` is the one that matters: it is a defined part of the characteristic, and a client reading the time gets a random day. This PR assigns it from `DateTime::DayOfWeek()`, whose Days enum already matches the GATT encoding exactly (Unknown = 0, Monday = 1 ... Sunday = 7), so it casts directly like Month() on the line above. `reason` is an adjust-reason bit field with no bits to report here, so it is set to 0.