### PR TITLE
Stop failed DFU sessions wedging the radio or failing silently

### DIFF
--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -138,11 +138,21 @@ int DfuService::WritePacketHandler(uint16_t connectionHandle, os_mbuf* om) {
                    bootloaderSize,
                    applicationSize);
 
-      // Wait until SystemTask has disabled sleeping
+      // Wait until SystemTask has disabled sleeping.
       // This isn't quite correct, as we don't actually know
-      // if BleFirmwareUpdateStarted has been received yet
-      while (!systemTask.IsSleepDisabled()) {
+      // if BleFirmwareUpdateStarted has been received yet.
+      // Bounded on purpose: this runs on the BLE host task, so waiting here forever stalls
+      // every GATT operation and leaves disconnect events unprocessed, and the watch cannot
+      // advertise again until it is rebooted. If the wake lock never arrives, continue
+      // without it - a DFU that races the sleep timer beats a radio wedged until reboot.
+      constexpr uint8_t sleepLockWaitTicks = 200; // 200 * 5ms = 1s
+      uint8_t waited = 0;
+      while (!systemTask.IsSleepDisabled() && waited < sleepLockWaitTicks) {
         vTaskDelay(pdMS_TO_TICKS(5));
+        waited++;
+      }
+      if (!systemTask.IsSleepDisabled()) {
+        NRF_LOG_INFO("[DFU] -> Wake lock never arrived, continuing anyway");
       }
 
       dfuImage.Erase();

--- a/src/components/ble/DfuService.cpp
+++ b/src/components/ble/DfuService.cpp
@@ -211,10 +211,24 @@ int DfuService::WritePacketHandler(uint16_t connectionHandle, os_mbuf* om) {
     }
       return 0;
     default:
-      // Invalid state
+      // Data arriving in a state that cannot consume it. Report it once - reporting every
+      // stray packet would flood the notification path - so the host learns it is talking
+      // to a watch parked mid-transfer instead of waiting for a reply that never comes.
+      if (!strayPacketReported) {
+        strayPacketReported = true;
+        SendInvalidState(connectionHandle, Opcodes::ReceiveFirmwareImage);
+      }
       return 0;
   }
   return 0;
+}
+
+void DfuService::SendInvalidState(uint16_t connectionHandle, Opcodes opcode) {
+  uint8_t data[4] {static_cast<uint8_t>(Opcodes::Response),
+                   static_cast<uint8_t>(opcode),
+                   static_cast<uint8_t>(ErrorCodes::InvalidState),
+                   static_cast<uint8_t>(state)};
+  notificationManager.Send(connectionHandle, controlPointCharacteristicHandle, data, 4);
 }
 
 int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
@@ -225,6 +239,7 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
     case Opcodes::StartDFU: {
       if (state != States::Idle && state != States::Start) {
         NRF_LOG_INFO("[DFU] -> Start DFU requested, but we are not in Idle state");
+        SendInvalidState(connectionHandle, Opcodes::StartDFU);
         return 0;
       }
       if (state == States::Start) {
@@ -249,6 +264,7 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
     case Opcodes::InitDFUParameters: {
       if (state != States::Init) {
         NRF_LOG_INFO("[DFU] -> Init DFU requested, but we are not in Init state");
+        SendInvalidState(connectionHandle, Opcodes::InitDFUParameters);
         return 0;
       }
       bool isInitComplete = (om->om_data[1] != 0);
@@ -270,6 +286,7 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
     case Opcodes::ReceiveFirmwareImage:
       if (state != States::Init) {
         NRF_LOG_INFO("[DFU] -> Receive firmware image requested, but we are not in Start Init");
+        SendInvalidState(connectionHandle, Opcodes::ReceiveFirmwareImage);
         return 0;
       }
       // TODO the chunk size is dependent of the implementation of the host application...
@@ -280,6 +297,7 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
     case Opcodes::ValidateFirmware: {
       if (state != States::Validate) {
         NRF_LOG_INFO("[DFU] -> Validate firmware image requested, but we are not in Data state %d", state);
+        SendInvalidState(connectionHandle, Opcodes::ValidateFirmware);
         return 0;
       }
 
@@ -310,6 +328,7 @@ int DfuService::ControlPointHandler(uint16_t connectionHandle, os_mbuf* om) {
     case Opcodes::ActivateImageAndReset:
       if (state != States::Validated) {
         NRF_LOG_INFO("[DFU] -> Activate image and reset requested, but we are not in Validated state");
+        SendInvalidState(connectionHandle, Opcodes::ActivateImageAndReset);
         return 0;
       }
       NRF_LOG_INFO("[DFU] -> Activate image and reset!");
@@ -328,6 +347,7 @@ void DfuService::OnTimeout() {
 
 void DfuService::Reset() {
   state = States::Idle;
+  strayPacketReported = false;
   nbPacketsToNotify = 0;
   nbPacketReceived = 0;
   bytesReceived = 0;

--- a/src/components/ble/DfuService.h
+++ b/src/components/ble/DfuService.h
@@ -119,6 +119,7 @@ namespace Pinetime {
 
       enum class States : uint8_t { Idle, Init, Start, Data, Validate, Validated };
       States state = States::Idle;
+      bool strayPacketReported = false;
 
       enum class ImageTypes : uint8_t {
         NoImage = 0x00,
@@ -160,6 +161,7 @@ namespace Pinetime {
       int SendDfuRevision(os_mbuf* om) const;
       int WritePacketHandler(uint16_t connectionHandle, os_mbuf* om);
       int ControlPointHandler(uint16_t connectionHandle, os_mbuf* om);
+      void SendInvalidState(uint16_t connectionHandle, Opcodes opcode);
 
       TimerHandle_t timeoutTimer;
     };


### PR DESCRIPTION
Two independent DFU robustness fixes, one per commit, so either can be taken alone. Both came out of debugging repeated OTA failures on real hardware; the underlying data-corruption bug is #2466, and these are about the surrounding failure modes being invisible or unrecoverable.

## 1. Bound the wait for the sleep wake lock

`WritePacketHandler` spins until `SystemTask` disables sleeping, with no upper bound:

```cpp
while (!systemTask.IsSleepDisabled()) {
  vTaskDelay(pdMS_TO_TICKS(5));
}
```

This runs on the **BLE host task**. If the wake lock never arrives, the host task never returns: GATT operations stop being served, disconnect events are never processed, and the watch cannot advertise again. The status bar still shows Bluetooth as connected, but the watch is invisible to every scanner until it is rebooted — a failed update looks like the radio has died.

Capped at 1 s, then continue without the lock. Racing the sleep timer is a much better failure mode than a radio that needs a reboot to recover.

## 2. Answer commands that arrive in the wrong state

Every wrong-state branch in `ControlPointHandler` returns silently, and so do stray data packets. A host that reconnects to a watch left parked mid-transfer by an interrupted update gets **no reply at all** — Start DFU simply never answers, which is indistinguishable from a watch that is not listening. Every retry looks like an unexplained hang until the watch is rebooted or the 10 s inactivity timer happens to reset the state machine.

`ErrorCodes::InvalidState` is already defined in the protocol and was never used. These branches now reply `[Response, opcode, InvalidState, state]`, the fourth byte naming the state the watch is actually in, which makes the failure diagnosable from the host without a debugger.

Stray data packets report once per session rather than per packet, so a host that keeps sending cannot flood the notification path. The flag is cleared in `Reset()`.

## Testing

Tested on a PineTime (bootloader 1.0.1, InfiniTime 1.16.0), alongside #2466: the firmware builds and runs with these changes, and OTA updates complete normally with them in place.

To be precise about what I did **not** verify: I did not stage a mid-transfer reconnect to observe an `InvalidState` response arrive at the host. The silent-return behaviour it replaces is plain in the code, and my host client decodes the response, but the new reply path itself is unexercised — worth a reviewer's eye.

The unbounded wake-lock wait, by contrast, was hit repeatedly in practice: a watch showing Bluetooth as connected while being invisible to every scanner, recoverable only by reboot.

Happy to split this into two PRs if you would prefer them reviewed separately.