### PR TITLE
Improve notification preview UX

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -320,8 +320,8 @@ void DisplayApp::Refresh() {
           brightnessController.Set(Controllers::BrightnessController::Levels::Off);
         }
         // Since the active screen is not really an app, go back to Clock.
-        if (currentApp == Apps::Launcher || currentApp == Apps::Notifications || currentApp == Apps::QuickSettings ||
-            currentApp == Apps::Settings) {
+        if (currentApp == Apps::Launcher || currentApp == Apps::Notifications || currentApp == Apps::NotificationsPreview ||
+            currentApp == Apps::QuickSettings || currentApp == Apps::Settings) {
           LoadScreen(Apps::Clock, DisplayApp::FullRefreshDirections::None);
           // Wait for the clock app to load before moving on.
           while (!lv_task_handler()) {

--- a/src/displayapp/screens/Notifications.cpp
+++ b/src/displayapp/screens/Notifications.cpp
@@ -55,7 +55,6 @@ Notifications::Notifications(DisplayApp* app,
 
     lv_line_set_points(timeoutLine, timeoutLinePoints, 2);
     timeoutTickCountStart = xTaskGetTickCount();
-    interacted = false;
   }
 
   taskRefresh = lv_task_create(RefreshTaskCallback, LV_DISP_DEF_REFR_PERIOD, LV_TASK_PRIO_MID, this);
@@ -121,6 +120,7 @@ void Notifications::Refresh() {
 void Notifications::OnPreviewInteraction() {
   wakeLock.Release();
   motorController.StopRinging();
+  mode = Modes::Normal;
   if (timeoutLine != nullptr) {
     lv_obj_del(timeoutLine);
     timeoutLine = nullptr;
@@ -147,16 +147,15 @@ void Notifications::OnPreviewDismiss() {
 }
 
 bool Notifications::OnTouchEvent(Pinetime::Applications::TouchEvents event) {
-  if (mode != Modes::Normal) {
-    if (!interacted && event == TouchEvents::Tap) {
-      interacted = true;
+  if (mode == Modes::Preview) {
+    if (event == TouchEvents::Tap || event == TouchEvents::SwipeDown) {
       OnPreviewInteraction();
-      return true;
     } else if (event == Pinetime::Applications::TouchEvents::SwipeRight) {
       OnPreviewDismiss();
       return true;
+    } else {
+      return false;
     }
-    return false;
   }
 
   switch (event) {

--- a/src/displayapp/screens/Notifications.h
+++ b/src/displayapp/screens/Notifications.h
@@ -86,7 +86,6 @@ namespace Pinetime {
         TickType_t timeoutTickCountStart;
 
         static const TickType_t timeoutLength = pdMS_TO_TICKS(7000);
-        bool interacted = true;
 
         bool dismissingNotification = false;
 


### PR DESCRIPTION
Implements better notifications UX as discussed in #1844 as I have always been annoyed that you can't swipeDown to see earlier messages when in notification preview state but you can tap, dismiss or swipeUp.

```bool interacted``` no longer required because you now transition from Modes:Preview to Modes:Normal when you interact with a preview notification.

Maintains the same functionality as before but enables you to swipeDown to see earlier messages when you get a notification.