### PR TITLE
DisplayApp: Return to the clock when sleeping from a notification preview

### DIFF
--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -320,8 +320,8 @@ void DisplayApp::Refresh() {
           brightnessController.Set(Controllers::BrightnessController::Levels::Off);
         }
         // Since the active screen is not really an app, go back to Clock.
-        if (currentApp == Apps::Launcher || currentApp == Apps::Notifications || currentApp == Apps::QuickSettings ||
-            currentApp == Apps::Settings) {
+        if (currentApp == Apps::Launcher || currentApp == Apps::Notifications || currentApp == Apps::NotificationsPreview ||
+            currentApp == Apps::QuickSettings || currentApp == Apps::Settings) {
           LoadScreen(Apps::Clock, DisplayApp::FullRefreshDirections::None);
           // Wait for the clock app to load before moving on.
           while (!lv_task_handler()) {


### PR DESCRIPTION
When the display goes to sleep, `DisplayApp::Refresh()` returns to the clock face from every transient screen except the notification preview. A preview that has been tapped once has already cancelled its auto-close timer and released its wake lock, so it stays loaded across sleep and reappears on every wake until you navigate away from it manually.

This adds `Apps::NotificationsPreview` to the list of screens that are left behind on sleep, so a tapped preview is dismissed like every other transient screen.

**To reproduce:** send a notification, tap the preview once (don't swipe it away), let the display time out, then wake the watch — the preview is still there, and stays there on every subsequent wake.

Tested on hardware (PineTime, `pinetime-app`).
