### PR TITLE
Fix OTA silently transferring a zero-length image

### DIFF
--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -145,7 +145,13 @@ int DfuService::WritePacketHandler(uint16_t connectionHandle, os_mbuf* om) {
         vTaskDelay(pdMS_TO_TICKS(5));
       }
 
+      // Erasing the image slot takes far longer than the 10s inactivity timeout, and that
+      // timer runs on the FreeRTOS timer task, so it fires while this call blocks. Its
+      // Reset() zeroes applicationSize, the erase then completes and the transfer carries
+      // on with a zero-length image. Hold the timeout off for the duration of the erase.
+      xTimerStop(timeoutTimer, 0);
       dfuImage.Erase();
+      xTimerStart(timeoutTimer, 0);
 
       uint8_t data[] {16, 1, 1};
       notificationManager.Send(connectionHandle, controlPointCharacteristicHandle, data, 3);

--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -138,6 +138,15 @@ int DfuService::WritePacketHandler(uint16_t connectionHandle, os_mbuf* om) {
                    bootloaderSize,
                    applicationSize);
 
+      // From here until the response below, this task blocks and cannot service BLE:
+      // first the unbounded wait for SystemTask to disable sleeping, then the image-slot
+      // erase, which can approach or exceed the 10s inactivity timeout (116 sectors at a
+      // datasheet-max 300ms each). The timer runs on the FreeRTOS timer task, so it fires
+      // while this task is blocked; its Reset() zeroes applicationSize, the erase then
+      // completes and the transfer carries on with a zero-length image. Hold the timeout
+      // off until this handler can react to packets again.
+      xTimerStop(timeoutTimer, 0);
+
       // Wait until SystemTask has disabled sleeping
       // This isn't quite correct, as we don't actually know
       // if BleFirmwareUpdateStarted has been received yet
@@ -145,11 +154,6 @@ int DfuService::WritePacketHandler(uint16_t connectionHandle, os_mbuf* om) {
         vTaskDelay(pdMS_TO_TICKS(5));
       }
 
-      // Erasing the image slot takes far longer than the 10s inactivity timeout, and that
-      // timer runs on the FreeRTOS timer task, so it fires while this call blocks. Its
-      // Reset() zeroes applicationSize, the erase then completes and the transfer carries
-      // on with a zero-length image. Hold the timeout off for the duration of the erase.
-      xTimerStop(timeoutTimer, 0);
       dfuImage.Erase();
       xTimerStart(timeoutTimer, 0);
 


### PR DESCRIPTION
## The bug

`DfuService::OnServiceData` arms the 10 s one-shot inactivity timer before dispatching each access:

```cpp
if (bleController.IsFirmwareUpdating()) {
  xTimerStart(timeoutTimer, 0);
}
```

The image-size write then blocks the BLE host task twice before it can respond: an unbounded wait for SystemTask to disable sleeping, then `DfuImage::Erase()`, which erases the whole image slot sector by sector. Measured from the host (the gap between writing the image sizes and the `10 01 01` response, which is only sent after the erase returns), the erase finishes in under ~8 s on my watch (BY25Q32ESWIG) — but the datasheet worst case is ~35 s (116 sectors × 300 ms max), and the sleep-disable wait ahead of it is unbounded, so the blocked stretch can outlast the 10 s window. The timer runs on the FreeRTOS timer task, so it fires while the BLE task is blocked and calls `Reset()`, which zeroes `applicationSize`.

The erase then completes and the handler carries on regardless — it sets `state = Init` and reports success. `ReceiveFirmwareImage` later calls `dfuImage.Init(20, 0, crc)`, so `IsComplete()` (`totalWriteIndex == totalSize`, now `0 == 0`) is **already true when the first data packet arrives**. The watch tells the host the entire image has been received, emits no packet-receipt notifications, writes nothing to flash, and validation CRCs zero bytes.

## What it looks like from the host

- `10 03 01` ("whole image received") arrives a fraction of a second after Begin DFU — no real transfer can be that fast
- **zero** `11 …` packet-receipt notifications for the entire "transfer"
- validation fails, and nothing was written

There is no indication that anything timed out, which makes this very hard to attribute. It cost me a couple of evenings before I instrumented the watch.

Recovery mode is unaffected: its blocked stretch finishes inside the 10 s window. That is why OTA can fail consistently from the running firmware while succeeding from recovery — which reads like a host or radio problem rather than a firmware one.

## The fix

Stop the timer for the whole blocked stretch — the sleep-disable wait and the erase — and restart it once the handler can react to packets again. While the BLE task is blocked there it cannot process packets anyway, so there is no inactivity for the timer to detect in that window; it still guards the actual transfer, and a host that disappears mid-erase is caught ~10 s after the response goes out.

## Testing

Tested on a PineTime (bootloader 1.0.1, InfiniTime 1.16.0, BY25Q32ESWIG flash). Before this change, every OTA from the running firmware failed exactly as described. After it, updates complete and validate normally, and recovery mode is no longer needed to flash — verified across several successful ~390 kB updates.

For scale: host-side logs of seven successful runs put the `10 01 01` response at 8.4–9.3 s after script start *including* scan, connect and service discovery, so the erase itself is under ~8 s on this watch — the failures need the extra contribution of the sleep-disable wait, or a slower/worn part. I don't have an instrumented failing run (those predate the logging), so the exact split on the failing attempts is unknown.
