### PR TITLE
Remove redundant LFS logging information

### DIFF
--- a/src/libs/lfs_config.h
+++ b/src/libs/lfs_config.h
@@ -5,7 +5,7 @@
 #ifndef LFS_TRACE
 #ifdef LFS_YES_TRACE
 #define LFS_TRACE_(fmt, ...) \
-    NRF_LOG_DEBUG("[LFS] %s:%d:trace: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+    NRF_LOG_DEBUG("[LFS] trace: " fmt "%s\n", __VA_ARGS__)
 #define LFS_TRACE(...) LFS_TRACE_(__VA_ARGS__, "")
 #else
 #define LFS_TRACE(...)
@@ -15,7 +15,7 @@
 #ifndef LFS_DEBUG
 #ifndef LFS_NO_DEBUG
 #define LFS_DEBUG_(fmt, ...) \
-    NRF_LOG_DEBUG("[LFS] %s:%d:debug: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+    NRF_LOG_DEBUG("[LFS] debug: " fmt "%s\n", __VA_ARGS__)
 #define LFS_DEBUG(...) LFS_DEBUG_(__VA_ARGS__, "")
 #else
 #define LFS_DEBUG(...)
@@ -25,7 +25,7 @@
 #ifndef LFS_WARN
 #ifndef LFS_NO_WARN
 #define LFS_WARN_(fmt, ...) \
-    NRF_LOG_WARNING("[LFS] %s:%d:warn: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+    NRF_LOG_WARNING("[LFS] warn: " fmt "%s\n", __VA_ARGS__)
 #define LFS_WARN(...) LFS_WARN_(__VA_ARGS__, "")
 #else
 #define LFS_WARN(...)
@@ -35,7 +35,7 @@
 #ifndef LFS_ERROR
 #ifndef LFS_NO_ERROR
 #define LFS_ERROR_(fmt, ...) \
-    NRF_LOG_ERROR("[LFS] %s:%d:error: " fmt "%s\n", __FILE__, __LINE__, __VA_ARGS__)
+    NRF_LOG_ERROR("[LFS] error: " fmt "%s\n", __VA_ARGS__)
 #define LFS_ERROR(...) LFS_ERROR_(__VA_ARGS__, "")
 #else
 #define LFS_ERROR(...)


### PR DESCRIPTION
The LFS log events are unique and don't need line/file information

Since some of the LFS logs use 4 parameters, this was causing too many parameters of the maximum 6 to be used

I'm not sure why this wasn't a problem with GCC 10.3

To be honest I'm not a macro expert so I can't really debug the actual expansion, but I don't think we actually lose debugability here by dropping these