### PR TITLE
Switch dice RNG

### DIFF
--- a/src/displayapp/screens/Dice.h
+++ b/src/displayapp/screens/Dice.h
@@ -29,7 +29,7 @@ namespace Pinetime {
         lv_task_t* refreshTask;
         bool enableShakeForDice = false;
 
-        std::mt19937 gen;
+        std::minstd_rand gen;
 
         std::array<lv_color_t, 3> resultColors = {LV_COLOR_YELLOW, LV_COLOR_MAGENTA, LV_COLOR_AQUA};
         uint8_t currentColorIndex;


### PR DESCRIPTION
The mersenne twister uses multiple KBs of state and is not needed for a dice app in terms of RNG quality

When we pick up GCC16, we can switch to `philox4x32`

This is an alternative to #2385: while I agree that PR is a better RNG than the one here, I don't think it's worth carrying a new dependency / implementation for it