### PR TITLE
Reseed Dice RNG on every Roll

### DIFF
--- a/src/displayapp/screens/Dice.cpp
+++ b/src/displayapp/screens/Dice.cpp
@@ -43,12 +43,6 @@ Dice::Dice(Controllers::MotionController& motionController,
            Controllers::MotorController& motorController,
            Controllers::Settings& settingsController)
   : motorController {motorController}, motionController {motionController}, settingsController {settingsController} {
-  std::seed_seq sseq {static_cast<uint32_t>(xTaskGetTickCount()),
-                      static_cast<uint32_t>(motionController.X()),
-                      static_cast<uint32_t>(motionController.Y()),
-                      static_cast<uint32_t>(motionController.Z())};
-  gen.seed(sseq);
-
   lv_obj_t* nCounterLabel = MakeLabel(&jetbrains_mono_bold_20,
                                       LV_COLOR_WHITE,
                                       LV_LABEL_LONG_EXPAND,
@@ -155,6 +149,12 @@ void Dice::Refresh() {
 }
 
 void Dice::Roll() {
+  std::seed_seq sseq {static_cast<uint32_t>(xTaskGetTickCount()),
+                      static_cast<uint32_t>(motionController.X()),
+                      static_cast<uint32_t>(motionController.Y()),
+                      static_cast<uint32_t>(motionController.Z())};
+  gen.seed(sseq);
+
   uint8_t resultIndividual;
   uint16_t resultTotal = 0;
   std::uniform_int_distribution<> distrib(1, dCounter.GetValue());


### PR DESCRIPTION
This improves entropy of Dice and makes PRNG state recovery harder.
As a pleasant side effect this also makes the Dice app more like a physical dice - dependent on how it is shaken, but in a hard to predict manner.
The monotonic counter `xTaskGetTickCount()` in the seed should greatly reduce chances of generating the same RNG seed in multiple rolls.

At least on my PineTime watch the `motionController` seems to return 12 bits for each axis and single axis very often gets saturated (returns 2047 or -2048) during shake, sometimes two axis get saturated during shake.
Assuming `xTaskGetTickCount()` resolution is close to 1 ms (and people have precision of no more than 64 - 256 ms), ~it should also provide at least around 6-8 bits of entropy~ its provided entropy likely will be limited by the temporal resolution and jitter of the mechanism triggering the roll (e.g. the accelerometer refresh rate of 10 Hz).
I think in most cases (unless the roller intentionally precisely times the roll and saturates/fixates/predicts all 3 accelerometer axis), **this PR should provide enough entropy to make a single number (in the 2-99 sides range) per roll truly-random**. 🔒 
And this PR should eliminate the biggest security problem with current Dice app implementation (regardless of whether `std::mt19937` or `std::minstd_rand` is used) - ability to analyze results of certain number of Dice app rolls (likely little over 13 rolls of 6 sides in case of `std::minstd_rand` - assuming `std::minstd_rand` has 32-bit internal state and every roll leaks around 2.58 bits of it) and predict the results of all subsequent rolls (until the Dice app gets restarted).

**TL;DR** I think this could be a good addition to #2473 and a pretty cool thing on it's own as it makes the Dice app more like a real physical dice. 😎 🎲 