### PR TITLE
Resets the appStack when the display is automatically moved back to the watch face

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -323,6 +323,8 @@ void DisplayApp::Refresh() {
         if (currentApp == Apps::Launcher || currentApp == Apps::Notifications || currentApp == Apps::QuickSettings ||
             currentApp == Apps::Settings) {
           LoadScreen(Apps::Clock, DisplayApp::FullRefreshDirections::None);
+          appStackDirections.Reset();
+          returnAppStack.Reset();
           // Wait for the clock app to load before moving on.
           while (!lv_task_handler()) {
           };


### PR DESCRIPTION
Button presses and gestures to move to another screen pop the previous screen off the App Stack. 

When the display times out to go to sleep, if you are on the Notifications or Settings screen, the display automatically goes back to the watch face.  This change in screen isn't popped off the App Stack which eventually fills the appStack and causes a button press to jump straight to the watch face rather than the previous screen. 

Given the watch face can be considered as the top level screen, this PR prevents the stack overflow/stale-entry behaviour.  This is in fact what happens when you do a button:longPress